### PR TITLE
refactor: remove builtin marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,20 @@
 - change visibility of all `honeycomb-core` modules to private & re-export types
   accordingly (#23)
 - rename `TwoMap`/`Orbit` to `CMap2`/`Orbit2` for consistency (#23)
+- remove marks table from `DartData` (#24), resulting in a signature change for many
+  functions and structures (anything with `const N_MARKS: usize`) '
 
 #### honeycomb-guide
 
 - update all references to renamed types (#23)
+
+#### honeycomb-render
+
+- update examples, function & structure signatures to reflect mark removal (#24)
+
+#### honeycomb-utils
+
+- update benchmarks, examples, function & structure signatures to reflect mark removal (#24)
 
 ---
 

--- a/honeycomb-core/src/dart.rs
+++ b/honeycomb-core/src/dart.rs
@@ -57,18 +57,10 @@ pub struct CellIdentifiers {
 /// No example is provided as the structure should not be used directly.
 /// The documentation is generated mostly for developing purposes.
 ///
+#[cfg_attr(feature = "benchmarking_utils", derive(Clone))]
 pub struct DartData {
     /// List of associated cell identifiers.
     pub associated_cells: Vec<CellIdentifiers>,
-}
-
-#[cfg(feature = "benchmarking_utils")]
-impl Clone for DartData {
-    fn clone(&self) -> Self {
-        Self {
-            associated_cells: self.associated_cells.clone(),
-        }
-    }
 }
 
 impl DartData {

--- a/honeycomb-core/src/dart.rs
+++ b/honeycomb-core/src/dart.rs
@@ -52,11 +52,6 @@ pub struct CellIdentifiers {
 /// Structure used to store dart-related data. The association of data with
 /// a given dart is done implicitly through indexing.
 ///
-/// # Generics
-///
-/// - `const N_MARKS: usize` -- Number of marks used for search algorithms.
-///   This corresponds to the number of search that can be done concurrently.
-///
 /// # Example
 ///
 /// No example is provided as the structure should not be used directly.

--- a/honeycomb-core/src/dart.rs
+++ b/honeycomb-core/src/dart.rs
@@ -10,11 +10,9 @@
 
 // ------ IMPORTS
 
-// ------ CONTENT
-
-use std::sync::atomic::AtomicBool;
-
 use crate::{FaceIdentifier, VertexIdentifier};
+
+// ------ CONTENT
 
 /// Type definition for dart identifiers
 ///
@@ -64,40 +62,21 @@ pub struct CellIdentifiers {
 /// No example is provided as the structure should not be used directly.
 /// The documentation is generated mostly for developing purposes.
 ///
-pub struct DartData<const N_MARKS: usize> {
-    /// Array of boolean used for algorithmic search.
-    ///
-    /// Atomics allow for non-mutable interfaces, i.e. parallel friendly
-    /// methods. Storage is done line-wise as it would be very rare to
-    /// access multiple marks of the same dart successively.
-    pub marks: [Vec<AtomicBool>; N_MARKS],
+pub struct DartData {
     /// List of associated cell identifiers.
     pub associated_cells: Vec<CellIdentifiers>,
 }
 
 #[cfg(feature = "benchmarking_utils")]
-impl<const N_MARKS: usize> Clone for DartData<N_MARKS> {
+impl Clone for DartData {
     fn clone(&self) -> Self {
         Self {
-            marks: self
-                .marks
-                .iter()
-                .map(|elem| {
-                    elem.iter()
-                        .map(|atombool| {
-                            AtomicBool::new(atombool.load(std::sync::atomic::Ordering::Relaxed))
-                        })
-                        .collect::<Vec<AtomicBool>>()
-                })
-                .collect::<Vec<Vec<AtomicBool>>>()
-                .try_into()
-                .unwrap(),
             associated_cells: self.associated_cells.clone(),
         }
     }
 }
 
-impl<const N_MARKS: usize> DartData<N_MARKS> {
+impl DartData {
     /// Create a [DartData] object.
     ///
     /// **This should not be used directly by the user.**
@@ -111,17 +90,7 @@ impl<const N_MARKS: usize> DartData<N_MARKS> {
     /// Returns a [DartData] structure with default values.
     ///
     pub fn new(n_darts: usize) -> Self {
-        let marks: [Vec<AtomicBool>; N_MARKS] = (0..N_MARKS)
-            .map(|_| {
-                (0..n_darts + 1)
-                    .map(|_| AtomicBool::new(false))
-                    .collect::<Vec<AtomicBool>>()
-            })
-            .collect::<Vec<Vec<AtomicBool>>>()
-            .try_into()
-            .unwrap();
         Self {
-            marks,
             associated_cells: vec![
                 CellIdentifiers {
                     vertex_id: 0,
@@ -133,62 +102,11 @@ impl<const N_MARKS: usize> DartData<N_MARKS> {
         }
     }
 
-    /// Free all darts of a given mark.
-    ///
-    /// **This should not be used directly by the user.**
-    ///
-    /// # Arguments
-    ///
-    /// - `mark_id: usize` -- Identifier of the mark that must be reset.
-    ///
-    pub fn free_mark(&self, mark_id: usize) {
-        self.marks[mark_id]
-            .iter()
-            .filter(|e| e.load(std::sync::atomic::Ordering::Relaxed)) // useful?
-            .for_each(|mark| mark.store(false, std::sync::atomic::Ordering::Relaxed));
-    }
-
-    /// Check and update if a given dart was marked.
-    ///
-    ///  # Arguments
-    ///
-    /// - `mark_id: usize` -- Identifier of the mark that must be checked.
-    /// - `dart_id: DartIdentifier` -- Identifier of the dart that must be checked.
-    ///
-    /// # Return / Panic
-    ///
-    /// Returns a boolean to indicate whether the dart was marked or not. In
-    /// both case, the dart is marked after the operation.
-    ///
-    /// The method will panic if the provided mark ID is invalid.
-    ///
-    pub fn was_marked(&self, mark_id: usize, dart_id: DartIdentifier) -> bool {
-        assert!(mark_id < N_MARKS);
-        match self.marks[mark_id][dart_id as usize].compare_exchange(
-            false,
-            true,
-            std::sync::atomic::Ordering::Release,
-            std::sync::atomic::Ordering::Relaxed,
-        ) {
-            Ok(_) => {
-                // comparison was successful => was false
-                false
-            }
-            Err(_) => {
-                // comparison failed => was true
-                true
-            }
-        }
-    }
-
     /// Add a new entry to the structure.
     ///
     /// **This should not be used directly by the user.**
     ///
     pub fn add_entry(&mut self) {
-        self.marks
-            .iter_mut()
-            .for_each(|mark| mark.push(AtomicBool::new(false)));
         self.associated_cells.push(CellIdentifiers::default());
     }
 
@@ -197,9 +115,6 @@ impl<const N_MARKS: usize> DartData<N_MARKS> {
     /// **This should not be used directly by the user.**
     ///
     pub fn add_entries(&mut self, n_darts: usize) {
-        self.marks
-            .iter_mut()
-            .for_each(|mark| mark.extend((0..n_darts).map(|_| AtomicBool::new(false))));
         self.associated_cells
             .extend((0..n_darts).map(|_| CellIdentifiers::default()));
     }
@@ -213,9 +128,6 @@ impl<const N_MARKS: usize> DartData<N_MARKS> {
     /// - `dart_id: DartIdentifier` -- Identifier of the dart which entry should be reset.
     ///
     pub fn reset_entry(&mut self, dart_id: DartIdentifier) {
-        self.marks.iter().for_each(|mark| {
-            mark[dart_id as usize].store(false, std::sync::atomic::Ordering::Relaxed)
-        });
         self.associated_cells[dart_id as usize] = CellIdentifiers::default();
     }
 }

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -62,9 +62,9 @@ pub enum OrbitPolicy<'a> {
 ///
 /// See [CMap2] example.
 ///
-pub struct Orbit2<'a, const N_MARKS: usize, T: CoordsFloat> {
+pub struct Orbit2<'a, T: CoordsFloat> {
     /// Reference to the map containing the beta functions used in the BFS.
-    map_handle: &'a CMap2<N_MARKS, T>,
+    map_handle: &'a CMap2<T>,
     /// Policy used by the orbit for the BFS. It can be predetermined or custom.
     orbit_policy: OrbitPolicy<'a>,
     /// Set used to identify which dart is marked during the BFS.
@@ -73,7 +73,7 @@ pub struct Orbit2<'a, const N_MARKS: usize, T: CoordsFloat> {
     pending: VecDeque<DartIdentifier>,
 }
 
-impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit2<'a, N_MARKS, T> {
+impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     /// Constructor
     ///
     /// # Arguments
@@ -96,7 +96,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit2<'a, N_MARKS, T> {
     /// See [CMap2] example.
     ///
     pub fn new(
-        map_handle: &'a CMap2<N_MARKS, T>,
+        map_handle: &'a CMap2<T>,
         orbit_policy: OrbitPolicy<'a>,
         dart: DartIdentifier,
     ) -> Self {
@@ -118,7 +118,7 @@ impl<'a, const N_MARKS: usize, T: CoordsFloat> Orbit2<'a, N_MARKS, T> {
     }
 }
 
-impl<'a, const N_MARKS: usize, T: CoordsFloat> Iterator for Orbit2<'a, N_MARKS, T> {
+impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
     type Item = DartIdentifier;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -182,8 +182,8 @@ mod tests {
     use crate::orbits::OrbitPolicy;
     use crate::{CMap2, DartIdentifier, FloatType, Orbit2};
 
-    fn simple_map() -> CMap2<1, FloatType> {
-        let mut map: CMap2<1, FloatType> = CMap2::new(6, 4);
+    fn simple_map() -> CMap2<FloatType> {
+        let mut map: CMap2<FloatType> = CMap2::new(6, 4);
         map.set_betas(1, [3, 2, 0]);
         map.set_betas(2, [1, 3, 4]);
         map.set_betas(3, [2, 1, 0]);

--- a/honeycomb-core/src/orbits.rs
+++ b/honeycomb-core/src/orbits.rs
@@ -39,7 +39,6 @@ pub enum OrbitPolicy<'a> {
 /// # Generics
 ///
 /// - `'a` -- Lifetime of the reference to the map
-/// - `const N_MARKS: usize` -- Generic parameter of the referenced map.
 /// - `T: CoordsFloat` -- Generic parameter of the referenced map.
 ///
 /// # The search algorithm
@@ -78,7 +77,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     ///
     /// # Arguments
     ///
-    /// - `map_handle: &'a CMap2<N_MARKS, T>` -- Reference to the map containing the beta
+    /// - `map_handle: &'a CMap2<T>` -- Reference to the map containing the beta
     /// functions used in the BFS.
     /// - `orbit_policy: OrbitPolicy<'a>` -- Policy used by the orbit for the BFS.
     /// - `dart: DartIdentifier` -- Dart of which the structure will compute the orbit.

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -13,7 +13,8 @@
 // ------ IMPORTS
 
 use std::collections::BTreeSet;
-use std::{fs::File, io::Write, sync::atomic::AtomicBool};
+#[cfg(feature = "benchmarking_utils")]
+use std::{fs::File, io::Write};
 
 use crate::coords::CoordsFloat;
 use crate::{
@@ -264,7 +265,7 @@ pub struct CMap2<const N_MARKS: usize, T: CoordsFloat> {
     /// List of faces making up the represented mesh
     faces: Vec<Face>,
     /// Structure holding data related to darts (marks, associated cells)
-    dart_data: DartData<N_MARKS>,
+    dart_data: DartData,
     /// List of free darts identifiers, i.e. empty spots
     /// in the current dart list
     unused_darts: BTreeSet<DartIdentifier>,
@@ -1288,6 +1289,8 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
     /// ```
     ///
     pub fn build_all_faces(&mut self) -> usize {
+        todo!();
+        /*
         self.faces.clear();
         let mut n_faces = 0;
         // go through all darts ? update
@@ -1304,6 +1307,7 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
             }
         });
         n_faces
+        */
     }
 
     /// Build the geometrical face associated with a given dart
@@ -1433,12 +1437,9 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
             self.dart_data.associated_cells.capacity() * std::mem::size_of::<VertexIdentifier>();
         let embed_face =
             self.dart_data.associated_cells.capacity() * std::mem::size_of::<FaceIdentifier>();
-        let embed_marks =
-            self.dart_data.marks[0].capacity() * N_MARKS * std::mem::size_of::<AtomicBool>();
-        let embed_total = embed_vertex + embed_face + embed_marks;
+        let embed_total = embed_vertex + embed_face;
         writeln!(file, "embed_vertex, {embed_vertex}").unwrap();
         writeln!(file, "embed_face, {embed_face}").unwrap();
-        writeln!(file, "embed_marks, {embed_marks}").unwrap();
         writeln!(file, "embed_total, {embed_total}").unwrap();
 
         // geometry
@@ -1516,11 +1517,9 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
         // embed
         let embed_vertex = self.n_darts * std::mem::size_of::<VertexIdentifier>();
         let embed_face = self.n_darts * std::mem::size_of::<FaceIdentifier>();
-        let embed_marks = self.n_darts * N_MARKS * std::mem::size_of::<AtomicBool>();
-        let embed_total = embed_vertex + embed_face + embed_marks;
+        let embed_total = embed_vertex + embed_face;
         writeln!(file, "embed_vertex, {embed_vertex}").unwrap();
         writeln!(file, "embed_face, {embed_face}").unwrap();
-        writeln!(file, "embed_marks, {embed_marks}").unwrap();
         writeln!(file, "embed_total, {embed_total}").unwrap();
 
         // geometry
@@ -1604,11 +1603,9 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
         // embed
         let embed_vertex = n_used_darts * std::mem::size_of::<VertexIdentifier>();
         let embed_face = n_used_darts * std::mem::size_of::<FaceIdentifier>();
-        let embed_marks = n_used_darts * N_MARKS * std::mem::size_of::<AtomicBool>();
-        let embed_total = embed_vertex + embed_face + embed_marks;
+        let embed_total = embed_vertex + embed_face;
         writeln!(file, "embed_vertex, {embed_vertex}").unwrap();
         writeln!(file, "embed_face, {embed_face}").unwrap();
-        writeln!(file, "embed_marks, {embed_marks}").unwrap();
         writeln!(file, "embed_total, {embed_total}").unwrap();
 
         // geometry

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1289,17 +1289,16 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ```
     ///
     pub fn build_all_faces(&mut self) -> usize {
-        todo!();
-        /*
         self.faces.clear();
+        let mut marked = BTreeSet::<DartIdentifier>::new();
         let mut n_faces = 0;
         // go through all darts ? update
         (1..self.n_darts as DartIdentifier).for_each(|id| {
-            if !self.dart_data.was_marked(0, id) {
+            if marked.insert(id) {
                 let tmp = self.i_cell::<2>(id);
                 if tmp.len() > 1 {
                     tmp.iter().for_each(|member| {
-                        let _ = self.dart_data.was_marked(0, *member);
+                        let _ = marked.insert(*member);
                     });
                     self.build_face(id);
                     n_faces += 1
@@ -1307,7 +1306,6 @@ impl<T: CoordsFloat> CMap2<T> {
             }
         });
         n_faces
-        */
     }
 
     /// Build the geometrical face associated with a given dart

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -59,7 +59,7 @@ const CMAP2_BETA: usize = 3;
 /// - `free_vertices: BTreeSet<VertexIdentifier>` -- Set of free vertex identifiers,
 ///   i.e. empty spots in the current vertex list
 /// - `faces: Vec<Face>` -- List of faces making up the represented mesh
-/// - `dart_data: DartData<N_MARKS>` -- List of embedded data associated with darts
+/// - `dart_data: DartData` -- Structure holding embedded data associated with darts
 /// - `free_darts: BTreeSet<DartIdentifier>` -- Set of free darts identifiers, i.e. empty
 ///   spots in the current dart list
 /// - `betas: Vec<[DartIdentifier; 3]>` -- Array representation of the beta functions
@@ -73,8 +73,6 @@ const CMAP2_BETA: usize = 3;
 ///
 /// # Generics
 ///
-/// - `const N_MARKS: usize` -- Number of marks used for search algorithms.
-///   This corresponds to the number of search that can be done concurrently.
 /// - `T: CoordsFloat` -- Generic type for coordinates representation.
 ///
 /// # Example

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -96,7 +96,7 @@ const CMAP2_BETA: usize = 3;
 /// // --- Map creation
 ///
 /// // create a map with 3 non-null darts & 3 vertices
-/// let mut map: CMap2<1, f64> = CMap2::new(3, 3);
+/// let mut map: CMap2<f64> = CMap2::new(3, 3);
 ///
 /// // the two following lines are not strictly necessary, you may use integers directly
 /// let (d1, d2, d3): (DartIdentifier, DartIdentifier, DartIdentifier) = (1, 2, 3);
@@ -256,7 +256,7 @@ const CMAP2_BETA: usize = 3;
 /// ```
 ///
 #[cfg_attr(feature = "benchmarking_utils", derive(Clone))]
-pub struct CMap2<const N_MARKS: usize, T: CoordsFloat> {
+pub struct CMap2<T: CoordsFloat> {
     /// List of vertices making up the represented mesh
     vertices: Vec<Vertex2<T>>,
     /// List of free vertex identifiers, i.e. empty spots
@@ -284,7 +284,7 @@ macro_rules! stretch {
     };
 }
 
-impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
+impl<T: CoordsFloat> CMap2<T> {
     /// Creates a new 2D combinatorial map.
     ///
     /// # Arguments
@@ -1379,7 +1379,7 @@ impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
 }
 
 #[cfg(any(doc, feature = "benchmarking_utils"))]
-impl<const N_MARKS: usize, T: CoordsFloat> CMap2<N_MARKS, T> {
+impl<T: CoordsFloat> CMap2<T> {
     /// Computes the total allocated space dedicated to the map.
     ///
     /// # Arguments
@@ -1639,7 +1639,7 @@ mod tests {
     #[should_panic]
     fn remove_vertex_twice() {
         // in its default state, all darts/vertices of a map are considered to be used
-        let mut map: CMap2<1, FloatType> = CMap2::new(4, 4);
+        let mut map: CMap2<FloatType> = CMap2::new(4, 4);
         // set vertex 1 as unused
         map.remove_vertex(1);
         // set vertex 1 as unused, again
@@ -1651,7 +1651,7 @@ mod tests {
     fn remove_dart_twice() {
         // in its default state, all darts/vertices of a map are considered to be used
         // darts are also free
-        let mut map: CMap2<1, FloatType> = CMap2::new(4, 4);
+        let mut map: CMap2<FloatType> = CMap2::new(4, 4);
         // set dart 1 as unused
         map.remove_free_dart(1);
         // set dart 1 as unused, again

--- a/honeycomb-render/examples/render_default_no_aa.rs
+++ b/honeycomb-render/examples/render_default_no_aa.rs
@@ -5,5 +5,5 @@ fn main() {
         smaa_mode: SmaaMode::Disabled,
         ..Default::default()
     };
-    Runner::default().run::<1, f32>(render_params, None);
+    Runner::default().run::<f32>(render_params, None);
 }

--- a/honeycomb-render/examples/render_default_smaa1x.rs
+++ b/honeycomb-render/examples/render_default_smaa1x.rs
@@ -5,5 +5,5 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    Runner::default().run::<1, f32>(render_params, None);
+    Runner::default().run::<f32>(render_params, None);
 }

--- a/honeycomb-render/examples/render_splitsquaremap.rs
+++ b/honeycomb-render/examples/render_splitsquaremap.rs
@@ -7,6 +7,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<1, f32> = splitsquare_cmap2(4);
+    let map: CMap2<f32> = splitsquare_cmap2(4);
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-render/examples/render_squaremap.rs
+++ b/honeycomb-render/examples/render_squaremap.rs
@@ -7,6 +7,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<1, f32> = square_cmap2(4);
+    let map: CMap2<f32> = square_cmap2(4);
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -43,16 +43,16 @@ macro_rules! as_f32_tuple {
     };
 }
 
-pub struct CMap2RenderHandle<'a, const N_MARKS: usize, T: CoordsFloat> {
-    handle: &'a CMap2<N_MARKS, T>,
+pub struct CMap2RenderHandle<'a, T: CoordsFloat> {
+    handle: &'a CMap2<T>,
     params: RenderParameters,
     dart_construction_buffer: Vec<Coords2Shader>,
     _beta_construction_buffer: Vec<Coords2Shader>,
     vertices: Vec<Coords2Shader>,
 }
 
-impl<'a, const N_MARKS: usize, T: CoordsFloat> CMap2RenderHandle<'a, N_MARKS, T> {
-    pub fn new(map: &'a CMap2<N_MARKS, T>, params: Option<RenderParameters>) -> Self {
+impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
+    pub fn new(map: &'a CMap2<T>, params: Option<RenderParameters>) -> Self {
         Self {
             handle: map,
             params: params.unwrap_or_default(),

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -16,17 +16,17 @@ use honeycomb_core::{CMap2, CoordsFloat};
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
-        pub type MapRef<'a, const N_MARKS: usize, T> = &'static CMap2<N_MARKS, T>;
+        pub type MapRef<'a, T> = &'static CMap2<T>;
     } else {
-        pub type MapRef<'a, const N_MARKS: usize, T> = &'a CMap2<N_MARKS, T>;
+        pub type MapRef<'a, T> = &'a CMap2<T>;
     }
 }
 
-async fn inner<const N_MARKS: usize, T: CoordsFloat>(
+async fn inner<T: CoordsFloat>(
     event_loop: EventLoop<()>,
     window: Window,
     render_params: RenderParameters,
-    map: Option<MapRef<'_, N_MARKS, T>>,
+    map: Option<MapRef<'_, T>>,
 ) {
     let mut state = if let Some(val) = map {
         State::new(&window, render_params, val).await
@@ -92,11 +92,7 @@ impl Runner {
     /// cargo run --example <EXAMPLE>
     /// ```
     ///
-    pub fn run<const N_MARKS: usize, T: CoordsFloat>(
-        self,
-        render_params: RenderParameters,
-        map: Option<MapRef<'_, N_MARKS, T>>,
-    ) {
+    pub fn run<T: CoordsFloat>(self, render_params: RenderParameters, map: Option<MapRef<'_, T>>) {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "wasm32")] {
                 std::panic::set_hook(Box::new(console_error_panic_hook::hook));

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -44,7 +44,7 @@ impl From<SmaaMode> for smaa::SmaaMode {
     }
 }
 
-pub struct State<'a, const N_MARKS: usize, T: CoordsFloat> {
+pub struct State<'a, T: CoordsFloat> {
     surface: wgpu::Surface<'a>,
     device: wgpu::Device,
     queue: wgpu::Queue,
@@ -59,7 +59,7 @@ pub struct State<'a, const N_MARKS: usize, T: CoordsFloat> {
     camera_bind_group: wgpu::BindGroup,
     camera_controller: CameraController,
     smaa_target: smaa::SmaaTarget,
-    map_handle: Option<CMap2RenderHandle<'a, N_MARKS, T>>,
+    map_handle: Option<CMap2RenderHandle<'a, T>>,
     window: &'a Window,
 }
 
@@ -226,11 +226,11 @@ async fn inner(
     )
 }
 
-impl<'a, const N_MARKS: usize, T: CoordsFloat> State<'a, N_MARKS, T> {
+impl<'a, T: CoordsFloat> State<'a, T> {
     pub async fn new(
         window: &'a Window,
         render_params: RenderParameters,
-        map: &'a CMap2<N_MARKS, T>,
+        map: &'a CMap2<T>,
     ) -> Self {
         let mut size = window.inner_size();
         size.width = size.width.max(1);

--- a/honeycomb-utils/benches/core/cmap2/editing.rs
+++ b/honeycomb-utils/benches/core/cmap2/editing.rs
@@ -23,12 +23,12 @@ use std::hint::black_box;
 
 // ------ CONTENT
 
-fn get_map(n_square: usize) -> CMap2<1, FloatType> {
-    square_cmap2::<1, FloatType>(n_square)
+fn get_map(n_square: usize) -> CMap2<FloatType> {
+    square_cmap2::<FloatType>(n_square)
 }
 
-fn get_sparse_map(n_square: usize) -> CMap2<1, FloatType> {
-    let mut map = square_cmap2::<1, FloatType>(n_square);
+fn get_sparse_map(n_square: usize) -> CMap2<FloatType> {
+    let mut map = square_cmap2::<FloatType>(n_square);
     map.set_betas(5, [0; 3]); // free dart 5
     map.remove_free_dart(5);
     map.remove_vertex(1);
@@ -41,7 +41,7 @@ fn compute_dims(n_square: usize) -> (usize, usize) {
 
 #[library_benchmark]
 #[benches::with_setup(args = [16, 32, 64, 128, 256, 512], setup = compute_dims)]
-fn constructor((n_darts, n_vertices): (usize, usize)) -> CMap2<1, FloatType> {
+fn constructor((n_darts, n_vertices): (usize, usize)) -> CMap2<FloatType> {
     black_box(CMap2::new(n_darts, n_vertices))
 }
 
@@ -49,7 +49,7 @@ fn constructor((n_darts, n_vertices): (usize, usize)) -> CMap2<1, FloatType> {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn add_single_dart(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
+fn add_single_dart(map: &mut CMap2<FloatType>) -> DartIdentifier {
     black_box(map.add_free_dart())
 }
 
@@ -57,7 +57,7 @@ fn add_single_dart(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn add_ten_darts(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
+fn add_ten_darts(map: &mut CMap2<FloatType>) -> DartIdentifier {
     black_box(map.add_free_darts(10))
 }
 
@@ -65,7 +65,7 @@ fn add_ten_darts(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn add_default_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
+fn add_default_vertex(map: &mut CMap2<FloatType>) -> VertexIdentifier {
     black_box(map.add_vertex(None))
 }
 
@@ -73,7 +73,7 @@ fn add_default_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn add_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
+fn add_vertex(map: &mut CMap2<FloatType>) -> VertexIdentifier {
     black_box(map.add_vertex(Some(Vertex2::from((12.0, 6.0)))))
 }
 
@@ -81,7 +81,7 @@ fn add_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn add_10_vertices(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
+fn add_10_vertices(map: &mut CMap2<FloatType>) -> VertexIdentifier {
     black_box(map.add_vertices(10))
 }
 
@@ -100,7 +100,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_sparse_map(5))]
 #[bench::medium(&mut get_sparse_map(50))]
 #[bench::large(&mut get_sparse_map(500))]
-fn insert_dart(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
+fn insert_dart(map: &mut CMap2<FloatType>) -> DartIdentifier {
     black_box(map.insert_free_dart())
 }
 
@@ -108,7 +108,7 @@ fn insert_dart(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn insert_dart_full(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
+fn insert_dart_full(map: &mut CMap2<FloatType>) -> DartIdentifier {
     black_box(map.insert_free_dart())
 }
 
@@ -116,7 +116,7 @@ fn insert_dart_full(map: &mut CMap2<1, FloatType>) -> DartIdentifier {
 #[bench::small(&mut get_sparse_map(5))]
 #[bench::medium(&mut get_sparse_map(50))]
 #[bench::large(&mut get_sparse_map(500))]
-fn insert_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
+fn insert_vertex(map: &mut CMap2<FloatType>) -> VertexIdentifier {
     black_box(map.insert_vertex(None))
 }
 
@@ -124,7 +124,7 @@ fn insert_vertex(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn insert_vertex_full(map: &mut CMap2<1, FloatType>) -> VertexIdentifier {
+fn insert_vertex_full(map: &mut CMap2<FloatType>) -> VertexIdentifier {
     black_box(map.insert_vertex(None))
 }
 
@@ -141,7 +141,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn build_face(map: &mut CMap2<1, FloatType>) -> FaceIdentifier {
+fn build_face(map: &mut CMap2<FloatType>) -> FaceIdentifier {
     black_box(map.build_face(5))
 }
 
@@ -149,7 +149,7 @@ fn build_face(map: &mut CMap2<1, FloatType>) -> FaceIdentifier {
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn build_faces(map: &mut CMap2<1, FloatType>) -> usize {
+fn build_faces(map: &mut CMap2<FloatType>) -> usize {
     black_box(map.build_all_faces())
 }
 

--- a/honeycomb-utils/benches/core/cmap2/reading.rs
+++ b/honeycomb-utils/benches/core/cmap2/reading.rs
@@ -23,15 +23,15 @@ use std::hint::black_box;
 
 // ------ CONTENT
 
-fn get_map(n_square: usize) -> CMap2<1, FloatType> {
-    square_cmap2::<1, FloatType>(n_square)
+fn get_map(n_square: usize) -> CMap2<FloatType> {
+    square_cmap2::<FloatType>(n_square)
 }
 
 #[library_benchmark]
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn single_beta_single_dart(map: &CMap2<1, FloatType>) -> DartIdentifier {
+fn single_beta_single_dart(map: &CMap2<FloatType>) -> DartIdentifier {
     black_box(map.beta::<1>(5))
 }
 
@@ -40,7 +40,7 @@ fn single_beta_single_dart(map: &CMap2<1, FloatType>) -> DartIdentifier {
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
 fn all_betas_single_dart(
-    map: &CMap2<1, FloatType>,
+    map: &CMap2<FloatType>,
 ) -> (DartIdentifier, DartIdentifier, DartIdentifier) {
     (
         black_box(map.beta::<0>(5)),
@@ -54,7 +54,7 @@ fn all_betas_single_dart(
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
 fn single_beta_contiguous_darts(
-    map: &CMap2<1, FloatType>,
+    map: &CMap2<FloatType>,
 ) -> (DartIdentifier, DartIdentifier, DartIdentifier) {
     (
         black_box(map.beta::<1>(5)),
@@ -68,7 +68,7 @@ fn single_beta_contiguous_darts(
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
 fn single_beta_random_darts(
-    map: &CMap2<1, FloatType>,
+    map: &CMap2<FloatType>,
 ) -> (DartIdentifier, DartIdentifier, DartIdentifier) {
     (
         black_box(map.beta::<0>(3)),
@@ -90,7 +90,7 @@ library_benchmark_group!(
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn i_free(map: &CMap2<1, FloatType>) -> bool {
+fn i_free(map: &CMap2<FloatType>) -> bool {
     black_box(map.is_i_free::<1>(3))
 }
 
@@ -98,7 +98,7 @@ fn i_free(map: &CMap2<1, FloatType>) -> bool {
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn free(map: &CMap2<1, FloatType>) -> bool {
+fn free(map: &CMap2<FloatType>) -> bool {
     black_box(map.is_free(3))
 }
 
@@ -113,7 +113,7 @@ library_benchmark_group!(
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn zero_cell(map: &CMap2<1, FloatType>) -> Vec<DartIdentifier> {
+fn zero_cell(map: &CMap2<FloatType>) -> Vec<DartIdentifier> {
     black_box(map.i_cell::<0>(5))
 }
 
@@ -121,7 +121,7 @@ fn zero_cell(map: &CMap2<1, FloatType>) -> Vec<DartIdentifier> {
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn one_cell(map: &CMap2<1, FloatType>) -> Vec<DartIdentifier> {
+fn one_cell(map: &CMap2<FloatType>) -> Vec<DartIdentifier> {
     black_box(map.i_cell::<0>(5))
 }
 
@@ -129,7 +129,7 @@ fn one_cell(map: &CMap2<1, FloatType>) -> Vec<DartIdentifier> {
 #[bench::small(&get_map(5))]
 #[bench::medium(&get_map(50))]
 #[bench::large(&get_map(500))]
-fn two_cell(map: &CMap2<1, FloatType>) -> Vec<DartIdentifier> {
+fn two_cell(map: &CMap2<FloatType>) -> Vec<DartIdentifier> {
     black_box(map.i_cell::<2>(5))
 }
 

--- a/honeycomb-utils/benches/core/cmap2/sewing.rs
+++ b/honeycomb-utils/benches/core/cmap2/sewing.rs
@@ -28,11 +28,11 @@ fn compute_dims(n_square: usize) -> (usize, usize) {
     (n_square.pow(2) * 4, (n_square + 1).pow(2))
 }
 
-fn get_map(n_square: usize) -> CMap2<1, FloatType> {
-    square_cmap2::<1, FloatType>(n_square)
+fn get_map(n_square: usize) -> CMap2<FloatType> {
+    square_cmap2::<FloatType>(n_square)
 }
 
-fn get_unstructured_map(n_square: usize) -> CMap2<1, FloatType> {
+fn get_unstructured_map(n_square: usize) -> CMap2<FloatType> {
     let (n_darts, n_vertices) = compute_dims(n_square);
     CMap2::new(n_darts, n_vertices)
 }
@@ -41,7 +41,7 @@ fn get_unstructured_map(n_square: usize) -> CMap2<1, FloatType> {
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn one_sew_left(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn one_sew_left(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.one_sew(4, 6, SewPolicy::StretchLeft);
     black_box(map)
 }
@@ -50,7 +50,7 @@ fn one_sew_left(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn one_sew_right(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn one_sew_right(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.one_sew(4, 6, SewPolicy::StretchRight);
     black_box(map)
 }
@@ -59,7 +59,7 @@ fn one_sew_right(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn one_sew_avg(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn one_sew_avg(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.one_sew(4, 6, SewPolicy::StretchAverage);
     black_box(map)
 }
@@ -76,7 +76,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn two_sew_left(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn two_sew_left(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.two_sew(4, 6, SewPolicy::StretchLeft);
     black_box(map)
 }
@@ -85,7 +85,7 @@ fn two_sew_left(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn two_sew_right(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn two_sew_right(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.two_sew(4, 6, SewPolicy::StretchRight);
     black_box(map)
 }
@@ -94,7 +94,7 @@ fn two_sew_right(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
 #[bench::small(&mut get_unstructured_map(5))]
 #[bench::medium(&mut get_unstructured_map(50))]
 #[bench::large(&mut get_unstructured_map(500))]
-fn two_sew_avg(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn two_sew_avg(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.two_sew(4, 6, SewPolicy::StretchAverage);
     black_box(map)
 }
@@ -111,7 +111,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn one_unsew_nothing(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn one_unsew_nothing(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.one_unsew(4, UnsewPolicy::DoNothing);
     black_box(map)
 }
@@ -120,7 +120,7 @@ fn one_unsew_nothing(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> 
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn one_unsew_duplicate(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn one_unsew_duplicate(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.one_unsew(4, UnsewPolicy::Duplicate);
     black_box(map)
 }
@@ -136,7 +136,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn two_unsew_nothing(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn two_unsew_nothing(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.two_unsew(4, UnsewPolicy::DoNothing);
     black_box(map)
 }
@@ -145,7 +145,7 @@ fn two_unsew_nothing(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> 
 #[bench::small(&mut get_map(5))]
 #[bench::medium(&mut get_map(50))]
 #[bench::large(&mut get_map(500))]
-fn two_unsew_duplicate(map: &mut CMap2<1, FloatType>) -> &mut CMap2<1, FloatType> {
+fn two_unsew_duplicate(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
     map.two_unsew(4, UnsewPolicy::Duplicate);
     black_box(map)
 }

--- a/honeycomb-utils/benches/splitsquaremap/init.rs
+++ b/honeycomb-utils/benches/splitsquaremap/init.rs
@@ -24,7 +24,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<1, FloatType> = splitsquare_cmap2(*n_square);
+                let mut map: CMap2<FloatType> = splitsquare_cmap2(*n_square);
                 black_box(&mut map);
             })
         });

--- a/honeycomb-utils/benches/splitsquaremap/shift.rs
+++ b/honeycomb-utils/benches/splitsquaremap/shift.rs
@@ -28,20 +28,14 @@ use honeycomb_utils::generation::splitsquare_cmap2;
 
 // ------ CONTENT
 
-fn offset<const N_MARKS: usize>(
-    mut map: CMap2<N_MARKS, FloatType>,
-    offsets: &[Vertex2<FloatType>],
-) {
+fn offset(mut map: CMap2<FloatType>, offsets: &[Vertex2<FloatType>]) {
     (0..map.n_vertices().0).for_each(|vertex_id| {
         let _ = map.set_vertex(vertex_id as VertexIdentifier, offsets[vertex_id]);
     });
     black_box(&mut map);
 }
 
-fn offset_if_inner<const N_MARKS: usize>(
-    mut map: CMap2<N_MARKS, FloatType>,
-    offsets: &[Vertex2<FloatType>],
-) {
+fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vertex2<FloatType>]) {
     let mut inner: BTreeSet<VertexIdentifier> = BTreeSet::new();
     // collect inner vertex IDs
     (0..map.n_darts().0 as DartIdentifier).for_each(|dart_id| {
@@ -63,11 +57,11 @@ fn offset_if_inner<const N_MARKS: usize>(
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<1, FloatType> = splitsquare_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = splitsquare_cmap2(N_SQUARE);
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);
-    let range: Uniform<FloatType> = rand::distributions::Uniform::new(-0.5, 0.5);
+    let range: Uniform<FloatType> = Uniform::new(-0.5, 0.5);
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
 

--- a/honeycomb-utils/benches/squaremap/init.rs
+++ b/honeycomb-utils/benches/squaremap/init.rs
@@ -24,7 +24,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<1, FloatType> = square_cmap2(*n_square);
+                let mut map: CMap2<FloatType> = square_cmap2(*n_square);
                 black_box(&mut map);
             })
         });

--- a/honeycomb-utils/benches/squaremap/shift.rs
+++ b/honeycomb-utils/benches/squaremap/shift.rs
@@ -28,20 +28,14 @@ use honeycomb_utils::generation::square_cmap2;
 
 // ------ CONTENT
 
-fn offset<const N_MARKS: usize>(
-    mut map: CMap2<N_MARKS, FloatType>,
-    offsets: &[Vertex2<FloatType>],
-) {
+fn offset(mut map: CMap2<FloatType>, offsets: &[Vertex2<FloatType>]) {
     (0..map.n_vertices().0).for_each(|vertex_id| {
         let _ = map.set_vertex(vertex_id as VertexIdentifier, offsets[vertex_id]);
     });
     black_box(&mut map);
 }
 
-fn offset_if_inner<const N_MARKS: usize>(
-    mut map: CMap2<N_MARKS, FloatType>,
-    offsets: &[Vertex2<FloatType>],
-) {
+fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vertex2<FloatType>]) {
     let mut inner: BTreeSet<VertexIdentifier> = BTreeSet::new();
     // collect inner vertex IDs
     (0..map.n_darts().0 as DartIdentifier).for_each(|dart_id| {
@@ -63,11 +57,11 @@ fn offset_if_inner<const N_MARKS: usize>(
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<1, FloatType> = square_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = square_cmap2(N_SQUARE);
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);
-    let range: Uniform<FloatType> = rand::distributions::Uniform::new(-0.5, 0.5);
+    let range: Uniform<FloatType> = Uniform::new(-0.5, 0.5);
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
 

--- a/honeycomb-utils/benches/squaremap/split.rs
+++ b/honeycomb-utils/benches/squaremap/split.rs
@@ -33,7 +33,7 @@ use honeycomb_utils::generation::square_cmap2;
 const N_SQUARE: usize = 2_usize.pow(10);
 const P_BERNOULLI: f64 = 0.6;
 
-fn split<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>) {
+fn split(mut map: CMap2<FloatType>) {
     (0..N_SQUARE.pow(2)).for_each(|square| {
         let d1 = (1 + square * 4) as DartIdentifier;
         let (d2, d3, d4) = (d1 + 1, d1 + 2, d1 + 3);
@@ -55,7 +55,7 @@ fn split<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>) {
     black_box(&mut map);
 }
 
-fn split_some<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>, split: &[bool]) {
+fn split_some(mut map: CMap2<FloatType>, split: &[bool]) {
     (0..N_SQUARE.pow(2))
         .filter(|square| split[*square]) // split only if true
         .for_each(|square| {
@@ -79,7 +79,7 @@ fn split_some<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>, split: &
     black_box(&mut map);
 }
 
-fn split_diff<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>, split: &[bool]) {
+fn split_diff(mut map: CMap2<FloatType>, split: &[bool]) {
     (0..N_SQUARE.pow(2)).for_each(|square| {
         let ddown = (1 + square * 4) as DartIdentifier;
         let (dright, dup, dleft) = (ddown + 1, ddown + 2, ddown + 3);
@@ -125,7 +125,7 @@ fn split_diff<const N_MARKS: usize>(mut map: CMap2<N_MARKS, FloatType>, split: &
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let map: CMap2<1, FloatType> = square_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = square_cmap2(N_SQUARE);
     let seed: u64 = 9817498146784;
     let rng = SmallRng::seed_from_u64(seed);
     let dist = Bernoulli::new(P_BERNOULLI).unwrap();

--- a/honeycomb-utils/examples/memory_usage.rs
+++ b/honeycomb-utils/examples/memory_usage.rs
@@ -3,7 +3,7 @@ use honeycomb_utils::generation::square_cmap2;
 
 pub fn main() {
     // create a 3x3 grid & remove the central square
-    let mut cmap: CMap2<1, FloatType> = square_cmap2(3);
+    let mut cmap: CMap2<FloatType> = square_cmap2(3);
     // darts making up the central square
     let (d1, d2, d3, d4): (
         DartIdentifier,

--- a/honeycomb-utils/src/generation.rs
+++ b/honeycomb-utils/src/generation.rs
@@ -37,7 +37,7 @@ use honeycomb_core::{
 /// use honeycomb_core::CMap2;
 /// use honeycomb_utils::generation::square_cmap2;
 ///
-/// let cmap: CMap2<1, f64> = square_cmap2(2);
+/// let cmap: CMap2<f64> = square_cmap2(2);
 /// ```
 ///
 /// The above code generates the following map:
@@ -54,8 +54,8 @@ use honeycomb_core::{
 /// - cells are ordered from left to right, from the bottom up. The same rule
 ///   applies for face IDs.
 ///
-pub fn square_cmap2<const N_MARKS: usize, T: CoordsFloat>(n_square: usize) -> CMap2<N_MARKS, T> {
-    let mut map: CMap2<N_MARKS, T> = CMap2::new(4 * n_square.pow(2), (n_square + 1).pow(2));
+pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
+    let mut map: CMap2<T> = CMap2::new(4 * n_square.pow(2), (n_square + 1).pow(2));
 
     // first, topology
     (0..n_square).for_each(|y_idx| {
@@ -151,7 +151,7 @@ pub fn square_cmap2<const N_MARKS: usize, T: CoordsFloat>(n_square: usize) -> CM
 /// use honeycomb_core::CMap2;
 /// use honeycomb_utils::generation::splitsquare_cmap2;
 ///
-/// let cmap: CMap2<1, f64> = splitsquare_cmap2(2);
+/// let cmap: CMap2<f64> = splitsquare_cmap2(2);
 /// ```
 ///
 /// The above code generates the following map:
@@ -168,10 +168,8 @@ pub fn square_cmap2<const N_MARKS: usize, T: CoordsFloat>(n_square: usize) -> CM
 /// - cells are ordered from left to right, from the bottom up. The same rule
 ///   applies for face IDs.
 ///
-pub fn splitsquare_cmap2<const N_MARKS: usize, T: CoordsFloat>(
-    n_square: usize,
-) -> CMap2<N_MARKS, T> {
-    let mut map: CMap2<N_MARKS, T> = square_cmap2(n_square);
+pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
+    let mut map: CMap2<T> = square_cmap2(n_square);
 
     (0..n_square.pow(2)).for_each(|square| {
         let d1 = (1 + square * 4) as DartIdentifier;
@@ -202,7 +200,7 @@ mod tests {
 
     #[test]
     fn square_cmap2_correctness() {
-        let cmap: CMap2<1, f64> = square_cmap2(2);
+        let cmap: CMap2<f64> = square_cmap2(2);
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction
@@ -298,7 +296,7 @@ mod tests {
 
     #[test]
     fn splitsquare_cmap2_correctness() {
-        let cmap: CMap2<1, f64> = splitsquare_cmap2(2);
+        let cmap: CMap2<f64> = splitsquare_cmap2(2);
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction

--- a/honeycomb-utils/src/generation.rs
+++ b/honeycomb-utils/src/generation.rs
@@ -23,7 +23,7 @@ use honeycomb_core::{
 ///
 /// ## Generics
 ///
-/// - `const N_MARKS: usize` -- Generic parameter of the returned [CMap2]
+/// - `const T: CoordsFloat` -- Generic parameter of the returned [CMap2].
 ///
 /// # Return / Panic
 ///
@@ -137,7 +137,7 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 ///
 /// ## Generics
 ///
-/// - `const N_MARKS: usize` -- Generic parameter of the returned [CMap2]
+/// - `const T: CoordsFloat` -- Generic parameter of the returned [CMap2].
 ///
 /// # Return / Panic
 ///


### PR DESCRIPTION
# Description

Remove the marks built-in the `DartData` structure. This results in many function / structure signature changes, most notably:
- `Cmap2`
- `Orbit2`
- Both `honeycomb-utils::generation` functions
- `CMap2RenderHandle` in `honeycomb-render`

## Scope

- [x] Code
- [x] Documentation

## Type of change

- [x] Refactor

## Other

- [x] Breaking change

## Necessary follow-up

...

## Mentions

...