### PR TITLE
feat: implement an orbit structure for more efficient geometry computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
   computation is done through the `Iterator` trait implementation.
 - `OrbitPolicy<'a>` - Enum used to specify the beta functions used by an orbit.
   It currently does not not support compositions.
-- New (temporary?) method for `TwoMap`: `beta_bis`. It works exactly like the
-  regular `beta` method except the beta index is passed as an argument instead
-  of a `const` generic.
+- New (temporary?) method for `TwoMap`: `beta_runtime`. It works by redirecting
+  to the original `beta` method, using match block and a beta identifier provided
+  at runtime.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## To be released
+
+### Repository Changes
+
+...
+
+### New Features
+
+#### honeycomb-core
+
+- `Orbit<'a, const N_MARKS: usize, T: CoordsFloat>` - Generic implementation for
+  2D orbit computations. The structure itself only contains meta-data, the orbit
+  computation is done through the `Iterator` trait implementation.
+- `OrbitPolicy<'a>` - Enum used to specify the beta functions used by an orbit.
+  It currently does not not support compositions.
+- New (temporary?) method for `TwoMap`: `beta_bis`. It works exactly like the
+  regular `beta` method except the beta index is passed as an argument instead
+  of a `const` generic.
+
 ## 0.1.2
 
 ### Repository Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   regular `beta` method except the beta index is passed as an argument instead
   of a `const` generic.
 
+---
+
 ## 0.1.2
 
 ### Repository Changes
@@ -43,6 +45,8 @@
 #### honeycomb-utils
 
 - update content according to features introduced in #15, #16
+
+---
 
 ## 0.1.1
 
