### PR TITLE
feat: implement generic attribute traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - remove the `Vertex2` type alias in favor of the new structure (#25)
 - add a new public module, `utils`, compiled when the `utils` feature is enabled (#31)
     - the module contains functions previously defined in the `honeycomb-utils` crate
+- add two new traits, `AttributeLogic` and `AttributeSupport`, for basic attribute genericity (#33)
 
 #### honeycomb-examples (new)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Honeycomb
 
-![Rust Tests](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml/badge.svg)
-![User Guide](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/doc.yml/badge.svg)
+[![Rust Tests](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml/badge.svg)](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml)
+[![User Guide Deployment](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/doc.yml/badge.svg)][UG]
 
 Honeycomb aims to provide a safe, efficient and scalable implementation of
 combinatorial maps for meshing applications. More specifically, the goal is

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -6,6 +6,16 @@
 
 // ------ CONTENT
 
+pub trait AttributeLogic: Sized {
+    fn merge(lhs: Self, rhs: Self) -> Self;
+
+    fn split(lhs: Self) -> (Self, Self);
+
+    fn merge_undefined(lhs: Option<Self>) -> Self {
+        lhs.unwrap() // todo: choose a policy for default behavior
+    }
+}
+
 // ------ TESTS
 
 #[cfg(test)]

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -4,6 +4,8 @@
 
 // ------ IMPORTS
 
+use crate::OrbitPolicy;
+
 // ------ CONTENT
 
 pub trait AttributeLogic: Sized {
@@ -14,6 +16,10 @@ pub trait AttributeLogic: Sized {
     fn merge_undefined(lhs: Option<Self>) -> Self {
         lhs.unwrap() // todo: choose a policy for default behavior
     }
+}
+
+pub trait AttributeSupport: Sized {
+    fn binds_to(&self) -> OrbitPolicy;
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -28,25 +28,25 @@ use crate::OrbitPolicy;
 /// }
 ///
 /// impl AttributeLogic for Temperature {
-///     fn merge(lhs: Self, rhs: Self) -> Self {
-///         Temperature { val: (lhs.val + rhs.val) / 2.0 }
+///     fn merge(attr1: Self, attr2: Self) -> Self {
+///         Temperature { val: (attr1.val + attr2.val) / 2.0 }
 ///     }
 ///
-///     fn split(lhs: Self) -> (Self, Self) {
-///         (lhs, lhs)
+///     fn split(attr: Self) -> (Self, Self) {
+///         (attr, attr)
 ///     }
 ///
-///     fn merge_undefined(lhs: Option<Self>) -> Self {
-///         lhs.unwrap_or(Temperature { val: 0.0 })
+///     fn merge_undefined(attr: Option<Self>) -> Self {
+///         attr.unwrap_or(Temperature { val: 0.0 })
 ///     }
 /// }
 /// ```
 pub trait AttributeLogic: Sized {
     /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.
-    fn merge(lhs: Self, rhs: Self) -> Self;
+    fn merge(attr1: Self, attr2: Self) -> Self;
 
     /// Splitting routine, i.e. how to obtain the two attributes from a single one.
-    fn split(lhs: Self) -> (Self, Self);
+    fn split(attr: Self) -> (Self, Self);
 
     /// Fallback merging routine, i.e. how to obtain the new attribute value from potentially
     /// undefined instances.
@@ -59,8 +59,8 @@ pub trait AttributeLogic: Sized {
     /// (un)sewing operation. Considering this context, as well as the definition of (un)linking
     /// operations, this panic seems reasonable: If the darts you are sewing have totally undefined
     /// attributes, you should most likely be linking them instead of sewing.
-    fn merge_undefined(lhs: Option<Self>) -> Self {
-        lhs.unwrap()
+    fn merge_undefined(attr: Option<Self>) -> Self {
+        attr.unwrap()
     }
 }
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -40,6 +40,14 @@ use crate::OrbitPolicy;
 ///         attr.unwrap_or(Temperature { val: 0.0 })
 ///     }
 /// }
+///
+/// let t1 = Temperature { val: 273.0 };
+/// let t2 = Temperature { val: 298.0 };
+///
+/// let t_new = AttributeLogic::merge(t1, t2);
+/// let t_ref = Temperature { val: 285.5 };
+///
+/// assert_eq!(AttributeLogic::split(t_new), (t_ref, t_ref));
 /// ```
 pub trait AttributeLogic: Sized {
     /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.
@@ -75,7 +83,7 @@ pub trait AttributeLogic: Sized {
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust
-/// use honeycomb_core::{AttributeBind, OrbitPolicy, VertexIdentifier};
+/// use honeycomb_core::{AttributeBind, FaceIdentifier, OrbitPolicy};
 ///
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
@@ -83,7 +91,7 @@ pub trait AttributeLogic: Sized {
 /// }
 ///
 /// impl AttributeBind for Temperature {
-///     type IdentifierType = VertexIdentifier;
+///     type IdentifierType = FaceIdentifier;
 ///
 ///     fn binds_to<'a>() -> OrbitPolicy<'a> {
 ///         OrbitPolicy::Face

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -22,7 +22,7 @@ use crate::OrbitPolicy;
 /// ```rust
 /// use honeycomb_core::AttributeUpdate;
 ///
-/// #[derive(Copy, Clone, Debug, PartialEq)]
+/// #[derive(Clone, Copy, Debug, PartialEq)]
 /// pub struct Temperature {
 ///     pub val: f32
 /// }
@@ -44,10 +44,10 @@ use crate::OrbitPolicy;
 /// let t1 = Temperature { val: 273.0 };
 /// let t2 = Temperature { val: 298.0 };
 ///
-/// let t_new = AttributeUpdate::merge(t1, t2);
+/// let t_new = AttributeUpdate::merge(t1, t2); // use AttributeUpdate::_
 /// let t_ref = Temperature { val: 285.5 };
 ///
-/// assert_eq!(Temperature::split(t_new), (t_ref, t_ref));
+/// assert_eq!(Temperature::split(t_new), (t_ref, t_ref)); // or Temperature::_
 /// ```
 pub trait AttributeUpdate: Sized {
     /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.
@@ -85,7 +85,7 @@ pub trait AttributeUpdate: Sized {
 /// ```rust
 /// use honeycomb_core::{AttributeBind, FaceIdentifier, OrbitPolicy};
 ///
-/// #[derive(Copy, Clone)]
+/// #[derive(Clone, Copy, Debug, PartialEq)]
 /// pub struct Temperature {
 ///     pub val: f32
 /// }
@@ -105,16 +105,4 @@ pub trait AttributeBind: Sized {
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
     fn binds_to<'a>() -> OrbitPolicy<'a>;
-}
-
-// ------ TESTS
-
-#[cfg(test)]
-mod tests {
-    //use super::*;
-
-    #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
-    }
 }

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -22,7 +22,7 @@ use crate::OrbitPolicy;
 /// ```rust
 /// use honeycomb_core::AttributeUpdate;
 ///
-/// #[derive(Copy, Clone)]
+/// #[derive(Copy, Clone, Debug, PartialEq)]
 /// pub struct Temperature {
 ///     pub val: f32
 /// }
@@ -47,7 +47,7 @@ use crate::OrbitPolicy;
 /// let t_new = AttributeUpdate::merge(t1, t2);
 /// let t_ref = Temperature { val: 285.5 };
 ///
-/// assert_eq!(AttributeUpdate::split(t_new), (t_ref, t_ref));
+/// assert_eq!(Temperature::split(t_new), (t_ref, t_ref));
 /// ```
 pub trait AttributeUpdate: Sized {
     /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -8,6 +8,38 @@ use crate::OrbitPolicy;
 
 // ------ CONTENT
 
+/// Generic attribute trait for logical behavior
+///
+/// This trait can be implemented for a given attribute in order to define the behavior to
+/// follow when (un)sewing operations result in an update of the attribute.
+///
+/// # Example
+///
+/// For an intensive property of a system (e.g. a temperature), a dummy implementation would look
+/// like this:
+///
+/// ```rust
+/// use honeycomb_core::AttributeLogic;
+///
+/// #[derive(Copy, Clone)]
+/// pub struct Temperature {
+///     pub val: f32
+/// };
+///
+/// impl AttributeLogic for Temperature {
+///     fn merge(lhs: Self, rhs: Self) -> Self {
+///         Temperature { val: (lhs.val + rhs.val) / 2.0 }
+///     }
+///
+///     fn split(lhs: Self) -> (Self, Self) {
+///         (lhs, lhs)
+///     }
+///
+///     fn merge_undefined(lhs: Option<Self>) -> Self {
+///         lhs.unwrap_or(Temperature { val: 0.0 })
+///     }
+/// }
+/// ```
 pub trait AttributeLogic: Sized {
     fn merge(lhs: Self, rhs: Self) -> Self;
 
@@ -18,6 +50,30 @@ pub trait AttributeLogic: Sized {
     }
 }
 
+/// Generic attribute trait for support description
+///
+/// This trait can be implemented for a given attribute in order to hint at which components of
+/// the map the attribute is bound.
+///
+/// # Example
+///
+/// Using the same context as the for the [AttributeLogic] example, we can associate temperature
+/// to faces if we're modeling a 2D mesh:
+///
+/// ```rust
+/// use honeycomb_core::{AttributeSupport, OrbitPolicy};
+///
+/// #[derive(Copy, Clone)]
+/// pub struct Temperature {
+///     pub val: f32
+/// };
+///
+/// impl AttributeSupport for Temperature {
+///     fn binds_to(&self) -> OrbitPolicy {
+///         OrbitPolicy::Face
+///     }
+/// }
+/// ```
 pub trait AttributeSupport: Sized {
     fn binds_to(&self) -> OrbitPolicy;
 }

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -4,7 +4,7 @@
 
 // ------ IMPORTS
 
-use crate::OrbitPolicy;
+use crate::{CoordsFloat, OrbitPolicy, Vertex2};
 
 // ------ CONTENT
 
@@ -24,7 +24,7 @@ use crate::OrbitPolicy;
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
 ///     pub val: f32
-/// };
+/// }
 ///
 /// impl AttributeLogic for Temperature {
 ///     fn merge(lhs: Self, rhs: Self) -> Self {
@@ -72,7 +72,7 @@ pub trait AttributeLogic: Sized {
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
 ///     pub val: f32
-/// };
+/// }
 ///
 /// impl AttributeSupport for Temperature {
 ///     fn binds_to(&self) -> OrbitPolicy {

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -75,20 +75,20 @@ pub trait AttributeLogic: Sized {
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust
-/// use honeycomb_core::{AttributeSupport, OrbitPolicy};
+/// use honeycomb_core::{AttributeBind, OrbitPolicy};
 ///
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
 ///     pub val: f32
 /// }
 ///
-/// impl AttributeSupport for Temperature {
+/// impl AttributeBind for Temperature {
 ///     fn binds_to(&self) -> OrbitPolicy {
 ///         OrbitPolicy::Face
 ///     }
 /// }
 /// ```
-pub trait AttributeSupport: Sized {
+pub trait AttributeBind: Sized {
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
     fn binds_to(&self) -> OrbitPolicy;

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -20,14 +20,14 @@ use crate::OrbitPolicy;
 /// like this:
 ///
 /// ```rust
-/// use honeycomb_core::AttributeLogic;
+/// use honeycomb_core::AttributeUpdate;
 ///
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
 ///     pub val: f32
 /// }
 ///
-/// impl AttributeLogic for Temperature {
+/// impl AttributeUpdate for Temperature {
 ///     fn merge(attr1: Self, attr2: Self) -> Self {
 ///         Temperature { val: (attr1.val + attr2.val) / 2.0 }
 ///     }
@@ -44,12 +44,12 @@ use crate::OrbitPolicy;
 /// let t1 = Temperature { val: 273.0 };
 /// let t2 = Temperature { val: 298.0 };
 ///
-/// let t_new = AttributeLogic::merge(t1, t2);
+/// let t_new = AttributeUpdate::merge(t1, t2);
 /// let t_ref = Temperature { val: 285.5 };
 ///
-/// assert_eq!(AttributeLogic::split(t_new), (t_ref, t_ref));
+/// assert_eq!(AttributeUpdate::split(t_new), (t_ref, t_ref));
 /// ```
-pub trait AttributeLogic: Sized {
+pub trait AttributeUpdate: Sized {
     /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.
     fn merge(attr1: Self, attr2: Self) -> Self;
 
@@ -79,7 +79,7 @@ pub trait AttributeLogic: Sized {
 ///
 /// # Example
 ///
-/// Using the same context as the for the [AttributeLogic] example, we can associate temperature
+/// Using the same context as the for the [AttributeUpdate] example, we can associate temperature
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -41,10 +41,16 @@ use crate::OrbitPolicy;
 /// }
 /// ```
 pub trait AttributeLogic: Sized {
+    /// Merging routine, i.e. how to obtain the new attribute value from the two existing ones.
     fn merge(lhs: Self, rhs: Self) -> Self;
 
+    /// Splitting routine, i.e. how to obtain the two attributes from a single one.
     fn split(lhs: Self) -> (Self, Self);
 
+    /// Fallback merging routine, i.e. how to obtain the new attribute value from potentially
+    /// undefined instances.
+    ///
+    /// The default implementation may panic if ...
     fn merge_undefined(lhs: Option<Self>) -> Self {
         lhs.unwrap() // todo: choose a policy for default behavior
     }
@@ -75,6 +81,10 @@ pub trait AttributeLogic: Sized {
 /// }
 /// ```
 pub trait AttributeSupport: Sized {
+    /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
+    /// which the attribute is associated.
+    ///
+    /// todo: decide if this should be turned into a const instead
     fn binds_to(&self) -> OrbitPolicy;
 }
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -1,6 +1,7 @@
 //! Generic attributes implementation
 //!
-//! This module contains all code used to handle attribute genericity in the context
+//! This module contains all code used to handle attribute genericity in the context of mesh
+//! representation through combinatorial maps embedded data.
 
 // ------ IMPORTS
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -1,0 +1,19 @@
+//! Generic attributes implementation
+//!
+//!
+
+// ------ IMPORTS
+
+// ------ CONTENT
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -83,7 +83,7 @@ pub trait AttributeLogic: Sized {
 /// }
 ///
 /// impl AttributeBind for Temperature {
-///     fn binds_to(&self) -> OrbitPolicy {
+///     fn binds_to<'a>() -> OrbitPolicy<'a> {
 ///         OrbitPolicy::Face
 ///     }
 /// }
@@ -91,7 +91,7 @@ pub trait AttributeLogic: Sized {
 pub trait AttributeBind: Sized {
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
-    fn binds_to(&self) -> OrbitPolicy;
+    fn binds_to<'a>() -> OrbitPolicy<'a>;
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -1,10 +1,10 @@
 //! Generic attributes implementation
 //!
-//!
+//! This module contains all code used to handle attribute genericity in the context
 
 // ------ IMPORTS
 
-use crate::{CoordsFloat, OrbitPolicy, Vertex2};
+use crate::OrbitPolicy;
 
 // ------ CONTENT
 
@@ -52,7 +52,7 @@ pub trait AttributeLogic: Sized {
     ///
     /// The default implementation may panic if ...
     fn merge_undefined(lhs: Option<Self>) -> Self {
-        lhs.unwrap() // todo: choose a policy for default behavior
+        lhs.unwrap()
     }
 }
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -51,7 +51,14 @@ pub trait AttributeLogic: Sized {
     /// Fallback merging routine, i.e. how to obtain the new attribute value from potentially
     /// undefined instances.
     ///
-    /// The default implementation may panic if ...
+    /// The default implementation may panic if no attribute can be used to create a value. The
+    /// reason for that is as follows:
+    ///
+    /// This trait and its methods were designed with the (un)sewing operation in mind. Their
+    /// purpose is to simplify the code needed to propagate updates of attributes affected by the
+    /// (un)sewing operation. Considering this context, as well as the definition of (un)linking
+    /// operations, this panic seems reasonable: If the darts you are sewing have totally undefined
+    /// attributes, you should most likely be linking them instead of sewing.
     fn merge_undefined(lhs: Option<Self>) -> Self {
         lhs.unwrap()
     }
@@ -84,8 +91,6 @@ pub trait AttributeLogic: Sized {
 pub trait AttributeSupport: Sized {
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
-    ///
-    /// todo: decide if this should be turned into a const instead
     fn binds_to(&self) -> OrbitPolicy;
 }
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -75,7 +75,7 @@ pub trait AttributeLogic: Sized {
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust
-/// use honeycomb_core::{AttributeBind, OrbitPolicy};
+/// use honeycomb_core::{AttributeBind, OrbitPolicy, VertexIdentifier};
 ///
 /// #[derive(Copy, Clone)]
 /// pub struct Temperature {
@@ -83,12 +83,17 @@ pub trait AttributeLogic: Sized {
 /// }
 ///
 /// impl AttributeBind for Temperature {
+///     type IdentifierType = VertexIdentifier;
+///
 ///     fn binds_to<'a>() -> OrbitPolicy<'a> {
 ///         OrbitPolicy::Face
 ///     }
 /// }
 /// ```
 pub trait AttributeBind: Sized {
+    /// Identifier type of the entity the attribute is bound to.
+    type IdentifierType;
+
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
     fn binds_to<'a>() -> OrbitPolicy<'a>;

--- a/honeycomb-core/src/cells/mod.rs
+++ b/honeycomb-core/src/cells/mod.rs
@@ -4,5 +4,6 @@
 
 // ------ MODULE DECLARATIONS
 
+mod attributes;
 pub mod identifiers;
 pub mod orbits;

--- a/honeycomb-core/src/cells/mod.rs
+++ b/honeycomb-core/src/cells/mod.rs
@@ -4,6 +4,6 @@
 
 // ------ MODULE DECLARATIONS
 
-mod attributes;
+pub mod attributes;
 pub mod identifiers;
 pub mod orbits;

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 // ------ RE-EXPORTS
 
 pub use cells::{
-    attributes::{AttributeLogic, AttributeSupport},
+    attributes::{AttributeBind, AttributeLogic},
     identifiers::*,
     orbits::{Orbit2, OrbitPolicy},
 };

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod utils;
 // ------ RE-EXPORTS
 
 pub use cells::{
+    attributes::{AttributeLogic, AttributeSupport},
     identifiers::*,
     orbits::{Orbit2, OrbitPolicy},
 };

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 // ------ RE-EXPORTS
 
 pub use cells::{
-    attributes::{AttributeBind, AttributeLogic},
+    attributes::{AttributeBind, AttributeUpdate},
     identifiers::*,
     orbits::{Orbit2, OrbitPolicy},
 };

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -236,7 +236,7 @@ impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
 ///
 /// - **BINDS TO 0-CELLS**
 impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
-    fn binds_to(&self) -> OrbitPolicy {
+    fn binds_to<'a>() -> OrbitPolicy<'a> {
         OrbitPolicy::Vertex
     }
 }

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -6,7 +6,9 @@
 
 // ------ IMPORTS
 
-use crate::{AttributeBind, AttributeLogic, Coords2, CoordsFloat, OrbitPolicy, Vector2};
+use crate::{
+    AttributeBind, AttributeLogic, Coords2, CoordsFloat, OrbitPolicy, Vector2, VertexIdentifier,
+};
 
 // ------ CONTENT
 
@@ -236,6 +238,8 @@ impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
 ///
 /// - **BINDS TO 0-CELLS**
 impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
+    type IdentifierType = VertexIdentifier;
+
     fn binds_to<'a>() -> OrbitPolicy<'a> {
         OrbitPolicy::Vertex
     }

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORTS
 
-use crate::{Coords2, CoordsFloat, Vector2};
+use crate::{AttributeLogic, AttributeSupport, Coords2, CoordsFloat, OrbitPolicy, Vector2};
 
 // ------ CONTENT
 
@@ -209,6 +209,35 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 
     fn sub(self, rhs: Vertex2<T>) -> Self::Output {
         Vector2::from(self.into_inner() - rhs.into_inner())
+    }
+}
+
+/// Attribute logic definitions
+///
+/// - **MERGING POLICY** - The new vertex is placed at the midpoint between the two existing ones.
+/// - **SPLITTING POLICY** - The current vertex is duplicated.
+/// - **UNDEFINED ATTRIBUTES MERGING** - The new vertex takes the value of the one provided if it
+/// exists, otherwise the function panics.
+impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
+    fn merge(lhs: Self, rhs: Self) -> Self {
+        Self::average(&lhs, &rhs)
+    }
+
+    fn split(lhs: Self) -> (Self, Self) {
+        (lhs, lhs)
+    }
+
+    fn merge_undefined(lhs: Option<Self>) -> Self {
+        lhs.unwrap()
+    }
+}
+
+/// Attribute support definitions
+///
+/// - **BINDS TO 0-CELLS**
+impl<T: CoordsFloat> AttributeSupport for Vertex2<T> {
+    fn binds_to(&self) -> OrbitPolicy {
+        OrbitPolicy::Vertex
     }
 }
 

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORTS
 
-use crate::{AttributeLogic, AttributeSupport, Coords2, CoordsFloat, OrbitPolicy, Vector2};
+use crate::{AttributeBind, AttributeLogic, Coords2, CoordsFloat, OrbitPolicy, Vector2};
 
 // ------ CONTENT
 
@@ -235,7 +235,7 @@ impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
 /// Attribute support definitions
 ///
 /// - **BINDS TO 0-CELLS**
-impl<T: CoordsFloat> AttributeSupport for Vertex2<T> {
+impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
     fn binds_to(&self) -> OrbitPolicy {
         OrbitPolicy::Vertex
     }

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -7,7 +7,7 @@
 // ------ IMPORTS
 
 use crate::{
-    AttributeBind, AttributeLogic, Coords2, CoordsFloat, OrbitPolicy, Vector2, VertexIdentifier,
+    AttributeBind, AttributeUpdate, Coords2, CoordsFloat, OrbitPolicy, Vector2, VertexIdentifier,
 };
 
 // ------ CONTENT
@@ -220,7 +220,7 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 /// - **SPLITTING POLICY** - The current vertex is duplicated.
 /// - **UNDEFINED ATTRIBUTES MERGING** - The new vertex takes the value of the one provided if it
 /// exists, otherwise the function panics.
-impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
+impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
     fn merge(attr1: Self, attr2: Self) -> Self {
         Self::average(&attr1, &attr2)
     }

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -219,16 +219,16 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 /// - **UNDEFINED ATTRIBUTES MERGING** - The new vertex takes the value of the one provided if it
 /// exists, otherwise the function panics.
 impl<T: CoordsFloat> AttributeLogic for Vertex2<T> {
-    fn merge(lhs: Self, rhs: Self) -> Self {
-        Self::average(&lhs, &rhs)
+    fn merge(attr1: Self, attr2: Self) -> Self {
+        Self::average(&attr1, &attr2)
     }
 
-    fn split(lhs: Self) -> (Self, Self) {
-        (lhs, lhs)
+    fn split(attr: Self) -> (Self, Self) {
+        (attr, attr)
     }
 
-    fn merge_undefined(lhs: Option<Self>) -> Self {
-        lhs.unwrap()
+    fn merge_undefined(attr: Option<Self>) -> Self {
+        attr.unwrap()
     }
 }
 


### PR DESCRIPTION
# Description

Add two traits: ~`AttributeLogic`~ `AttributeUpdate` and ~`AttributeSupport`~ `AttributeBind`. These will be used in order to introduce attribute genericity in the map implementation. 

## Scope

- [x] Code: `honeycomb-core`
- [x] Documentation

## Type of change

- [x] New feature(s)

## Other

...

## Necessary follow-up

- [x] Other: Refer to #30 

## Mentions

...