### PR TITLE
feat: add custom 2D vec structure

### DIFF
--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 benchmarking_utils = []
 
 [dependencies]
+cfg-if = "1"

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 benchmarking_utils = []
+single_precision = []
 
 [dependencies]
 cfg-if = "1"

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
 ///
 /// ```
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Coords2 {
     /// First coordinate
     pub x: FloatType,

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -39,6 +39,28 @@ pub struct Coords2 {
     pub y: FloatType,
 }
 
+impl Coords2 {
+    pub fn norm(&self) -> FloatType {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    pub fn unit_dir(&self) -> Coords2 {
+        *self / self.norm()
+    }
+
+    pub fn dot(&self, other: &Coords2) -> FloatType {
+        self.x * other.x + self.y * other.y
+    }
+
+    // should this consume self & other?
+    pub fn cross(&self, other: &Coords2) -> Coords2 {
+        Self {
+            x: self.x * other.y - self.y * other.x,
+            y: other.x * self.y - other.y * self.x,
+        }
+    }
+}
+
 // Building traits
 
 impl From<(FloatType, FloatType)> for Coords2 {

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -10,7 +10,13 @@
 
 // ------ CONTENT
 
-pub type FloatType = f64;
+pub type FloatType = cfg_if::cfg_if! {
+    if #[cfg(feature = "single_precision")] {
+        f32
+    } else {
+        f64
+    }
+};
 
 pub struct Coords2 {
     pub x: FloatType,

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
 ///
 /// ```
 ///
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct Coords2 {
     /// First coordinate
     pub x: FloatType,

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -1,0 +1,30 @@
+//! Module short description
+//!
+//! Should you interact with this module directly?
+//!
+//! Content description if needed
+
+// ------ MODULE DECLARATIONS
+
+// ------ IMPORTS
+
+// ------ CONTENT
+
+pub type FloatType = f64;
+
+pub struct Coords2 {
+    pub x: FloatType,
+    pub y: FloatType,
+}
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -8,7 +8,7 @@
 
 // ------ IMPORTS
 
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 // ------ CONTENT
 
@@ -68,6 +68,37 @@ impl SubAssign<Coords2> for Coords2 {
     fn sub_assign(&mut self, rhs: Coords2) {
         self.x -= rhs.x;
         self.y -= rhs.y;
+    }
+}
+
+impl Mul<FloatType> for Coords2 {
+    type Output = Self;
+
+    fn mul(self, rhs: FloatType) -> Self::Output {
+        Self::from((self.x * rhs, self.y * rhs))
+    }
+}
+
+impl MulAssign<FloatType> for Coords2 {
+    fn mul_assign(&mut self, rhs: FloatType) {
+        self.x *= rhs;
+        self.y *= rhs;
+    }
+}
+
+impl Div<FloatType> for Coords2 {
+    type Output = Self;
+
+    fn div(self, rhs: FloatType) -> Self::Output {
+        assert_ne!(rhs, 0.0);
+        self * 1.0 / rhs
+    }
+}
+
+impl DivAssign<FloatType> for Coords2 {
+    fn div_assign(&mut self, rhs: FloatType) {
+        assert_ne!(rhs, 0.0);
+        *self *= 1.0 / rhs;
     }
 }
 

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -20,8 +20,22 @@ cfg_if::cfg_if! {
     }
 }
 
+/// 2-dimensional coordinates structure
+///
+/// The floating type used for coordinate representation is determined
+/// using feature and the [FloatType] alias.
+///
+/// # Example
+///
+/// ```text
+///
+/// ```
+///
+#[derive(Debug, Clone, Copy)]
 pub struct Coords2 {
+    /// First coordinate
     pub x: FloatType,
+    /// Second coordinate
     pub y: FloatType,
 }
 

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -10,13 +10,13 @@
 
 // ------ CONTENT
 
-pub type FloatType = cfg_if::cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(feature = "single_precision")] {
-        f32
+        pub type FloatType = f32;
     } else {
-        f64
+        pub type FloatType = f64;
     }
-};
+}
 
 pub struct Coords2 {
     pub x: FloatType,

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -23,6 +23,18 @@ pub struct Coords2 {
     pub y: FloatType,
 }
 
+impl From<(FloatType, FloatType)> for Coords2 {
+    fn from((x, y): (FloatType, FloatType)) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<[FloatType; 2]> for Coords2 {
+    fn from([x, y]: [FloatType; 2]) -> Self {
+        Self { x, y }
+    }
+}
+
 // ------ TESTS
 
 #[cfg(test)]

--- a/honeycomb-core/src/coords.rs
+++ b/honeycomb-core/src/coords.rs
@@ -8,6 +8,8 @@
 
 // ------ IMPORTS
 
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
 // ------ CONTENT
 
 cfg_if::cfg_if! {
@@ -23,6 +25,8 @@ pub struct Coords2 {
     pub y: FloatType,
 }
 
+// Building traits
+
 impl From<(FloatType, FloatType)> for Coords2 {
     fn from((x, y): (FloatType, FloatType)) -> Self {
         Self { x, y }
@@ -32,6 +36,38 @@ impl From<(FloatType, FloatType)> for Coords2 {
 impl From<[FloatType; 2]> for Coords2 {
     fn from([x, y]: [FloatType; 2]) -> Self {
         Self { x, y }
+    }
+}
+
+// Basic operations
+
+impl Add<Coords2> for Coords2 {
+    type Output = Self;
+
+    fn add(self, rhs: Coords2) -> Self::Output {
+        Self::from((self.x + rhs.x, self.y + rhs.y))
+    }
+}
+
+impl AddAssign<Coords2> for Coords2 {
+    fn add_assign(&mut self, rhs: Coords2) {
+        self.x += rhs.x;
+        self.y += rhs.y;
+    }
+}
+
+impl Sub<Coords2> for Coords2 {
+    type Output = Self;
+
+    fn sub(self, rhs: Coords2) -> Self::Output {
+        Self::from((self.x - rhs.x, self.y - rhs.y))
+    }
+}
+
+impl SubAssign<Coords2> for Coords2 {
+    fn sub_assign(&mut self, rhs: Coords2) {
+        self.x -= rhs.x;
+        self.y -= rhs.y;
     }
 }
 

--- a/honeycomb-core/src/embed.rs
+++ b/honeycomb-core/src/embed.rs
@@ -14,6 +14,7 @@
 
 // ------ IMPORTS
 
+use crate::coords::Coords2;
 #[cfg(doc)]
 use crate::TwoMap;
 
@@ -95,7 +96,7 @@ pub enum UnsewPolicy {
 }
 
 /// Type definition for 2D vertex representation.
-pub type Vertex2 = [f64; 2];
+pub type Vertex2 = Coords2;
 
 /// Type definition for 3D vertex representation.
 pub type Vertex3 = [f64; 3];
@@ -126,7 +127,7 @@ pub type Vertex3 = [f64; 3];
 ///     [1.0, 1.0],
 ///     [0.0, 1.0],
 ///     [2.0, 0.0],
-/// ];
+/// ].map(Vertex2::from);
 ///
 /// let square_face = Face { corners: vec![0, 1, 2, 3], closed: true };
 /// let triangle_face = Face { corners: vec![1, 4, 2], closed: true };

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -9,6 +9,7 @@
 
 // ------ MODULE DECLARATIONS
 
+mod coords;
 pub mod dart;
 pub mod embed;
 pub mod twomap;

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -154,7 +154,7 @@ const TWO_MAP_BETA: usize = 3;
 /// assert!(map.is_free(d6));
 ///
 /// // create the corresponding three vertices
-/// let v4 = map.add_vertex(Some([15.0, 0.0])); // v4
+/// let v4 = map.add_vertex(Some([15.0, 0.0].into())); // v4
 /// let v5 = map.add_vertices(2); // v5, v6
 /// let v6 = v5 + 1;
 /// map.set_vertex(v5, [5.0, 10.0]); // v5
@@ -228,10 +228,10 @@ const TWO_MAP_BETA: usize = 3;
 /// assert_eq!(map.faceid(d3), new_face_id);
 ///
 /// // check dart positions
-/// assert_eq!(*map.vertex(map.vertexid(d1)), [0.0, 0.0]);
-/// assert_eq!(*map.vertex(map.vertexid(d5)), [0.0, 10.0]);
-/// assert_eq!(*map.vertex(map.vertexid(d6)), [10.0, 10.0]);
-/// assert_eq!(*map.vertex(map.vertexid(d3)), [10.0, 0.0]);
+/// assert_eq!(*map.vertex(map.vertexid(d1)), [0.0, 0.0].into());
+/// assert_eq!(*map.vertex(map.vertexid(d5)), [0.0, 10.0].into());
+/// assert_eq!(*map.vertex(map.vertexid(d6)), [10.0, 10.0].into());
+/// assert_eq!(*map.vertex(map.vertexid(d3)), [10.0, 0.0].into());
 ///
 /// // check topology of the new face
 /// let new_two_cell = map.i_cell::<2>(d3);
@@ -820,10 +820,10 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
     pub fn set_vertex(
         &mut self,
         vertex_id: VertexIdentifier,
-        vertex: Vertex2,
+        vertex: impl Into<Vertex2>,
     ) -> Result<(), MapError> {
         if let Some(val) = self.vertices.get_mut(vertex_id as usize) {
-            *val = vertex;
+            *val = vertex.into();
             return Ok(());
         }
         Err(MapError::VertexOOB)

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -294,7 +294,7 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
     /// See [TwoMap] example.
     ///
     pub fn new(n_darts: usize, n_vertices: usize) -> Self {
-        let vertices = vec![[0.0, 0.0]; n_vertices];
+        let vertices = vec![Vertex2::from([0.0, 0.0]); n_vertices];
         let betas = vec![[0; TWO_MAP_BETA]; n_darts + 1];
 
         Self {
@@ -964,10 +964,7 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                     // associated to rhs_dart
                     let lid_vertex = self.vertices[self.cells(lid).vertex_id as usize];
                     let rhs_vertex = self.vertices[self.cells(rhs_dart_id).vertex_id as usize];
-                    self.vertices.push([
-                        (lid_vertex[0] + rhs_vertex[0]) / 2.0,
-                        (lid_vertex[1] + rhs_vertex[1]) / 2.0,
-                    ]);
+                    self.vertices.push((lid_vertex + rhs_vertex) / 2.0);
                     let new_id = (self.vertices.len() - 1) as VertexIdentifier;
                     stretch!(self, lid, new_id);
                     stretch!(self, rhs_dart_id, new_id);
@@ -1046,10 +1043,7 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                         let vertex1 = self.vertices[self.cells(b1rid).vertex_id as usize];
                         let vertex2 = self.vertices[self.cells(lhs_dart_id).vertex_id as usize];
 
-                        self.vertices.push([
-                            (vertex1[0] + vertex2[0]) / 2.0,
-                            (vertex1[1] + vertex2[1]) / 2.0,
-                        ]);
+                        self.vertices.push((vertex1 + vertex2) / 2.0);
                         let new_id = (self.vertices.len() - 1) as VertexIdentifier;
 
                         stretch!(self, b1rid, new_id);
@@ -1070,10 +1064,7 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                         let vertex1 = self.vertices[self.cells(b1lid).vertex_id as usize];
                         let vertex2 = self.vertices[self.cells(rhs_dart_id).vertex_id as usize];
 
-                        self.vertices.push([
-                            (vertex1[0] + vertex2[0]) / 2.0,
-                            (vertex1[1] + vertex2[1]) / 2.0,
-                        ]);
+                        self.vertices.push((vertex1 + vertex2) / 2.0);
                         let new_id = (self.vertices.len() - 1) as VertexIdentifier;
 
                         stretch!(self, b1lid, new_id);
@@ -1092,11 +1083,11 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                 let b1_rvertex = self.vertices[self.cells(b1rid).vertex_id as usize];
                 let rvertex = self.vertices[self.cells(rhs_dart_id).vertex_id as usize];
 
-                let lhs_vec = [b1_lvertex[0] - lvertex[0], b1_lvertex[1] - lvertex[1]];
-                let rhs_vec = [b1_rvertex[0] - rvertex[0], b1_rvertex[1] - rvertex[1]];
+                let lhs_vec = b1_lvertex - lvertex;
+                let rhs_vec = b1_rvertex - rvertex;
 
                 // dot product should be negative if the two darts have opposite direction
-                let current = lhs_vec[0] * rhs_vec[0] + lhs_vec[1] * rhs_vec[1] < 0.0;
+                let current = lhs_vec.x * rhs_vec.x + lhs_vec.y * rhs_vec.y < 0.0;
 
                 if !current {
                     // we need reverse the orientation of the 2-cell
@@ -1117,14 +1108,8 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                         stretch!(self, lhs_dart_id, b1rid);
                     }
                     SewPolicy::StretchAverage => {
-                        let new_lvertex = [
-                            (lvertex[0] + b1_rvertex[0]) / 2.0,
-                            (lvertex[1] + b1_rvertex[1]) / 2.0,
-                        ];
-                        let new_rvertex = [
-                            (rvertex[0] + b1_lvertex[0]) / 2.0,
-                            (rvertex[1] + b1_lvertex[1]) / 2.0,
-                        ];
+                        let new_lvertex = (lvertex + b1_rvertex) / 2.0;
+                        let new_rvertex = (rvertex + b1_lvertex) / 2.0;
                         self.vertices.push(new_lvertex);
                         self.vertices.push(new_rvertex);
                         let new_lid = self.vertices.len() - 2;

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1087,16 +1087,14 @@ impl<const N_MARKS: usize> TwoMap<N_MARKS> {
                 let rhs_vec = b1_rvertex - rvertex;
 
                 // dot product should be negative if the two darts have opposite direction
-                let current = lhs_vec.x * rhs_vec.x + lhs_vec.y * rhs_vec.y < 0.0;
-
-                if !current {
-                    // we need reverse the orientation of the 2-cell
-                    // i.e. swap values of beta 1 & beta 0
-                    // for all elements connected to rhs & offset the
-                    // associated vertices to keep consistency between
-                    // placement & numbering
-                    todo!("figure out how to reverse orientation of closed & open 2-cell")
-                }
+                // we could also put restriction on the angle made by the two darts to prevent
+                // drastic deformation
+                assert!(
+                    lhs_vec.dot(&rhs_vec) < 0.0,
+                    "Dart {} and {} do not have consistent orientation for 2-sewing",
+                    lhs_dart_id,
+                    rhs_dart_id
+                );
 
                 match policy {
                     SewPolicy::StretchLeft => {

--- a/honeycomb-utils/benches/core/twomap/editing.rs
+++ b/honeycomb-utils/benches/core/twomap/editing.rs
@@ -14,7 +14,7 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{DartIdentifier, FaceIdentifier, TwoMap, VertexIdentifier};
+use honeycomb_core::{DartIdentifier, FaceIdentifier, TwoMap, Vertex2, VertexIdentifier};
 use honeycomb_utils::generation::square_two_map;
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
@@ -74,7 +74,7 @@ fn add_default_vertex(map: &mut TwoMap<1>) -> VertexIdentifier {
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
 fn add_vertex(map: &mut TwoMap<1>) -> VertexIdentifier {
-    black_box(map.add_vertex(Some([12.0, 6.0])))
+    black_box(map.add_vertex(Some(Vertex2::from((12.0, 6.0)))))
 }
 
 #[library_benchmark]

--- a/honeycomb-utils/benches/splitsquaremap/shift.rs
+++ b/honeycomb-utils/benches/splitsquaremap/shift.rs
@@ -50,13 +50,7 @@ fn offset_if_inner<const N_MARKS: usize>(mut map: TwoMap<N_MARKS>, offsets: &[Ve
     });
     inner.iter().for_each(|vertex_id| {
         let current_value = map.vertex(*vertex_id);
-        let _ = map.set_vertex(
-            *vertex_id,
-            [
-                current_value[0] + offsets[*vertex_id as usize][0],
-                current_value[1] + offsets[*vertex_id as usize][1],
-            ],
-        );
+        let _ = map.set_vertex(*vertex_id, *current_value + offsets[*vertex_id as usize]);
     });
     black_box(&mut map);
 }
@@ -71,7 +65,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
 
-    let offsets: Vec<Vertex2> = xs.zip(ys).map(|(x, y)| [x, y]).collect();
+    let offsets: Vec<Vertex2> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
 
     let mut group = c.benchmark_group("splitsquaremap-shift");
 

--- a/honeycomb-utils/benches/squaremap/shift.rs
+++ b/honeycomb-utils/benches/squaremap/shift.rs
@@ -50,13 +50,7 @@ fn offset_if_inner<const N_MARKS: usize>(mut map: TwoMap<N_MARKS>, offsets: &[Ve
     });
     inner.iter().for_each(|vertex_id| {
         let current_value = map.vertex(*vertex_id);
-        let _ = map.set_vertex(
-            *vertex_id,
-            [
-                current_value[0] + offsets[*vertex_id as usize][0],
-                current_value[1] + offsets[*vertex_id as usize][1],
-            ],
-        );
+        let _ = map.set_vertex(*vertex_id, *current_value + offsets[*vertex_id as usize]);
     });
     black_box(&mut map);
 }
@@ -71,7 +65,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
 
-    let offsets: Vec<Vertex2> = xs.zip(ys).map(|(x, y)| [x, y]).collect();
+    let offsets: Vec<Vertex2> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
 
     let mut group = c.benchmark_group("squaremap-shift");
 

--- a/honeycomb-utils/src/generation.rs
+++ b/honeycomb-utils/src/generation.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{DartIdentifier, SewPolicy, TwoMap, UnsewPolicy, VertexIdentifier};
+use honeycomb_core::{DartIdentifier, SewPolicy, TwoMap, UnsewPolicy, Vertex2, VertexIdentifier};
 
 // ------ CONTENT
 
@@ -82,8 +82,11 @@ pub fn square_two_map<const N_MARKS: usize>(n_square: usize) -> TwoMap<N_MARKS> 
         (0..n_square + 1).for_each(|x_idx| {
             // first position the vertex
             let vertex_id = (y_idx * (n_square + 1) + x_idx) as VertexIdentifier;
-            map.set_vertex(vertex_id, [x_idx as f64 * 1.0, y_idx as f64 * 1.0])
-                .unwrap();
+            map.set_vertex(
+                vertex_id,
+                Vertex2::from((x_idx as f64 * 1.0, y_idx as f64 * 1.0)),
+            )
+            .unwrap();
             // update the associated 0-cell
             if (y_idx < n_square) & (x_idx < n_square) {
                 let base_dart = (1 + 4 * x_idx + n_square * 4 * y_idx) as DartIdentifier;


### PR DESCRIPTION
# Description

Add a custom structure representing 2D coordinates: `Coords2`.  The type used by the map is still `Vertex2`, but it now stands as an alias to the new structure. This is done in case we ever discriminate vectors from vertices.

The structure uses `f64` as a floating type by default but it can be changed by enabling the `single_precision` feature for the core crate.

## Scope

- [x] Code: all features in `honeycomb-core`, other changes are just support/usage of the new structure
- [ ] Documentation

## Type of change

- [x] New feature(s)

## Other

- [x] New dependency

## Necessary follow-up

...

## Mentions

...