@@ -72,6 +76,8 @@
 ### Fixes
 
 - typos by @cedricchevalier19 (#9)
+
+---
 
 ## 0.1.0
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -29,6 +29,7 @@ pub use dart::{DartIdentifier, NULL_DART_ID};
 pub use embed::{
     FaceIdentifier, SewPolicy, UnsewPolicy, Vertex2, VertexIdentifier, VolumeIdentifier,
 };
+pub use orbits::Orbit;
 pub use twomap::TwoMap;
 
 // ------ IMPORTS

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use dart::{DartIdentifier, NULL_DART_ID};
 pub use embed::{
     FaceIdentifier, SewPolicy, UnsewPolicy, Vertex2, VertexIdentifier, VolumeIdentifier,
 };
-pub use orbits::Orbit;
+pub use orbits::{Orbit, OrbitPolicy};
 pub use twomap::TwoMap;
 
 // ------ IMPORTS

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -19,6 +19,7 @@
 mod coords;
 pub mod dart;
 pub mod embed;
+mod orbits;
 pub mod twomap;
 
 // ------ RE-EXPORTS

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -61,9 +61,7 @@ pub enum OrbitPolicy<'a> {
 ///
 /// # Example
 ///
-/// ```text
-///
-/// ```
+/// See [TwoMap] example.
 ///
 pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
     /// Reference to the map containing the beta functions used in the BFS.
@@ -96,9 +94,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit<'a, N_MARKS, T> {
     ///
     /// # Example
     ///
-    /// ```text
-    ///
-    /// ```
+    /// See [TwoMap] example.
     ///
     pub fn new(
         map_handle: &'a TwoMap<N_MARKS, T>,

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -11,9 +11,16 @@ use std::collections::{BTreeSet, VecDeque};
 
 // ------ CONTENT
 
+pub enum OrbitPolicy<'a> {
+    Vertex,
+    Edge,
+    Face,
+    Custom(&'a [u8]),
+}
+
 pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
     map_handle: &'a TwoMap<N_MARKS, T>,
-    pub beta_slice: &'a [u8],
+    beta_slice: &'a [u8],
     marked: BTreeSet<DartIdentifier>,
     pending: VecDeque<DartIdentifier>,
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -22,8 +22,7 @@ pub enum OrbitPolicy<'a> {
     Edge,
     /// 2-cell orbit.
     Face,
-    /// User-defined orbit. The integers correspond to the indices of the
-    /// Ordered array of beta functions that define the orbit
+    /// Ordered array of beta functions that define the orbit.
     Custom(&'a [u8]),
 }
 
@@ -159,7 +158,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
                 }
                 OrbitPolicy::Custom(beta_slice) => {
                     beta_slice.iter().for_each(|beta_id| {
-                        let image = self.map_handle.beta_bis(*beta_id, d);
+                        let image = self.map_handle.beta_runtime(*beta_id, d);
                         if self.marked.insert(image) {
                             // if true, we did not see this dart yet
                             // i.e. we need to visit it later

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -131,6 +131,16 @@ mod tests {
     }
 
     #[test]
+    fn full_map_from_orbit() {
+        let map = simple_map();
+        let orbit = Orbit::new(&map, OrbitPolicy::Custom(&[1, 2]), 3);
+        let darts: Vec<DartIdentifier> = orbit.into_iter().collect();
+        assert_eq!(darts.len(), 6);
+        // because the algorithm is consistent, we can predict the exact layout
+        assert_eq!(&darts, &[3, 1, 2, 4, 5, 6]);
+    }
+
+    #[test]
     fn face_from_orbit() {
         let map = simple_map();
         let face_orbit = Orbit::new(&map, OrbitPolicy::Face, 1);

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -165,4 +165,14 @@ mod tests {
         assert_eq!(other_darts.len(), 2);
         assert_eq!(&other_darts, &[4, 2]);
     }
+
+    #[test]
+    fn vertex_from_orbit() {
+        let map = simple_map();
+        let orbit = Orbit::new(&map, OrbitPolicy::Vertex, 4);
+        let darts: Vec<DartIdentifier> = orbit.into_iter().collect();
+        // note that this one fails if we start at 3, because the vertex is not complete
+        assert_eq!(darts.len(), 2);
+        assert_eq!(&darts, &[4, 3]);
+    }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -59,9 +59,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
 
 #[cfg(test)]
 mod tests {
-    use crate::{FloatType, TwoMap};
-
-    //use super::*;
+    use crate::{DartIdentifier, FloatType, Orbit, TwoMap};
 
     fn simple_map() -> TwoMap<1, FloatType> {
         let mut map: TwoMap<1, FloatType> = TwoMap::new(6, 4);
@@ -85,7 +83,28 @@ mod tests {
     }
 
     #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+    fn face_from_orbit() {
+        let map = simple_map();
+        let face_orbit = Orbit::new(&map, &[1], 1);
+        let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
+        assert_eq!(darts.len(), 3);
+        assert_eq!(&darts, &[1, 2, 3]);
+        let other_face_orbit = Orbit::new(&map, &[1], 5);
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.into_iter().collect();
+        assert_eq!(other_darts.len(), 3);
+        assert_eq!(&other_darts, &[5, 6, 4]);
+    }
+
+    #[test]
+    fn edge_from_orbit() {
+        let map = simple_map();
+        let face_orbit = Orbit::new(&map, &[2], 1);
+        let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
+        assert_eq!(darts.len(), 1);
+        assert_eq!(&darts, &[1]); // dart 1 is on the boundary
+        let other_face_orbit = Orbit::new(&map, &[2], 4);
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.into_iter().collect();
+        assert_eq!(other_darts.len(), 2);
+        assert_eq!(&other_darts, &[4, 2]);
     }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -11,23 +11,34 @@ use std::collections::{BTreeSet, VecDeque};
 
 // ------ CONTENT
 
-struct OrbitCore<'a, const N_MARKS: usize, T: CoordsFloat> {
-    pub map_handle: &'a TwoMap<N_MARKS, T>,
-    pub beta_slice: &'a [u8],
-    pub visited: BTreeSet<DartIdentifier>,
-    pub pending: VecDeque<DartIdentifier>,
-}
-
 pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
-    ocore: OrbitCore<'a, N_MARKS, T>,
-    current_dart: DartIdentifier,
+    map_handle: &'a TwoMap<N_MARKS, T>,
+    pub beta_slice: &'a [u8],
+    marked: BTreeSet<DartIdentifier>,
+    pending: VecDeque<DartIdentifier>,
 }
 
 impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T> {
     type Item = DartIdentifier;
 
     fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+        if let Some(d) = self.pending.pop_front() {
+            self.beta_slice.iter().for_each(|beta_id| {
+                let image = self.map_handle.beta_bis(*beta_id, d);
+                if self.marked.insert(image) {
+                    // if true, we did not see this dart yet
+                    // i.e. we need to visit it later
+                    self.pending.push_back(image);
+                }
+            });
+
+            Some(d)
+        } else {
+            // this makes the structure reusable
+            self.marked.clear();
+            self.pending.clear();
+            None
+        }
     }
 }
 

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn face_from_orbit() {
         let map = simple_map();
-        let face_orbit = Orbit::new(&map, OrbitPolicy::Custom(&[1]), 1);
+        let face_orbit = Orbit::new(&map, OrbitPolicy::Face, 1);
         let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
         assert_eq!(darts.len(), 3);
         assert_eq!(&darts, &[1, 2, 3]);
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn edge_from_orbit() {
         let map = simple_map();
-        let face_orbit = Orbit::new(&map, OrbitPolicy::Custom(&[2]), 1);
+        let face_orbit = Orbit::new(&map, OrbitPolicy::Edge, 1);
         let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
         assert_eq!(darts.len(), 1);
         assert_eq!(&darts, &[1]); // dart 1 is on the boundary

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -52,13 +52,36 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
         if let Some(d) = self.pending.pop_front() {
             match self.orbit_policy {
                 OrbitPolicy::Vertex => {
-                    todo!()
+                    // THIS CODE IS ONLY VALID IN 2D
+                    // WE ASSUME THAT THE EDGE IS COMPLETE
+                    let image = self.map_handle.beta::<1>(self.map_handle.beta::<2>(d));
+                    if self.marked.insert(image) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image);
+                    }
+                    Some(d)
                 }
                 OrbitPolicy::Edge => {
-                    todo!()
+                    // THIS CODE IS ONLY VALID IN 2D
+                    let image = self.map_handle.beta::<2>(d);
+                    if self.marked.insert(image) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image);
+                    }
+                    Some(d)
                 }
                 OrbitPolicy::Face => {
-                    todo!()
+                    // THIS CODE IS ONLY VALID IN 2D
+                    // WE ASSUME THAT THE FACE IS COMPLETE
+                    let image = self.map_handle.beta::<1>(d);
+                    if self.marked.insert(image) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image);
+                    }
+                    Some(d)
                 }
                 OrbitPolicy::Custom(beta_slice) => {
                     beta_slice.iter().for_each(|beta_id| {

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -50,9 +50,6 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
 
             Some(d)
         } else {
-            // this makes the structure reusable
-            self.marked.clear();
-            self.pending.clear();
             None
         }
     }
@@ -62,7 +59,30 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
 
 #[cfg(test)]
 mod tests {
+    use crate::{FloatType, TwoMap};
+
     //use super::*;
+
+    fn simple_map() -> TwoMap<1, FloatType> {
+        let mut map: TwoMap<1, FloatType> = TwoMap::new(6, 4);
+        map.set_betas(1, [3, 2, 0]);
+        map.set_betas(2, [1, 3, 4]);
+        map.set_betas(3, [2, 1, 0]);
+        map.set_betas(4, [6, 5, 2]);
+        map.set_betas(5, [4, 6, 0]);
+        map.set_betas(6, [5, 4, 0]);
+        map.set_vertex(0, (0.0, 0.0)).unwrap();
+        map.set_vertex(1, (1.0, 0.0)).unwrap();
+        map.set_vertex(2, (1.0, 1.0)).unwrap();
+        map.set_vertex(3, (0.0, 1.0)).unwrap();
+        map.set_vertexid(1, 0);
+        map.set_vertexid(2, 1);
+        map.set_vertexid(3, 3);
+        map.set_vertexid(4, 3);
+        map.set_vertexid(5, 1);
+        map.set_vertexid(6, 2);
+        map
+    }
 
     #[test]
     fn some_test() {

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -138,7 +138,7 @@ mod tests {
     fn full_map_from_orbit() {
         let map = simple_map();
         let orbit = Orbit::new(&map, OrbitPolicy::Custom(&[1, 2]), 3);
-        let darts: Vec<DartIdentifier> = orbit.into_iter().collect();
+        let darts: Vec<DartIdentifier> = orbit.collect();
         assert_eq!(darts.len(), 6);
         // because the algorithm is consistent, we can predict the exact layout
         assert_eq!(&darts, &[3, 1, 2, 4, 5, 6]);
@@ -148,11 +148,11 @@ mod tests {
     fn face_from_orbit() {
         let map = simple_map();
         let face_orbit = Orbit::new(&map, OrbitPolicy::Face, 1);
-        let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
+        let darts: Vec<DartIdentifier> = face_orbit.collect();
         assert_eq!(darts.len(), 3);
         assert_eq!(&darts, &[1, 2, 3]);
         let other_face_orbit = Orbit::new(&map, OrbitPolicy::Custom(&[1]), 5);
-        let other_darts: Vec<DartIdentifier> = other_face_orbit.into_iter().collect();
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.collect();
         assert_eq!(other_darts.len(), 3);
         assert_eq!(&other_darts, &[5, 6, 4]);
     }
@@ -161,11 +161,11 @@ mod tests {
     fn edge_from_orbit() {
         let map = simple_map();
         let face_orbit = Orbit::new(&map, OrbitPolicy::Edge, 1);
-        let darts: Vec<DartIdentifier> = face_orbit.into_iter().collect();
+        let darts: Vec<DartIdentifier> = face_orbit.collect();
         assert_eq!(darts.len(), 1);
         assert_eq!(&darts, &[1]); // dart 1 is on the boundary
         let other_face_orbit = Orbit::new(&map, OrbitPolicy::Custom(&[2]), 4);
-        let other_darts: Vec<DartIdentifier> = other_face_orbit.into_iter().collect();
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.collect();
         assert_eq!(other_darts.len(), 2);
         assert_eq!(&other_darts, &[4, 2]);
     }
@@ -174,7 +174,7 @@ mod tests {
     fn vertex_from_orbit() {
         let map = simple_map();
         let orbit = Orbit::new(&map, OrbitPolicy::Vertex, 4);
-        let darts: Vec<DartIdentifier> = orbit.into_iter().collect();
+        let darts: Vec<DartIdentifier> = orbit.collect();
         // note that this one fails if we start at 3, because the vertex is not complete
         assert_eq!(darts.len(), 2);
         assert_eq!(&darts, &[4, 3]);

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -1,5 +1,22 @@
-use crate::{CoordsFloat, TwoMap};
+use crate::{CoordsFloat, DartIdentifier, TwoMap};
+use std::collections::BTreeSet;
+
+struct OrbitCore<'a, const N_MARKS: usize, T: CoordsFloat> {
+    map_handle: &'a TwoMap<N_MARKS, T>,
+    beta_slice: &'a [u8],
+    visited: BTreeSet<DartIdentifier>,
+    pending: Vec<DartIdentifier>,
+}
 
 pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
-    map_handle: &'a TwoMap<N_MARKS, T>,
+    ocore: OrbitCore<'a, N_MARKS, T>,
+    current_dart: DartIdentifier,
+}
+
+impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T> {
+    type Item = DartIdentifier;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -1,11 +1,21 @@
+//! Module short description
+//!
+//! Should you interact with this module directly?
+//!
+//! Content description if needed
+
+// ------ IMPORTS
+
 use crate::{CoordsFloat, DartIdentifier, TwoMap};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
+
+// ------ CONTENT
 
 struct OrbitCore<'a, const N_MARKS: usize, T: CoordsFloat> {
-    map_handle: &'a TwoMap<N_MARKS, T>,
-    beta_slice: &'a [u8],
-    visited: BTreeSet<DartIdentifier>,
-    pending: Vec<DartIdentifier>,
+    pub map_handle: &'a TwoMap<N_MARKS, T>,
+    pub beta_slice: &'a [u8],
+    pub visited: BTreeSet<DartIdentifier>,
+    pub pending: VecDeque<DartIdentifier>,
 }
 
 pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
@@ -18,5 +28,17 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T
 
     fn next(&mut self) -> Option<Self::Item> {
         todo!()
+    }
+}
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
     }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -1,12 +1,12 @@
-//! Module short description
+//! Orbit implementation
 //!
-//! Should you interact with this module directly?
-//!
-//! Content description if needed
+//! This module contains all code used to model orbits, a notion defined
+//! along the structure of combinatorial maps.
 
 // ------ IMPORTS
 
 use crate::{CoordsFloat, DartIdentifier, TwoMap, NULL_DART_ID};
+use num::Zero;
 use std::collections::{BTreeSet, VecDeque};
 
 // ------ CONTENT
@@ -35,6 +35,10 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit<'a, N_MARKS, T> {
         marked.insert(NULL_DART_ID); // we don't want to include the null dart in the orbit
         marked.insert(dart); // we're starting here, so we mark it beforehand
         let pending = VecDeque::from([dart]);
+
+        if let OrbitPolicy::Custom(slice) = orbit_policy {
+            assert!(!slice.len().is_zero());
+        }
 
         Self {
             map_handle,
@@ -174,5 +178,20 @@ mod tests {
         // note that this one fails if we start at 3, because the vertex is not complete
         assert_eq!(darts.len(), 2);
         assert_eq!(&darts, &[4, 3]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn empty_orbit_policy() {
+        let map = simple_map();
+        let _ = Orbit::new(&map, OrbitPolicy::Custom(&[]), 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_orbit_policy() {
+        let map = simple_map();
+        let orbit = Orbit::new(&map, OrbitPolicy::Custom(&[6]), 3);
+        let _: Vec<DartIdentifier> = orbit.collect();
     }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -23,7 +23,7 @@ pub enum OrbitPolicy<'a> {
     /// 2-cell orbit.
     Face,
     /// User-defined orbit. The integers correspond to the indices of the
-    /// beta functions that should be used for the computation.
+    /// Ordered array of beta functions that define the orbit
     Custom(&'a [u8]),
 }
 

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORTS
 
-use crate::{CoordsFloat, DartIdentifier, TwoMap};
+use crate::{CoordsFloat, DartIdentifier, TwoMap, NULL_DART_ID};
 use std::collections::{BTreeSet, VecDeque};
 
 // ------ CONTENT
@@ -16,6 +16,22 @@ pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
     pub beta_slice: &'a [u8],
     marked: BTreeSet<DartIdentifier>,
     pending: VecDeque<DartIdentifier>,
+}
+
+impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit<'a, N_MARKS, T> {
+    pub fn new(map_handle: &'a TwoMap<N_MARKS, T>, betas: &'a [u8], dart: DartIdentifier) -> Self {
+        let mut marked = BTreeSet::<DartIdentifier>::new();
+        marked.insert(NULL_DART_ID); // we don't want to include the null dart in the orbit
+        marked.insert(dart); // we're starting here, so we mark it beforehand
+        let pending = VecDeque::from([dart]);
+
+        Self {
+            map_handle,
+            beta_slice: betas,
+            marked,
+            pending,
+        }
+    }
 }
 
 impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit<'a, N_MARKS, T> {

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -1,0 +1,5 @@
+use crate::{CoordsFloat, TwoMap};
+
+pub struct Orbit<'a, const N_MARKS: usize, T: CoordsFloat> {
+    map_handle: &'a TwoMap<N_MARKS, T>,
+}

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -379,6 +379,32 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
         self.betas[dart_id as usize][I as usize]
     }
 
+    /// Compute the value of the i-th beta function of a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of *dart*.
+    ///
+    /// - `i: u8` -- Index of the beta function. *i* should
+    /// be 0, 1 or 2 for a 2D map.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return the identifier of the dart *d* such that *d = β<sub>i</sub>(dart)*. If
+    /// the returned value is the null dart (i.e. a dart identifier equal to 0), this
+    /// means that *dart* is i-free .
+    ///
+    /// The method will panic if *i* is not 0, 1 or 2.
+    ///
+    /// # Example
+    ///
+    /// See [TwoMap] example.
+    ///
+    pub fn beta_bis(&self, i: u8, dart_id: DartIdentifier) -> DartIdentifier {
+        assert!(i < 3);
+        self.betas[dart_id as usize][i as usize]
+    }
+
     /// Fetch cells associated to a given dart.
     ///
     /// # Arguments

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -404,9 +404,14 @@ impl<const N_MARKS: usize, T: CoordsFloat> TwoMap<N_MARKS, T> {
     ///
     /// See [TwoMap] example.
     ///
-    pub fn beta_bis(&self, i: u8, dart_id: DartIdentifier) -> DartIdentifier {
+    pub fn beta_runtime(&self, i: u8, dart_id: DartIdentifier) -> DartIdentifier {
         assert!(i < 3);
-        self.betas[dart_id as usize][i as usize]
+        match i {
+            0 => self.beta::<0>(dart_id),
+            1 => self.beta::<1>(dart_id),
+            2 => self.beta::<2>(dart_id),
+            _ => unreachable!(),
+        }
     }
 
     /// Fetch cells associated to a given dart.

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -88,9 +88,7 @@ const TWO_MAP_BETA: usize = 3;
 /// progressive changes applied to the structure.
 ///
 /// ```
-/// use honeycomb_core::{
-///     DartIdentifier, SewPolicy, TwoMap, UnsewPolicy, VertexIdentifier, NULL_DART_ID,
-/// };
+/// use honeycomb_core::{ DartIdentifier, SewPolicy, TwoMap, UnsewPolicy, VertexIdentifier, NULL_DART_ID, Orbit, OrbitPolicy};
 ///
 /// // --- Map creation
 ///
@@ -102,9 +100,9 @@ const TWO_MAP_BETA: usize = 3;
 /// let (v1, v2, v3): (VertexIdentifier, VertexIdentifier, VertexIdentifier) = (0, 1, 2);
 ///
 /// // place the vertices in space
-/// map.set_vertex(v1, [0.0, 0.0]);
-/// map.set_vertex(v2, [0.0, 10.0]);
-/// map.set_vertex(v3, [10.0, 0.0]);
+/// map.set_vertex(v1, [0.0, 0.0]).unwrap();
+/// map.set_vertex(v2, [0.0, 10.0]).unwrap();
+/// map.set_vertex(v3, [10.0, 0.0]).unwrap();
 /// // associate dart to vertices
 /// map.set_vertexid(d1, v1);
 /// map.set_vertexid(d2, v2);
@@ -136,7 +134,9 @@ const TWO_MAP_BETA: usize = 3;
 ///
 /// // fetch all darts of the two-cell d2 belongs to
 /// // i.e. the face
-/// let two_cell = map.i_cell::<2>(d2);
+/// let two_cell = map.i_cell::<2>(d2); // directly
+/// let orbit = Orbit::new(&map, OrbitPolicy::Face, d2); // using an orbit
+/// let two_cell_from_orbit: Vec<DartIdentifier> = orbit.collect();
 ///
 /// // check topology of the face
 /// // we make no assumption on the ordering of the result when using the i_cell method
@@ -144,6 +144,10 @@ const TWO_MAP_BETA: usize = 3;
 /// assert!(two_cell.contains(&d2));
 /// assert!(two_cell.contains(&d3));
 /// assert_eq!(two_cell.len(), 3);
+/// assert!(two_cell_from_orbit.contains(&d1));
+/// assert!(two_cell_from_orbit.contains(&d2));
+/// assert!(two_cell_from_orbit.contains(&d3));
+/// assert_eq!(two_cell_from_orbit.len(), 3);
 ///
 /// // --- (a)
 ///
@@ -160,8 +164,8 @@ const TWO_MAP_BETA: usize = 3;
 /// let v4 = map.add_vertex(Some([15.0, 0.0].into())); // v4
 /// let v5 = map.add_vertices(2); // v5, v6
 /// let v6 = v5 + 1;
-/// map.set_vertex(v5, [5.0, 10.0]); // v5
-/// map.set_vertex(v6, [15.0, 10.0]); // v6
+/// map.set_vertex(v5, [5.0, 10.0]).unwrap(); // v5
+/// map.set_vertex(v6, [15.0, 10.0]).unwrap(); // v6
 /// // associate dart to vertices
 /// map.set_vertexid(d4, v4);
 /// map.set_vertexid(d5, v5);
@@ -198,7 +202,7 @@ const TWO_MAP_BETA: usize = 3;
 /// // --- (c)
 ///
 /// // shift the position of d6 to build a square using the two faces
-/// map.set_vertex(map.vertexid(d6), [10.0, 10.0]);
+/// map.set_vertex(map.vertexid(d6), [10.0, 10.0]).unwrap();
 ///
 /// // --- (d)
 ///


### PR DESCRIPTION
# Description

Implement a generic orbit structure that can be used for consistent, standardized cell computation. The algorithm used is detailed in the documentation.

The TwoMap implementation is left unchanged at the moment since replacing its code would probably lead to breaking changes. 

To do:
- [x] add more tests
- [x] add documentation

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] New feature(s)
- [x] Testing

## Other

...

## Necessary follow-up

- [x] Needs documentation
- [x] Other: Benchmark new methods

## Mentions

...