### PR TITLE
feat: implement a 2D combinatorial map visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
+# Rust
 Cargo.lock
 /target
+
+# wasm
+*/pkg
+
 # local IDE configs
 /.idea
 /.vscode
+
 # ignore csv & svg files in root directory
 /*.csv
 /*.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-members = ["honeycomb-utils", "honeycomb-core"]
+members = ["honeycomb-utils", "honeycomb-core", "honeycomb-render"]
 
 resolver = "2"
 

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1322,7 +1322,7 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
             part_one
         };
 
-        let face = Face {
+        let mut face = Face {
             corners: res
                 .iter()
                 .map(|d_id| self.dart_data.associated_cells[*d_id as usize].vertex_id)
@@ -1330,6 +1330,9 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
             closed,
         };
 
+        if face.closed {
+            face.corners.push(face.corners[0]);
+        }
         self.faces.push(face);
         new_faceid
     }

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1322,7 +1322,7 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
             part_one
         };
 
-        let mut face = Face {
+        let face = Face {
             corners: res
                 .iter()
                 .map(|d_id| self.dart_data.associated_cells[*d_id as usize].vertex_id)
@@ -1330,9 +1330,6 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
             closed,
         };
 
-        if face.closed {
-            face.corners.push(face.corners[0]);
-        }
         self.faces.push(face);
         new_faceid
     }

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "honeycomb-render"
+version = "0.1.2"
+edition = "2021"
+
+[dependencies]

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -4,3 +4,21 @@ version = "0.1.2"
 edition = "2021"
 
 [dependencies]
+cfg-if = "1"
+wgpu = "0.19"
+winit = "0.29"
+env_logger = "0.11"
+pollster = "0.3"
+cgmath = "0.18"
+bytemuck = { version = "1.14", features = ["derive"] }
+honeycomb-core = { git = "https://github.com/LIHPC-Computational-Geometry/honeycomb.git", rev = "06772b0" }
+smaa = "0.13"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.6"
+console_log = "1.0"
+wgpu = { version = "0.19", features = ["webgl"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["Document", "Window", "Element"] }
+

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -3,6 +3,9 @@ name = "honeycomb-render"
 version = "0.1.2"
 edition = "2021"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 cfg-if = "1"
 wgpu = "0.19"

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.11"
 pollster = "0.3"
 cgmath = "0.18"
 bytemuck = { version = "1.14", features = ["derive"] }
-honeycomb-core = { git = "https://github.com/LIHPC-Computational-Geometry/honeycomb.git", rev = "06772b0" }
+honeycomb-core = { path = "../honeycomb-core/" }
 smaa = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.11"
 pollster = "0.3"
 cgmath = "0.18"
 bytemuck = { version = "1.14", features = ["derive"] }
-honeycomb-core = { path = "../honeycomb-core/" }
+honeycomb-core = { path = "../honeycomb-core" }
 smaa = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -21,4 +21,19 @@ wgpu = { version = "0.19", features = ["webgl"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Document", "Window", "Element"] }
+
+[dev-dependencies]
+honeycomb-utils = { path = "../honeycomb-utils" }
+
+[[example]]
+name = "render_default_no_aa"
+path = "examples/render_default_no_aa.rs"
+
+[[example]]
+name = "render_default_smaa1x"
+path = "examples/render_default_smaa1x.rs"
+
+[[example]]
+name = "render_squaremap"
+path = "examples/render_squaremap.rs"
 

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -37,3 +37,7 @@ path = "examples/render_default_smaa1x.rs"
 name = "render_squaremap"
 path = "examples/render_squaremap.rs"
 
+[[example]]
+name = "render_splitsquaremap"
+path = "examples/render_splitsquaremap.rs"
+

--- a/honeycomb-render/examples/render_default_no_aa.rs
+++ b/honeycomb-render/examples/render_default_no_aa.rs
@@ -1,0 +1,5 @@
+use honeycomb_render::{Runner, SmaaMode};
+
+fn main() {
+    Runner::default().run::<1, f32>(SmaaMode::Disabled, None);
+}

--- a/honeycomb-render/examples/render_default_no_aa.rs
+++ b/honeycomb-render/examples/render_default_no_aa.rs
@@ -1,5 +1,9 @@
-use honeycomb_render::{Runner, SmaaMode};
+use honeycomb_render::{RenderParameters, Runner, SmaaMode};
 
 fn main() {
-    Runner::default().run::<1, f32>(SmaaMode::Disabled, None);
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Disabled,
+        ..Default::default()
+    };
+    Runner::default().run::<1, f32>(render_params, None);
 }

--- a/honeycomb-render/examples/render_default_smaa1x.rs
+++ b/honeycomb-render/examples/render_default_smaa1x.rs
@@ -1,5 +1,9 @@
-use honeycomb_render::{Runner, SmaaMode};
+use honeycomb_render::{RenderParameters, Runner, SmaaMode};
 
 fn main() {
-    Runner::default().run::<1, f32>(SmaaMode::Smaa1X, None);
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    Runner::default().run::<1, f32>(render_params, None);
 }

--- a/honeycomb-render/examples/render_default_smaa1x.rs
+++ b/honeycomb-render/examples/render_default_smaa1x.rs
@@ -1,0 +1,5 @@
+use honeycomb_render::{Runner, SmaaMode};
+
+fn main() {
+    Runner::default().run::<1, f32>(SmaaMode::Smaa1X, None);
+}

--- a/honeycomb-render/examples/render_default_smaa1x.rs
+++ b/honeycomb-render/examples/render_default_smaa1x.rs
@@ -1,4 +1,4 @@
-use honeycomb_render::{RenderParameters, Runner, SmaaMode};
+use honeycomb_render::*;
 
 fn main() {
     let render_params = RenderParameters {

--- a/honeycomb-render/examples/render_splitsquaremap.rs
+++ b/honeycomb-render/examples/render_splitsquaremap.rs
@@ -1,0 +1,12 @@
+use honeycomb_core::TwoMap;
+use honeycomb_render::*;
+use honeycomb_utils::generation::splitsquare_two_map;
+
+fn main() {
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    let map: TwoMap<1, f32> = splitsquare_two_map(4);
+    Runner::default().run(render_params, Some(&map));
+}

--- a/honeycomb-render/examples/render_squaremap.rs
+++ b/honeycomb-render/examples/render_squaremap.rs
@@ -1,0 +1,12 @@
+use honeycomb_core::TwoMap;
+use honeycomb_render::*;
+use honeycomb_utils::generation::square_two_map;
+
+fn main() {
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    let map: TwoMap<1, f32> = square_two_map(4);
+    Runner::default().run(render_params, Some(&map));
+}

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -21,6 +21,14 @@ pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
     0.0, 0.0, 0.0, 1.0,
 );
 
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        const SPEED_FACTOR: f32 = 0.005;
+    } else {
+        const SPEED_FACTOR: f32 = 0.05;
+    }
+}
+
 pub struct Camera {
     pub eye: cgmath::Point3<f32>,
     pub target: cgmath::Point3<f32>,
@@ -138,15 +146,15 @@ impl CameraController {
         // Prevents glitching when the camera gets too close to the
         // center of the scene.
         if self.is_forward_pressed
-            && camera.eye.z + forward_dir.z * 0.05 * camera.eye.z > 2.0 * camera.znear
+            && camera.eye.z + forward_dir.z * SPEED_FACTOR * camera.eye.z > 2.0 * camera.znear
         {
-            self.speed = 0.05 * camera.eye.z;
+            self.speed = SPEED_FACTOR * camera.eye.z;
             camera.eye += forward_dir * self.speed;
         }
         if self.is_backward_pressed
-            && camera.eye.z - forward_dir.z * 0.05 * camera.eye.z < 2.0 * camera.zfar
+            && camera.eye.z - forward_dir.z * SPEED_FACTOR * camera.eye.z < 2.0 * camera.zfar
         {
-            self.speed = 0.05 * camera.eye.z;
+            self.speed = SPEED_FACTOR * camera.eye.z;
             camera.eye -= forward_dir * self.speed;
         }
 

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -4,20 +4,169 @@
 //!
 //! Content description if needed
 
-// ------ MODULE DECLARATIONS
-
 // ------ IMPORTS
+
+use winit::{
+    event::{ElementState, KeyEvent, WindowEvent},
+    keyboard::{Key, NamedKey},
+};
 
 // ------ CONTENT
 
-// ------ TESTS
+#[rustfmt::skip]
+pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
+    1.0, 0.0, 0.0, 0.0,
+    0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 0.5, 0.5,
+    0.0, 0.0, 0.0, 1.0,
+);
 
-#[cfg(test)]
-mod tests {
-    //use super::*;
+pub struct Camera {
+    pub eye: cgmath::Point3<f32>,
+    pub target: cgmath::Point3<f32>,
+    pub up: cgmath::Vector3<f32>,
+    pub aspect: f32,
+    pub fovy: f32,
+    pub znear: f32,
+    pub zfar: f32,
+}
 
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+impl Camera {
+    fn build_view_projection_matrix(&self) -> cgmath::Matrix4<f32> {
+        let view = cgmath::Matrix4::look_at_rh(self.eye, self.target, self.up);
+        let proj = cgmath::perspective(cgmath::Deg(self.fovy), self.aspect, self.znear, self.zfar);
+        OPENGL_TO_WGPU_MATRIX * proj * view
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CameraUniform {
+    view_proj: [[f32; 4]; 4],
+}
+
+impl Default for CameraUniform {
+    fn default() -> Self {
+        use cgmath::SquareMatrix;
+        Self {
+            view_proj: cgmath::Matrix4::identity().into(),
+        }
+    }
+}
+
+impl CameraUniform {
+    pub fn update_view_proj(&mut self, camera: &Camera) {
+        self.view_proj = camera.build_view_projection_matrix().into();
+    }
+}
+
+pub struct CameraController {
+    speed: f32,
+    is_forward_pressed: bool,
+    is_backward_pressed: bool,
+    is_up_pressed: bool,
+    is_down_pressed: bool,
+    is_left_pressed: bool,
+    is_right_pressed: bool,
+}
+
+impl CameraController {
+    pub fn new(speed: f32) -> Self {
+        Self {
+            speed,
+            is_forward_pressed: false,
+            is_backward_pressed: false,
+            is_up_pressed: false,
+            is_down_pressed: false,
+            is_left_pressed: false,
+            is_right_pressed: false,
+        }
+    }
+
+    pub fn process_events(&mut self, event: &WindowEvent) -> bool {
+        match event {
+            WindowEvent::KeyboardInput {
+                event: KeyEvent {
+                    state, logical_key, ..
+                },
+                ..
+            } => {
+                let is_pressed = *state == ElementState::Pressed;
+                match logical_key {
+                    Key::Named(named) => match named {
+                        NamedKey::ArrowUp => {
+                            self.is_up_pressed = is_pressed;
+                            true
+                        }
+                        NamedKey::ArrowLeft => {
+                            self.is_left_pressed = is_pressed;
+                            true
+                        }
+                        NamedKey::ArrowDown => {
+                            self.is_down_pressed = is_pressed;
+                            true
+                        }
+                        NamedKey::ArrowRight => {
+                            self.is_right_pressed = is_pressed;
+                            true
+                        }
+                        _ => false,
+                    },
+                    Key::Character(smolstr) => {
+                        if smolstr.as_str() == "f" {
+                            self.is_forward_pressed = is_pressed;
+                            true
+                        } else if smolstr.as_str() == "b" {
+                            self.is_backward_pressed = is_pressed;
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    pub fn update_camera(&mut self, camera: &mut Camera) {
+        use cgmath::InnerSpace;
+        let forward = camera.target - camera.eye;
+        let forward_dir = forward.normalize();
+
+        // Prevents glitching when the camera gets too close to the
+        // center of the scene.
+        if self.is_forward_pressed
+            && camera.eye.z + forward_dir.z * 0.05 * camera.eye.z > 2.0 * camera.znear
+        {
+            self.speed = 0.05 * camera.eye.z;
+            camera.eye += forward_dir * self.speed;
+        }
+        if self.is_backward_pressed
+            && camera.eye.z - forward_dir.z * 0.05 * camera.eye.z < 2.0 * camera.zfar
+        {
+            self.speed = 0.05 * camera.eye.z;
+            camera.eye -= forward_dir * self.speed;
+        }
+
+        let right = forward_dir.cross(camera.up);
+
+        if self.is_right_pressed {
+            camera.eye += right * self.speed;
+            camera.target += right * self.speed;
+        }
+        if self.is_left_pressed {
+            camera.eye -= right * self.speed;
+            camera.target -= right * self.speed;
+        }
+        if self.is_up_pressed {
+            camera.eye += camera.up * self.speed;
+            camera.target += camera.up * self.speed;
+        }
+        if self.is_down_pressed {
+            camera.eye -= camera.up * self.speed;
+            camera.target -= camera.up * self.speed;
+        }
     }
 }

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -6,14 +6,18 @@
 
 // ------ MODULE DECLARATIONS
 
-mod camera;
-mod handle;
-mod runner;
-mod shader_data;
-mod state;
-
-// ------ RE-EXPORTS
+// ------ IMPORTS
 
 // ------ CONTENT
 
 // ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -23,9 +23,9 @@ pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "linux")] {
-        const SPEED_FACTOR: f32 = 0.005;
+        pub const SPEED_FACTOR: f32 = 0.005;
     } else {
-        const SPEED_FACTOR: f32 = 0.05;
+        pub const SPEED_FACTOR: f32 = 0.05;
     }
 }
 

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -7,11 +7,13 @@
 // ------ IMPORTS
 
 use crate::shader_data::Coords2Shader;
+use crate::SmaaMode;
 use honeycomb_core::{Coords2, CoordsFloat, FaceIdentifier, TwoMap};
 
 // ------ CONTENT
 
 pub struct RenderParameters {
+    pub smaa_mode: SmaaMode,
     pub shrink_factor: f32,
     pub arrow_headsize: f32,
     pub arrow_thickness: f32,
@@ -20,6 +22,7 @@ pub struct RenderParameters {
 impl Default for RenderParameters {
     fn default() -> Self {
         Self {
+            smaa_mode: SmaaMode::Disabled,
             shrink_factor: 0.1,   // need to adjust
             arrow_headsize: 0.1,  // need to adjust
             arrow_thickness: 0.1, // need to adjust

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -6,14 +6,18 @@
 
 // ------ MODULE DECLARATIONS
 
-mod camera;
-mod handle;
-mod runner;
-mod shader_data;
-mod state;
-
-// ------ RE-EXPORTS
+// ------ IMPORTS
 
 // ------ CONTENT
 
 // ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -30,7 +30,8 @@ impl Default for RenderParameters {
 pub struct TwoMapRenderHandle<'a, const N_MARKS: usize, T: CoordsFloat> {
     handle: &'a TwoMap<N_MARKS, T>,
     params: RenderParameters,
-    construction_buffer: Vec<Coords2Shader>,
+    dart_construction_buffer: Vec<Coords2Shader>,
+    beta_construction_buffer: Vec<Coords2Shader>,
     vertices: Vec<Coords2Shader>,
 }
 
@@ -39,14 +40,15 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T
         Self {
             handle: map,
             params: params.unwrap_or_default(),
-            construction_buffer: Vec::new(),
+            dart_construction_buffer: Vec::new(),
+            beta_construction_buffer: Vec::new(),
             vertices: Vec::new(),
         }
     }
 
     pub fn build_darts(&mut self) {
         let n_face = self.handle.n_faces() as FaceIdentifier;
-        self.construction_buffer.extend(
+        self.dart_construction_buffer.extend(
             (0..n_face)
                 .flat_map(|face_id| {
                     let cell = self.handle.face(face_id);
@@ -91,7 +93,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T
 
     pub fn save_buffered(&mut self) {
         self.vertices.clear();
-        self.vertices.append(&mut self.construction_buffer);
+        self.vertices.append(&mut self.dart_construction_buffer);
     }
 
     pub fn vertices(&self) -> &[Coords2Shader] {

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -72,15 +72,21 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T
             face_iter
                 .flat_map(|(cell, center, face_id)| {
                     let n_vertices = cell.corners.len();
-                    let fids = (0..n_vertices - 1).map(move |_| face_id);
-                    let centers = (0..n_vertices - 1).map(move |_| center);
-                    (0..n_vertices - 1)
+                    let fids = (0..n_vertices).map(move |_| face_id);
+                    let centers = (0..n_vertices).map(move |_| center);
+                    (0..n_vertices)
                         .zip(centers)
                         .map(|(vertex_id, center)| {
+                            let v1id = vertex_id;
+                            let v2id = if vertex_id == cell.corners.len() - 1 {
+                                0
+                            } else {
+                                vertex_id + 1
+                            };
                             // fetch dart vetices
                             let (v1, v2) = (
-                                self.handle.vertex(cell.corners[vertex_id]),
-                                self.handle.vertex(cell.corners[vertex_id + 1]),
+                                self.handle.vertex(cell.corners[v1id]),
+                                self.handle.vertex(cell.corners[v2id]),
                             );
 
                             // shrink towards center

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -40,7 +40,7 @@ pub struct TwoMapRenderHandle<'a, const N_MARKS: usize, T: CoordsFloat> {
     handle: &'a TwoMap<N_MARKS, T>,
     params: RenderParameters,
     dart_construction_buffer: Vec<Coords2Shader>,
-    beta_construction_buffer: Vec<Coords2Shader>,
+    _beta_construction_buffer: Vec<Coords2Shader>,
     vertices: Vec<Coords2Shader>,
 }
 
@@ -50,7 +50,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T
             handle: map,
             params: params.unwrap_or_default(),
             dart_construction_buffer: Vec::new(),
-            beta_construction_buffer: Vec::new(),
+            _beta_construction_buffer: Vec::new(),
             vertices: Vec::new(),
         }
     }
@@ -138,6 +138,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T
         );
     }
 
+    #[allow(dead_code)]
     pub fn build_betas(&mut self) {
         todo!()
     }

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -4,20 +4,97 @@
 //!
 //! Content description if needed
 
-// ------ MODULE DECLARATIONS
-
 // ------ IMPORTS
+
+use crate::shader_data::Coords2Shader;
+use honeycomb_core::{Coords2, CoordsFloat, FaceIdentifier, TwoMap};
 
 // ------ CONTENT
 
-// ------ TESTS
+pub struct RenderParameters {
+    pub shrink_factor: f32,
+    pub arrow_headsize: f32,
+    pub arrow_thickness: f32,
+}
 
-#[cfg(test)]
-mod tests {
-    //use super::*;
+impl Default for RenderParameters {
+    fn default() -> Self {
+        Self {
+            shrink_factor: 0.1,   // need to adjust
+            arrow_headsize: 0.1,  // need to adjust
+            arrow_thickness: 0.1, // need to adjust
+        }
+    }
+}
 
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+pub struct TwoMapRenderHandle<'a, const N_MARKS: usize, T: CoordsFloat> {
+    handle: &'a TwoMap<N_MARKS, T>,
+    params: RenderParameters,
+    construction_buffer: Vec<Coords2Shader>,
+    vertices: Vec<Coords2Shader>,
+}
+
+impl<'a, const N_MARKS: usize, T: CoordsFloat> TwoMapRenderHandle<'a, N_MARKS, T> {
+    pub fn new(map: &'a TwoMap<N_MARKS, T>, params: Option<RenderParameters>) -> Self {
+        Self {
+            handle: map,
+            params: params.unwrap_or_default(),
+            construction_buffer: Vec::new(),
+            vertices: Vec::new(),
+        }
+    }
+
+    pub fn build_darts(&mut self) {
+        let n_face = self.handle.n_faces() as FaceIdentifier;
+        self.construction_buffer.extend(
+            (0..n_face)
+                .flat_map(|face_id| {
+                    let cell = self.handle.face(face_id);
+                    // compute face center for shrink operation
+                    let center: Coords2<T> = cell
+                        .corners
+                        .iter()
+                        .map(|vid| self.handle.vertex(*vid))
+                        .sum::<Coords2<T>>()
+                        / T::from(cell.corners.len()).unwrap();
+                    let n_vertices = cell.corners.len();
+                    let fids = (0..n_vertices - 1).map(move |_| face_id);
+                    (0..n_vertices - 1)
+                        .map(|vertex_id| {
+                            // fetch dart vetices
+                            let (mut v1, mut v2) = (
+                                self.handle.vertex(cell.corners[vertex_id]),
+                                self.handle.vertex(cell.corners[vertex_id + 1]),
+                            );
+                            // shrink
+
+                            // return a coordinate pair
+                            (v1, v2)
+                        })
+                        .zip(fids)
+                })
+                .flat_map(|((v1, v2), face_id)| {
+                    // transform the coordinates into triangles for the shader to render
+
+                    [
+                        Coords2Shader::new((0.0, 0.0), 0),
+                        Coords2Shader::new((0.0, 0.0), 0),
+                    ]
+                    .into_iter()
+                }),
+        );
+    }
+
+    pub fn build_betas(&mut self) {
+        todo!()
+    }
+
+    pub fn save_buffered(&mut self) {
+        self.vertices.clear();
+        self.vertices.append(&mut self.construction_buffer);
+    }
+
+    pub fn vertices(&self) -> &[Coords2Shader] {
+        &self.vertices
     }
 }

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -1,8 +1,24 @@
-//! Module short description
+//! # honeycomb-render
 //!
-//! Should you interact with this module directly?
+//! This crate implements a runner that can be used to display
+//! combinatorial maps.
 //!
-//! Content description if needed
+//! It currently only supports 2D maps as the core library only
+//! implements these (as [TwoMap])
+//!
+//! ## Quickstart
+//!
+//! The crate provides the following example:
+//!
+//! - `render_default_no_aa` -- Render a hardcoded arrow without anti-aliasing.
+//! - `render_default_smaa1x` -- Render a hardcoded arrow with anti-aliasing.
+//! - `render_splitsquaremap` -- Render a map generated using functions provided by
+//!   the **honeycomb-utils** crate.
+//! - `render_squaremap` -- Render a map generated using functions provided by the
+//!   **honeycomb-utils** crate.
+
+#[cfg(doc)]
+use honeycomb_core::TwoMap;
 
 // ------ MODULE DECLARATIONS
 

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -13,3 +13,7 @@ mod shader_data;
 mod state;
 
 // ------ RE-EXPORTS
+
+pub use handle::RenderParameters;
+pub use runner::Runner;
+pub use state::SmaaMode;

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -6,6 +6,12 @@
 //! It currently only supports 2D maps as the core library only
 //! implements these (as [TwoMap])
 //!
+//! ## Key bindings
+//!
+//! - Directional arrows -- Move up, down, left and right
+//! - `F` -- Move forward (i.e. zoom in)
+//! - `B` -- Move backward (i.e. zoom out)
+//!
 //! ## Quickstart
 //!
 //! The crate provides the following example:

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -13,7 +13,3 @@ mod shader_data;
 mod state;
 
 // ------ RE-EXPORTS
-
-// ------ CONTENT
-
-// ------ TESTS

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -4,20 +4,101 @@
 //!
 //! Content description if needed
 
-// ------ MODULE DECLARATIONS
-
 // ------ IMPORTS
+
+use winit::event::{Event, WindowEvent};
+use winit::event_loop::EventLoop;
+use winit::window::Window;
+
+use crate::state::{SmaaMode, State};
+use honeycomb_core::{CoordsFloat, TwoMap};
 
 // ------ CONTENT
 
-// ------ TESTS
+async fn inner(event_loop: EventLoop<()>, window: Window, smaa_mode: SmaaMode) {
+    let mut state = State::new(&window, smaa_mode).await;
 
-#[cfg(test)]
-mod tests {
-    //use super::*;
+    event_loop
+        .run(move |event, target| {
+            match event {
+                Event::WindowEvent {
+                    window_id,
+                    event: wevent,
+                } => {
+                    if window_id == state.window().id() && !state.input(&wevent) {
+                        match wevent {
+                            WindowEvent::Resized(new_size) => state.resize(Some(new_size)),
+                            WindowEvent::RedrawRequested => {
+                                state.update();
+                                match state.render() {
+                                    Ok(_) => {}
+                                    Err(wgpu::SurfaceError::Lost) => state.resize(None),
+                                    Err(wgpu::SurfaceError::OutOfMemory) => target.exit(), // kill if OOM
+                                    Err(e) => eprintln!("{:?}", e),
+                                }
+                            }
+                            WindowEvent::CloseRequested => target.exit(),
+                            _ => {}
+                        };
+                    }
+                }
+                Event::AboutToWait => {
+                    state.window().request_redraw();
+                }
+                _ => {}
+            }
+        })
+        .unwrap();
+}
 
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+pub struct Runner {
+    event_loop: EventLoop<()>,
+    window: Window,
+}
+
+impl Runner {
+    pub fn run<const N_MARKS: usize, T: CoordsFloat>(
+        self,
+        smaa_mode: SmaaMode,
+        map: Option<&TwoMap<N_MARKS, T>>,
+    ) {
+        cfg_if::cfg_if! {
+            if #[cfg(target_arch = "wasm32")] {
+                std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+                console_log::init().expect("could not initialize logger");
+                wasm_bindgen_futures::spawn_local(run(event_loop, window));
+            } else {
+                env_logger::init();
+                pollster::block_on(inner(self.event_loop, self.window, smaa_mode));
+            }
+        }
+    }
+    pub async fn run_async(&self) {
+        unimplemented!()
+    }
+}
+
+impl Default for Runner {
+    fn default() -> Self {
+        let event_loop = EventLoop::new().unwrap();
+        #[allow(unused_mut)]
+        let mut builder = winit::window::WindowBuilder::new();
+        #[cfg(target_arch = "wasm32")]
+        {
+            use wasm_bindgen::JsCast;
+            use winit::platform::web::WindowBuilderExtWebSys;
+            let canvas = web_sys::window()
+                .unwrap()
+                .document()
+                .unwrap()
+                .get_element_by_id("canvas")
+                .unwrap()
+                .dyn_into::<web_sys::HtmlCanvasElement>()
+                .unwrap();
+            builder = builder.with_canvas(Some(canvas));
+        }
+        let window = builder.build(&event_loop).unwrap();
+
+        Self { event_loop, window }
     }
 }

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -6,14 +6,18 @@
 
 // ------ MODULE DECLARATIONS
 
-mod camera;
-mod handle;
-mod runner;
-mod shader_data;
-mod state;
-
-// ------ RE-EXPORTS
+// ------ IMPORTS
 
 // ------ CONTENT
 
 // ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -15,8 +15,17 @@ use honeycomb_core::{CoordsFloat, TwoMap};
 
 // ------ CONTENT
 
-async fn inner(event_loop: EventLoop<()>, window: Window, smaa_mode: SmaaMode) {
-    let mut state = State::new(&window, smaa_mode).await;
+async fn inner<const N_MARKS: usize, T: CoordsFloat>(
+    event_loop: EventLoop<()>,
+    window: Window,
+    smaa_mode: SmaaMode,
+    map: Option<&TwoMap<N_MARKS, T>>,
+) {
+    let mut state = if let Some(val) = map {
+        State::new(&window, smaa_mode, val).await
+    } else {
+        State::new_test(&window, smaa_mode).await
+    };
 
     event_loop
         .run(move |event, target| {
@@ -69,7 +78,7 @@ impl Runner {
                 wasm_bindgen_futures::spawn_local(run(event_loop, window));
             } else {
                 env_logger::init();
-                pollster::block_on(inner(self.event_loop, self.window, smaa_mode));
+                pollster::block_on(inner(self.event_loop, self.window, smaa_mode, map));
             }
         }
     }

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -11,6 +11,7 @@ use winit::event_loop::EventLoop;
 use winit::window::Window;
 
 use crate::state::{SmaaMode, State};
+use crate::RenderParameters;
 use honeycomb_core::{CoordsFloat, TwoMap};
 
 // ------ CONTENT
@@ -18,13 +19,13 @@ use honeycomb_core::{CoordsFloat, TwoMap};
 async fn inner<const N_MARKS: usize, T: CoordsFloat>(
     event_loop: EventLoop<()>,
     window: Window,
-    smaa_mode: SmaaMode,
+    render_params: RenderParameters,
     map: Option<&TwoMap<N_MARKS, T>>,
 ) {
     let mut state = if let Some(val) = map {
-        State::new(&window, smaa_mode, val).await
+        State::new(&window, render_params, val).await
     } else {
-        State::new_test(&window, smaa_mode).await
+        State::new_test(&window, render_params).await
     };
 
     event_loop
@@ -68,7 +69,7 @@ pub struct Runner {
 impl Runner {
     pub fn run<const N_MARKS: usize, T: CoordsFloat>(
         self,
-        smaa_mode: SmaaMode,
+        render_params: RenderParameters,
         map: Option<&TwoMap<N_MARKS, T>>,
     ) {
         cfg_if::cfg_if! {
@@ -78,7 +79,7 @@ impl Runner {
                 wasm_bindgen_futures::spawn_local(run(event_loop, window));
             } else {
                 env_logger::init();
-                pollster::block_on(inner(self.event_loop, self.window, smaa_mode, map));
+                pollster::block_on(inner(self.event_loop, self.window, render_params, map));
             }
         }
     }

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -10,7 +10,7 @@ use winit::event::{Event, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::window::Window;
 
-use crate::state::{SmaaMode, State};
+use crate::state::State;
 use crate::RenderParameters;
 use honeycomb_core::{CoordsFloat, TwoMap};
 

--- a/honeycomb-render/src/shader2.wgsl
+++ b/honeycomb-render/src/shader2.wgsl
@@ -23,7 +23,7 @@ fn vs_main(
 ) -> VertexOutput {
     var out: VertexOutput;
     out.clip_position = camera.view_proj * vec4<f32>(model.position, 0.0, 1.0);
-    out.color = model.color;
+    out.color = model.color % 7;
     return out;
 }
 

--- a/honeycomb-render/src/shader2.wgsl
+++ b/honeycomb-render/src/shader2.wgsl
@@ -1,0 +1,44 @@
+struct CameraUniform {
+    view_proj: mat4x4<f32>,
+};
+
+@group(0) @binding(0) // 1.
+var<uniform> camera: CameraUniform;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) color: u32,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: u32,
+}
+
+// vertex shader
+
+@vertex
+fn vs_main(
+    model: VertexInput,
+) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = camera.view_proj * vec4<f32>(model.position, 0.0, 1.0);
+    out.color = model.color;
+    return out;
+}
+
+// fragment shader
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    var color: array<vec3<f32>, 7> = array(
+        vec3<f32>(0.1, 0.1, 0.1),
+        vec3<f32>(1.0, 0.1, 0.1),
+        vec3<f32>(0.1, 1.0, 0.1),
+        vec3<f32>(0.1, 0.1, 1.0),
+        vec3<f32>(0.1, 1.0, 1.0),
+        vec3<f32>(1.0, 0.1, 1.0),
+        vec3<f32>(1.0, 1.0, 0.1),
+    );
+    return vec4<f32>(color[in.color], 1.0);
+}

--- a/honeycomb-render/src/shader_data.rs
+++ b/honeycomb-render/src/shader_data.rs
@@ -6,14 +6,18 @@
 
 // ------ MODULE DECLARATIONS
 
-mod camera;
-mod handle;
-mod runner;
-mod shader_data;
-mod state;
-
-// ------ RE-EXPORTS
+// ------ IMPORTS
 
 // ------ CONTENT
 
 // ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-render/src/shader_data.rs
+++ b/honeycomb-render/src/shader_data.rs
@@ -4,20 +4,65 @@
 //!
 //! Content description if needed
 
-// ------ MODULE DECLARATIONS
-
 // ------ IMPORTS
+
+use bytemuck::{Pod, Zeroable};
+use honeycomb_core::FaceIdentifier;
 
 // ------ CONTENT
 
-// ------ TESTS
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+pub struct Coords2Shader {
+    position: [f32; 2],
+    color: u32,
+}
 
-#[cfg(test)]
-mod tests {
-    //use super::*;
+impl Coords2Shader {
+    const ATTRIBUTES: [wgpu::VertexAttribute; 2] =
+        wgpu::vertex_attr_array![0 => Float32x2, 1 => Uint32];
 
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+    pub fn new((x, y): (f32, f32), face_id: FaceIdentifier) -> Self {
+        Self {
+            position: [x, y],
+            #[allow(clippy::unnecessary_cast)]
+            color: face_id as u32,
+        }
+    }
+
+    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Coords2Shader>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &Self::ATTRIBUTES,
+        }
     }
 }
+
+// pack of six => one arrow
+pub const TEST_VERTICES: &[Coords2Shader] = &[
+    Coords2Shader {
+        position: [-0.5, 0.0],
+        color: 0,
+    },
+    Coords2Shader {
+        position: [0.5, -0.02],
+        color: 0,
+    },
+    Coords2Shader {
+        position: [0.5, 0.02],
+        color: 0,
+    },
+    Coords2Shader {
+        position: [0.5, -0.04],
+        color: 0,
+    },
+    Coords2Shader {
+        position: [0.5, 0.04],
+        color: 0,
+    },
+    Coords2Shader {
+        position: [0.6, 0.0],
+        color: 0,
+    },
+];

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -7,7 +7,7 @@
 // ------ IMPORTS
 
 // intern
-use crate::camera::{Camera, CameraController, CameraUniform};
+use crate::camera::{Camera, CameraController, CameraUniform, SPEED_FACTOR};
 use crate::handle::TwoMapRenderHandle;
 use crate::shader_data::{Coords2Shader, TEST_VERTICES};
 use crate::RenderParameters;
@@ -157,7 +157,7 @@ async fn inner(
         label: Some("camera_bind_group"),
     });
 
-    let camera_controller = CameraController::new(0.05 * 3.0);
+    let camera_controller = CameraController::new(SPEED_FACTOR * 3.0);
 
     let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
         label: None,

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -4,20 +4,278 @@
 //!
 //! Content description if needed
 
-// ------ MODULE DECLARATIONS
-
 // ------ IMPORTS
+
+use crate::camera::{Camera, CameraController, CameraUniform};
+use crate::shader_data::{Coords2Shader, TEST_VERTICES};
+use smaa::{SmaaMode as ExtSmaaMode, SmaaTarget};
+use std::borrow::Cow;
+use wgpu::util::DeviceExt;
+use wgpu::PrimitiveTopology;
+use winit::{event::WindowEvent, window::Window};
 
 // ------ CONTENT
 
-// ------ TESTS
+pub enum SmaaMode {
+    Smaa1X,
+    Disabled,
+}
 
-#[cfg(test)]
-mod tests {
-    //use super::*;
+impl From<SmaaMode> for smaa::SmaaMode {
+    fn from(value: SmaaMode) -> Self {
+        match value {
+            SmaaMode::Smaa1X => ExtSmaaMode::Smaa1X,
+            SmaaMode::Disabled => ExtSmaaMode::Disabled,
+        }
+    }
+}
 
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+pub struct State<'a> {
+    surface: wgpu::Surface<'a>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    size: winit::dpi::PhysicalSize<u32>,
+    render_pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    num_vertices: u32,
+    camera: Camera,
+    camera_uniform: CameraUniform,
+    camera_buffer: wgpu::Buffer,
+    camera_bind_group: wgpu::BindGroup,
+    camera_controller: CameraController,
+    smaa_target: SmaaTarget,
+    window: &'a Window,
+}
+
+impl<'a> State<'a> {
+    pub async fn new(window: &'a Window, smaa_mode: SmaaMode) -> Self {
+        let mut size = window.inner_size();
+        size.width = size.width.max(1);
+        size.height = size.height.max(1);
+
+        let instance = wgpu::Instance::default();
+
+        let surface = instance.create_surface(window).unwrap();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: Some(&surface),
+            })
+            .await
+            .expect("E: Failed to fetch appropriate adaptater");
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::downlevel_webgl2_defaults()
+                        .using_resolution(adapter.limits()),
+                },
+                None,
+            )
+            .await
+            .expect("E: Failed to crete device");
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader2.wgsl"))),
+        });
+
+        let config = surface
+            .get_default_config(&adapter, size.width, size.height)
+            .unwrap();
+        surface.configure(&device, &config);
+
+        // Camera work
+
+        let camera = Camera {
+            // position the camera 1 unit up and 2 units back
+            // +z is out of the screen
+            eye: (0.0, 0.0, 3.0).into(),
+            // have it look at the origin
+            target: (0.0, 0.0, 0.0).into(),
+            // which way is "up"
+            up: cgmath::Vector3::unit_y(),
+            aspect: config.width as f32 / config.height as f32,
+            fovy: 45.0,
+            znear: 0.1,
+            zfar: 100.0,
+        };
+
+        let mut camera_uniform = CameraUniform::default();
+        camera_uniform.update_view_proj(&camera);
+
+        let camera_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Camera Buffer"),
+            contents: bytemuck::cast_slice(&[camera_uniform]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let camera_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+                label: Some("camera_bind_group_layout"),
+            });
+
+        let camera_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &camera_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: camera_buffer.as_entire_binding(),
+            }],
+            label: Some("camera_bind_group"),
+        });
+
+        let camera_controller = CameraController::new(0.05 * 3.0);
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&camera_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let swapchain_capabilities = surface.get_capabilities(&adapter);
+        let swapchain_format = swapchain_capabilities.formats[0];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Vertex Buffer"),
+            contents: bytemuck::cast_slice(TEST_VERTICES),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[Coords2Shader::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(swapchain_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: Default::default(),
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: Default::default(),
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
+
+        let num_vertices = TEST_VERTICES.len() as u32;
+
+        let smaa_target = SmaaTarget::new(
+            &device,
+            &queue,
+            window.inner_size().width,
+            window.inner_size().height,
+            swapchain_format,
+            ExtSmaaMode::from(smaa_mode),
+        );
+
+        Self {
+            surface,
+            device,
+            queue,
+            config,
+            size,
+            vertex_buffer,
+            render_pipeline,
+            num_vertices,
+            camera,
+            camera_uniform,
+            camera_buffer,
+            camera_bind_group,
+            camera_controller,
+            smaa_target,
+            window,
+        }
+    }
+
+    pub fn window(&self) -> &Window {
+        self.window
+    }
+
+    pub fn resize(&mut self, new_size_opt: Option<winit::dpi::PhysicalSize<u32>>) {
+        let new_size = new_size_opt.unwrap_or(self.size);
+        self.config.width = new_size.width.max(1);
+        self.config.height = new_size.height.max(1);
+        self.surface.configure(&self.device, &self.config);
+        self.window.request_redraw();
+    }
+
+    pub fn input(&mut self, event: &WindowEvent) -> bool {
+        self.camera_controller.process_events(event)
+    }
+
+    pub fn update(&mut self) {
+        self.camera_controller.update_camera(&mut self.camera);
+        self.camera_uniform.update_view_proj(&self.camera);
+        self.queue.write_buffer(
+            &self.camera_buffer,
+            0,
+            bytemuck::cast_slice(&[self.camera_uniform]),
+        );
+    }
+
+    pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+        let frame = self
+            .surface
+            .get_current_texture()
+            .expect("Failed to acquire next swap chain texture");
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let smaa_frame = self
+            .smaa_target
+            .start_frame(&self.device, &self.queue, &view);
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &smaa_frame,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            rpass.set_pipeline(&self.render_pipeline);
+            rpass.set_bind_group(0, &self.camera_bind_group, &[]);
+            rpass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            rpass.draw(0..self.num_vertices, 0..1);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+        smaa_frame.resolve();
+        frame.present();
+        Ok(())
     }
 }

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -6,18 +6,17 @@
 
 // ------ IMPORTS
 
+// intern
 use crate::camera::{Camera, CameraController, CameraUniform};
 use crate::handle::TwoMapRenderHandle;
 use crate::shader_data::{Coords2Shader, TEST_VERTICES};
 use crate::RenderParameters;
 use honeycomb_core::{CoordsFloat, TwoMap};
-use smaa::{SmaaMode as ExtSmaaMode, SmaaTarget};
+
+// extern
 use std::borrow::Cow;
 use wgpu::util::DeviceExt;
-use wgpu::{
-    Device, PipelineLayout, PrimitiveTopology, Queue, RenderPipeline, ShaderModule, Surface,
-    SurfaceConfiguration, TextureFormat,
-};
+use wgpu::PrimitiveTopology;
 use winit::dpi::PhysicalSize;
 use winit::{event::WindowEvent, window::Window};
 
@@ -33,8 +32,8 @@ pub enum SmaaMode {
 impl From<SmaaMode> for smaa::SmaaMode {
     fn from(value: SmaaMode) -> Self {
         match value {
-            SmaaMode::Smaa1X => ExtSmaaMode::Smaa1X,
-            SmaaMode::Disabled => ExtSmaaMode::Disabled,
+            SmaaMode::Smaa1X => smaa::SmaaMode::Smaa1X,
+            SmaaMode::Disabled => smaa::SmaaMode::Disabled,
         }
     }
 }
@@ -53,26 +52,26 @@ pub struct State<'a, const N_MARKS: usize, T: CoordsFloat> {
     camera_buffer: wgpu::Buffer,
     camera_bind_group: wgpu::BindGroup,
     camera_controller: CameraController,
-    smaa_target: SmaaTarget,
+    smaa_target: smaa::SmaaTarget,
     map_handle: Option<TwoMapRenderHandle<'a, N_MARKS, T>>,
     window: &'a Window,
 }
 
-async fn inner<'a>(
-    window: &'a Window,
+async fn inner(
+    window: &Window,
     size: PhysicalSize<u32>,
 ) -> (
-    Surface<'a>,
-    Device,
-    Queue,
-    SurfaceConfiguration,
+    wgpu::Surface<'_>,
+    wgpu::Device,
+    wgpu::Queue,
+    wgpu::SurfaceConfiguration,
     Camera,
     CameraUniform,
     wgpu::Buffer,
     wgpu::BindGroup,
     CameraController,
-    TextureFormat,
-    RenderPipeline,
+    wgpu::TextureFormat,
+    wgpu::RenderPipeline,
 ) {
     let instance = wgpu::Instance::default();
 
@@ -235,13 +234,13 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> State<'a, N_MARKS, T> {
             render_pipeline,
         ) = inner(window, size).await;
 
-        let smaa_target = SmaaTarget::new(
+        let smaa_target = smaa::SmaaTarget::new(
             &device,
             &queue,
             window.inner_size().width,
             window.inner_size().height,
             swapchain_format,
-            ExtSmaaMode::from(render_params.smaa_mode),
+            smaa::SmaaMode::from(render_params.smaa_mode),
         );
 
         let mut map_handle = TwoMapRenderHandle::new(map, Some(render_params));
@@ -298,13 +297,13 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> State<'a, N_MARKS, T> {
             render_pipeline,
         ) = inner(window, size).await;
 
-        let smaa_target = SmaaTarget::new(
+        let smaa_target = smaa::SmaaTarget::new(
             &device,
             &queue,
             window.inner_size().width,
             window.inner_size().height,
             swapchain_format,
-            ExtSmaaMode::from(render_params.smaa_mode),
+            smaa::SmaaMode::from(render_params.smaa_mode),
         );
 
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -75,6 +75,14 @@ async fn inner(
 ) {
     let instance = wgpu::Instance::default();
 
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        eprintln!("I: Available adapters:");
+        for a in instance.enumerate_adapters(wgpu::Backends::all()) {
+            eprintln!("    {:#?}", a.get_info())
+        }
+    }
+
     let surface = instance.create_surface(window).unwrap();
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
@@ -84,6 +92,8 @@ async fn inner(
         })
         .await
         .expect("E: Failed to fetch appropriate adaptater");
+
+    eprintln!("I: Selected adapter: {:#?}", adapter.get_info());
 
     let (device, queue) = adapter
         .request_device(
@@ -96,7 +106,7 @@ async fn inner(
             None,
         )
         .await
-        .expect("E: Failed to crete device");
+        .expect("E: Failed to create device");
 
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: None,

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -6,14 +6,18 @@
 
 // ------ MODULE DECLARATIONS
 
-mod camera;
-mod handle;
-mod runner;
-mod shader_data;
-mod state;
-
-// ------ RE-EXPORTS
+// ------ IMPORTS
 
 // ------ CONTENT
 
 // ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}


### PR DESCRIPTION
# Description

Add a new member to the workspace: `honeycomb-render`. This crate implements all that is needed to visualize the structure provided by `honeycomb-core`: `TwoMap`.

To-do:
- [x] finish the conversion code in the `honeycomb-render::handle` module
- [x] wire the map reference, to the runner, to the handle, to the render pipeline
- [x] expose a `RenderParameters` argument for the user to provide
- [x] add minimal usage instructions (for regular usage ~and web assembly target~)
- [x] add an example
- [x] fix the missing dart problem (cf. ac808cd)

## Scope

- [x] Code: `honeycomb-render`
- [x] Repository: new member

## Type of change

- [x] New feature(s)

## Other

- [x] New dependency

## Necessary follow-up

- [x] Documentation: Both for the crate & in the user guide / readme
- [x] Other: The `cgmath` dependency seems deprecated, it would be wise to look into it

## Mentions

...