### PR TITLE
feat: implement custom generic containers for our attribute system

### DIFF
--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -12,13 +12,13 @@ use std::ops::{Index, IndexMut};
 // ------ CONTENT
 
 pub struct AttributeSparseVec<T: AttributeBind + AttributeUpdate> {
-    inner: Vec<Option<T>>,
+    data: Vec<Option<T>>,
 }
 
 impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
     pub fn new(length: usize) -> Self {
         Self {
-            inner: (0..length).map(|_| None).collect(),
+            data: (0..length).map(|_| None).collect(),
         }
     }
 }
@@ -27,13 +27,41 @@ impl<T: AttributeBind + AttributeUpdate> Index<T::IdentifierType> for AttributeS
     type Output = Option<T>;
 
     fn index(&self, index: T::IdentifierType) -> &Self::Output {
-        &self.inner[index.into()]
+        &self.data[index.into()]
     }
 }
 
 impl<T: AttributeBind + AttributeUpdate> IndexMut<T::IdentifierType> for AttributeSparseVec<T> {
     fn index_mut(&mut self, index: T::IdentifierType) -> &mut Self::Output {
-        &mut self.inner[index.into()]
+        &mut self.data[index.into()]
+    }
+}
+
+pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
+    index_map: Vec<Option<usize>>,
+    data: Vec<T>,
+}
+
+impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
+    pub fn new(n_ids: usize, n_attributes: usize) -> Self {
+        Self {
+            index_map: vec![None; n_ids],
+            data: Vec::with_capacity(n_attributes),
+        }
+    }
+}
+
+impl<T: AttributeBind + AttributeUpdate> Index<T::IdentifierType> for AttributeCompactVec<T> {
+    type Output = Option<T>;
+
+    fn index(&self, index: T::IdentifierType) -> &Self::Output {
+        &self.index_map[index.into()].map(|id| self.data[id])
+    }
+}
+
+impl<T: AttributeBind + AttributeUpdate> IndexMut<T::IdentifierType> for AttributeCompactVec<T> {
+    fn index_mut(&mut self, index: T::IdentifierType) -> &mut Self::Output {
+        &mut self.index_map[index.into()].map(|id| self.data[id])
     }
 }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -76,14 +76,15 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
     }
 
     pub fn set(&mut self, index: T::IdentifierType, val: T) {
-        let idx = &mut self.index_map[index.to_usize().unwrap()];
-        *idx = if let Some(unused_idx) = self.unused_data_slots.pop() {
+        if let Some(idx) = self.index_map[index.to_usize().unwrap()] {
+            self.data[idx] = val;
+        } else if let Some(unused_idx) = self.unused_data_slots.pop() {
             self.data[unused_idx] = val;
-            Some(unused_idx)
+            self.index_map[index.to_usize().unwrap()] = Some(unused_idx);
         } else {
             self.data.push(val);
-            Some(self.data.len())
-        };
+            self.index_map[index.to_usize().unwrap()] = Some(self.data.len());
+        }
     }
 
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -60,6 +60,31 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttributeCompactVec<T> {
             data: (0..n_attributes).map(|_| T::default()).collect(),
         }
     }
+
+    pub fn get(&self, index: T::IdentifierType) -> Option<&T> {
+        self.index_map[index.to_usize().unwrap()].map(|idx| &self.data[idx])
+    }
+
+    pub fn get_mut(&mut self, index: T::IdentifierType) -> Option<&mut T> {
+        self.index_map[index.to_usize().unwrap()].map(|idx| &mut self.data[idx])
+    }
+
+    pub fn insert(&mut self, index: T::IdentifierType, val: T) {
+        let idx = &mut self.index_map[index.to_usize().unwrap()];
+        assert!(idx.is_none());
+        self.data.push(val);
+        *idx = Some(self.data.len());
+    }
+
+    pub fn replace(&mut self, index: T::IdentifierType, val: T) {
+        let idx = &self.index_map[index.to_usize().unwrap()];
+        assert!(idx.is_some());
+        self.data[idx.unwrap()] = val;
+    }
+
+    pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
+        todo!()
+    }
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -74,8 +74,13 @@ impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {
         let idx = &mut self.index_map[index.to_usize().unwrap()];
         assert!(idx.is_none());
-        self.data.push(val);
-        *idx = Some(self.data.len());
+        *idx = if let Some(unused_idx) = self.unused_data_slots.pop() {
+            self.data[unused_idx] = val;
+            Some(unused_idx)
+        } else {
+            self.data.push(val);
+            Some(self.data.len())
+        };
     }
 
     pub fn replace(&mut self, index: T::IdentifierType, val: T) {

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -32,36 +32,137 @@ pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
 }
 
 impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
+    /// Constructor
+    ///
+    /// # Arguments
+    ///
+    /// - `n_ids: usize` -- Upper bound of IDs used to index the attribute's values (in practice,
+    /// the number of darts).
+    ///
+    /// # Return
+    ///
+    /// Return a [AttrSparseVec] object full of `None`.
+    ///
     pub fn new(n_ids: usize) -> Self {
         Self {
             data: (0..n_ids).map(|_| None).collect(),
         }
     }
 
+    /// Getter
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return a reference to the value indexed by `index`.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn get(&self, index: T::IdentifierType) -> &Option<T> {
         &self.data[index.to_usize().unwrap()]
     }
 
+    /// Getter
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return a mutable reference to the value indexed by `index`.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn get_mut(&mut self, index: T::IdentifierType) -> &mut Option<T> {
         &mut self.data[index.to_usize().unwrap()]
     }
 
+    /// Setter
+    ///
+    /// Set the value of an element at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Panic
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn set(&mut self, index: T::IdentifierType, val: T) {
         self.data[index.to_usize().unwrap()] = Some(val);
     }
 
+    /// Setter
+    ///
+    /// Insert a value at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Panic
+    ///
+    /// The method may panic if:
+    /// - **there is already a value associated to the specified index**
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {
         let tmp = &mut self.data[index.to_usize().unwrap()];
         assert!(tmp.is_none());
         *tmp = Some(val);
     }
 
+    /// Setter
+    ///
+    /// Replace the value of an element at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Panic
+    ///
+    /// The method may panic if:
+    /// - **there is no value associated to the specified index**
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn replace(&mut self, index: T::IdentifierType, val: T) {
         let tmp = &mut self.data[index.to_usize().unwrap()];
         assert!(tmp.is_some());
         *tmp = Some(val);
     }
 
+    /// Remove an item from the storage and return it
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return the item associated to the specified index. Note that the method will not panic if
+    /// there was not one, it will simply return `None`.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
         self.data.push(None);
         self.data.swap_remove(index.to_usize().unwrap())

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -16,9 +16,9 @@ pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
 }
 
 impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
-    pub fn new(n_attributes: usize) -> Self {
+    pub fn new(n_ids: usize) -> Self {
         Self {
-            data: (0..n_attributes).map(|_| None).collect(),
+            data: (0..n_ids).map(|_| None).collect(),
         }
     }
 
@@ -122,7 +122,7 @@ mod tests {
     use super::*;
     use crate::{FaceIdentifier, OrbitPolicy};
 
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
     pub struct Temperature {
         pub val: f32,
     }
@@ -156,9 +156,9 @@ mod tests {
         }
     }
 
-    macro_rules! generate_storage {
+    macro_rules! generate_sparse {
         ($name: ident, $stype: ident) => {
-            let mut $name = $stype::<Temperature>::new(10);
+            let mut $name = AttrSparseVec::<Temperature>::new(10);
             $name.insert(0, Temperature::from(273.0));
             $name.insert(1, Temperature::from(275.0));
             $name.insert(2, Temperature::from(277.0));
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_get_set_get() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.set(3, Temperature::from(280.0));
         assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_get_replace_get() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.replace(3, Temperature::from(280.0));
         assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
@@ -191,34 +191,34 @@ mod tests {
     #[test]
     #[should_panic]
     fn sparse_vec_get_insert_get() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.insert(3, Temperature::from(280.0)); // panic
     }
 
     #[test]
     fn sparse_vec_remove() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
     }
 
     #[test]
     fn sparse_vec_remove_remove() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         assert!(storage.remove(3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_get() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         assert!(storage.get(3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_set() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.set(3, Temperature::from(280.0));
         assert!(storage.get(3).is_some());
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_remove_insert() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.insert(3, Temperature::from(280.0));
         assert!(storage.get(3).is_some());
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn sparse_vec_remove_replace() {
-        generate_storage!(storage, AttrSparseVec);
+        generate_sparse!(storage, AttrSparseVec);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.replace(3, Temperature::from(280.0)); // panic
     }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -63,7 +63,7 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
         Self {
             unused_data_slots: (0..n_attributes).collect(),
             index_map: vec![None; n_ids],
-            data: Vec::with_capacity(n_attributes),
+            data: (0..n_attributes).map(|_| T::default()).collect(),
         }
     }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -191,7 +191,7 @@ pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Default> {
 }
 
 impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
-    pub fn new(n_ids: usize, n_attributes: usize) -> Self {
+    pub fn new(n_ids: usize) -> Self {
         Self {
             unused_data_slots: Vec::new(),
             index_map: vec![None; n_ids],
@@ -378,7 +378,7 @@ mod tests {
 
     macro_rules! generate_compact {
         ($name: ident) => {
-            let mut $name = AttrCompactVec::<Temperature>::new(10, 10);
+            let mut $name = AttrCompactVec::<Temperature>::new(10);
             $name.insert(0, Temperature::from(273.0));
             $name.insert(1, Temperature::from(275.0));
             $name.insert(2, Temperature::from(277.0));

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -54,7 +54,7 @@ pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<T>,
 }
 
-impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
+impl<T: AttributeBind + AttributeUpdate + Default> AttributeCompactVec<T> {
     pub fn new(n_ids: usize, n_attributes: usize) -> Self {
         Self {
             unused_data_slots: (0..n_attributes).collect(),
@@ -90,7 +90,13 @@ impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
     }
 
     pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
-        todo!()
+        self.index_map.push(None);
+        if let Some(tmp) = self.index_map.swap_remove(index.to_usize().unwrap()) {
+            self.unused_data_slots.push(tmp);
+            self.data.push(T::default());
+            return Some(self.data.swap_remove(tmp));
+        };
+        None
     }
 }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -119,7 +119,36 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
 
 #[cfg(test)]
 mod tests {
-    //use super::*;
+    use super::*;
+    use crate::{FaceIdentifier, OrbitPolicy};
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct Temperature {
+        pub val: f32,
+    }
+
+    impl AttributeUpdate for Temperature {
+        fn merge(attr1: Self, attr2: Self) -> Self {
+            Temperature {
+                val: (attr1.val + attr2.val) / 2.0,
+            }
+        }
+
+        fn split(attr: Self) -> (Self, Self) {
+            (attr, attr)
+        }
+
+        fn merge_undefined(attr: Option<Self>) -> Self {
+            attr.unwrap_or(Temperature { val: 0.0 })
+        }
+    }
+
+    impl AttributeBind for Temperature {
+        type IdentifierType = FaceIdentifier;
+        fn binds_to<'a>() -> OrbitPolicy<'a> {
+            OrbitPolicy::Face
+        }
+    }
 
     #[test]
     fn some_test() {

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -150,8 +150,33 @@ mod tests {
         }
     }
 
+    impl From<f32> for Temperature {
+        fn from(val: f32) -> Self {
+            Self { val }
+        }
+    }
+
+    macro_rules! generate_storage {
+        ($name: ident, $stype: ident) => {
+            let mut $name = $stype::<Temperature>::new(10);
+            $name.insert(0, Temperature::from(273.0));
+            $name.insert(1, Temperature::from(275.0));
+            $name.insert(2, Temperature::from(277.0));
+            $name.insert(3, Temperature::from(279.0));
+            $name.insert(4, Temperature::from(281.0));
+            $name.insert(5, Temperature::from(283.0));
+            $name.insert(6, Temperature::from(285.0));
+            $name.insert(7, Temperature::from(287.0));
+            $name.insert(8, Temperature::from(289.0));
+            $name.insert(9, Temperature::from(291.0));
+        };
+    }
+
     #[test]
-    fn some_test() {
-        assert_eq!(1, 1);
+    fn sparse_vec_get_set_get() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
+        storage.set(3, Temperature::from(280.0));
+        assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
     }
 }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -1,8 +1,7 @@
-//! Module short description
+//! Attribute storage structures
 //!
-//! Should you interact with this module directly?
-//!
-//! Content description if needed
+//! This module contains all code used to describe custom collections used to store attributes
+//! (see [AttributeBind], [AttributeUpdate]).
 
 // ------ IMPORTS
 
@@ -11,7 +10,7 @@ use num::ToPrimitive;
 
 // ------ CONTENT
 
-/// Custom storage structure for [attributes]
+/// Custom storage structure for attributes
 ///
 /// This structured is used to store user-defined attributes using a vector of `Option<T>` items.
 /// This means that valid attributes value may be separated by an arbitrary number of `None`.
@@ -169,7 +168,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     }
 }
 
-/// Custom storage structure for [attributes]
+/// Custom storage structure for attributes
 ///
 /// This structured is used to store user-defined attributes using two internal collections:
 /// - a vector of `Option<usize>`, effectively acting as a map from identifiers to internal indices

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -209,13 +209,16 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
 
     pub fn set(&mut self, index: T::IdentifierType, val: T) {
         if let Some(idx) = self.index_map[index.to_usize().unwrap()] {
+            // internal index is defined => there should be associated data
             self.data[idx] = val;
         } else if let Some(unused_idx) = self.unused_data_slots.pop() {
+            // internal index is undefined => a) there is an unused internal slot
             self.data[unused_idx] = val;
             self.index_map[index.to_usize().unwrap()] = Some(unused_idx);
         } else {
+            // internal index is undefined => b) there is no unused internal slot
             self.data.push(val);
-            self.index_map[index.to_usize().unwrap()] = Some(self.data.len());
+            self.index_map[index.to_usize().unwrap()] = Some(self.data.len() - 1);
         }
     }
 
@@ -227,7 +230,7 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
             Some(unused_idx)
         } else {
             self.data.push(val);
-            Some(self.data.len())
+            Some(self.data.len() - 1)
         };
     }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -23,9 +23,8 @@ use num::ToPrimitive;
 ///
 /// # Example
 ///
-/// ```text
+/// todo
 ///
-/// ```
 pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<Option<T>>,
 }
@@ -183,9 +182,8 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
 ///
 /// # Example
 ///
-/// ```text
+/// todo
 ///
-/// ```
 pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Default> {
     unused_data_slots: Vec<usize>,
     index_map: Vec<Option<usize>>,
@@ -195,9 +193,9 @@ pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Default> {
 impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
     pub fn new(n_ids: usize, n_attributes: usize) -> Self {
         Self {
-            unused_data_slots: (0..n_attributes).collect(),
+            unused_data_slots: Vec::new(),
             index_map: vec![None; n_ids],
-            data: (0..n_attributes).map(|_| T::default()).collect(),
+            data: Vec::new(),
         }
     }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -16,9 +16,9 @@ pub struct AttributeSparseVec<T: AttributeBind + AttributeUpdate> {
 }
 
 impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
-    pub fn new(length: usize) -> Self {
+    pub fn new(n_attributes: usize) -> Self {
         Self {
-            data: (0..length).map(|_| None).collect(),
+            data: (0..n_attributes).map(|_| None).collect(),
         }
     }
 }
@@ -28,11 +28,11 @@ pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<T>,
 }
 
-impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
+impl<T: AttributeBind + AttributeUpdate + Default> AttributeCompactVec<T> {
     pub fn new(n_ids: usize, n_attributes: usize) -> Self {
         Self {
             index_map: vec![None; n_ids],
-            data: Vec::with_capacity(n_attributes),
+            data: (0..n_attributes).map(|_| T::default()).collect(),
         }
     }
 }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -30,6 +30,10 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
         &mut self.data[index.to_usize().unwrap()]
     }
 
+    pub fn set(&mut self, index: T::IdentifierType, val: T) {
+        self.data[index.to_usize().unwrap()] = Some(val);
+    }
+
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {
         let tmp = &mut self.data[index.to_usize().unwrap()];
         assert!(tmp.is_none());
@@ -69,6 +73,17 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
 
     pub fn get_mut(&mut self, index: T::IdentifierType) -> Option<&mut T> {
         self.index_map[index.to_usize().unwrap()].map(|idx| &mut self.data[idx])
+    }
+
+    pub fn set(&mut self, index: T::IdentifierType, val: T) {
+        let idx = &mut self.index_map[index.to_usize().unwrap()];
+        *idx = if let Some(unused_idx) = self.unused_data_slots.pop() {
+            self.data[unused_idx] = val;
+            Some(unused_idx)
+        } else {
+            self.data.push(val);
+            Some(self.data.len())
+        };
     }
 
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -49,15 +49,17 @@ impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
 }
 
 pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
+    unused_data_slots: Vec<usize>,
     index_map: Vec<Option<usize>>,
     data: Vec<T>,
 }
 
-impl<T: AttributeBind + AttributeUpdate + Default> AttributeCompactVec<T> {
+impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
     pub fn new(n_ids: usize, n_attributes: usize) -> Self {
         Self {
+            unused_data_slots: (0..n_attributes).collect(),
             index_map: vec![None; n_ids],
-            data: (0..n_attributes).map(|_| T::default()).collect(),
+            data: Vec::with_capacity(n_attributes),
         }
     }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -1,0 +1,21 @@
+//! Module short description
+//!
+//! Should you interact with this module directly?
+//!
+//! Content description if needed
+
+// ------ IMPORTS
+
+// ------ CONTENT
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    #[test]
+    fn some_test() {
+        assert_eq!(1, 1);
+    }
+}

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -30,8 +30,16 @@ impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
         &mut self.data[index.to_usize().unwrap()]
     }
 
-    pub fn set(&mut self, index: T::IdentifierType, val: T) {
-        self.data[index.to_usize().unwrap()] = Some(val);
+    pub fn insert(&mut self, index: T::IdentifierType, val: T) {
+        let tmp = &mut self.data[index.to_usize().unwrap()];
+        assert!(tmp.is_none());
+        *tmp = Some(val);
+    }
+
+    pub fn replace(&mut self, index: T::IdentifierType, val: T) {
+        let tmp = &mut self.data[index.to_usize().unwrap()];
+        assert!(tmp.is_some());
+        *tmp = Some(val);
     }
 
     pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -241,7 +241,7 @@ mod tests {
     }
 
     macro_rules! generate_compact {
-        ($name: ident, $stype: ident) => {
+        ($name: ident) => {
             let mut $name = AttrCompactVec::<Temperature>::new(10, 10);
             $name.insert(0, Temperature::from(273.0));
             $name.insert(1, Temperature::from(275.0));
@@ -254,5 +254,73 @@ mod tests {
             $name.insert(8, Temperature::from(289.0));
             $name.insert(9, Temperature::from(291.0));
         };
+    }
+
+    #[test]
+    fn compact_vec_get_set_get() {
+        generate_compact!(storage);
+        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
+        storage.set(3, Temperature::from(280.0));
+        assert_eq!(storage.get(3), Some(&Temperature::from(280.0)));
+    }
+
+    #[test]
+    fn compact_vec_get_replace_get() {
+        generate_compact!(storage);
+        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
+        storage.replace(3, Temperature::from(280.0));
+        assert_eq!(storage.get(3), Some(&Temperature::from(280.0)));
+    }
+
+    #[test]
+    #[should_panic]
+    fn compact_vec_get_insert_get() {
+        generate_compact!(storage);
+        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
+        storage.insert(3, Temperature::from(280.0)); // panic
+    }
+
+    #[test]
+    fn compact_vec_remove() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+    }
+
+    #[test]
+    fn compact_vec_remove_remove() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert!(storage.remove(3).is_none());
+    }
+
+    #[test]
+    fn compact_vec_remove_get() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert!(storage.get(3).is_none());
+    }
+
+    #[test]
+    fn compact_vec_remove_set() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.set(3, Temperature::from(280.0));
+        assert!(storage.get(3).is_some());
+    }
+
+    #[test]
+    fn compact_vec_remove_insert() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.insert(3, Temperature::from(280.0));
+        assert!(storage.get(3).is_some());
+    }
+
+    #[test]
+    #[should_panic]
+    fn compact_vec_remove_replace() {
+        generate_compact!(storage);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.replace(3, Temperature::from(280.0)); // panic
     }
 }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -7,7 +7,7 @@
 // ------ IMPORTS
 
 use crate::{AttributeBind, AttributeUpdate};
-use std::ops::{Index, IndexMut};
+use num::ToPrimitive;
 
 // ------ CONTENT
 
@@ -20,6 +20,23 @@ impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
         Self {
             data: (0..n_attributes).map(|_| None).collect(),
         }
+    }
+
+    pub fn get(&self, index: T::IdentifierType) -> &Option<T> {
+        &self.data[index.to_usize().unwrap()]
+    }
+
+    pub fn get_mut(&mut self, index: T::IdentifierType) -> &mut Option<T> {
+        &mut self.data[index.to_usize().unwrap()]
+    }
+
+    pub fn set(&mut self, index: T::IdentifierType, val: T) {
+        self.data[index.to_usize().unwrap()] = Some(val);
+    }
+
+    pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
+        self.data.push(None);
+        self.data.swap_remove(index.to_usize().unwrap())
     }
 }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -179,4 +179,64 @@ mod tests {
         storage.set(3, Temperature::from(280.0));
         assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
     }
+
+    #[test]
+    fn sparse_vec_get_replace_get() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
+        storage.replace(3, Temperature::from(280.0));
+        assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
+    }
+
+    #[test]
+    #[should_panic]
+    fn sparse_vec_get_insert_get() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
+        storage.insert(3, Temperature::from(280.0)); // panic
+    }
+
+    #[test]
+    fn sparse_vec_remove() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+    }
+
+    #[test]
+    fn sparse_vec_remove_remove() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert!(storage.remove(3).is_none());
+    }
+
+    #[test]
+    fn sparse_vec_remove_get() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert!(storage.get(3).is_none());
+    }
+
+    #[test]
+    fn sparse_vec_remove_set() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.set(3, Temperature::from(280.0));
+        assert!(storage.get(3).is_some());
+    }
+
+    #[test]
+    fn sparse_vec_remove_insert() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.insert(3, Temperature::from(280.0));
+        assert!(storage.get(3).is_some());
+    }
+
+    #[test]
+    #[should_panic]
+    fn sparse_vec_remove_replace() {
+        generate_storage!(storage, AttrSparseVec);
+        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        storage.replace(3, Temperature::from(280.0)); // panic
+    }
 }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -23,20 +23,6 @@ impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
     }
 }
 
-impl<T: AttributeBind + AttributeUpdate> Index<T::IdentifierType> for AttributeSparseVec<T> {
-    type Output = Option<T>;
-
-    fn index(&self, index: T::IdentifierType) -> &Self::Output {
-        &self.data[index.into()]
-    }
-}
-
-impl<T: AttributeBind + AttributeUpdate> IndexMut<T::IdentifierType> for AttributeSparseVec<T> {
-    fn index_mut(&mut self, index: T::IdentifierType) -> &mut Self::Output {
-        &mut self.data[index.into()]
-    }
-}
-
 pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
     index_map: Vec<Option<usize>>,
     data: Vec<T>,
@@ -48,20 +34,6 @@ impl<T: AttributeBind + AttributeUpdate> AttributeCompactVec<T> {
             index_map: vec![None; n_ids],
             data: Vec::with_capacity(n_attributes),
         }
-    }
-}
-
-impl<T: AttributeBind + AttributeUpdate> Index<T::IdentifierType> for AttributeCompactVec<T> {
-    type Output = Option<T>;
-
-    fn index(&self, index: T::IdentifierType) -> &Self::Output {
-        &self.index_map[index.into()].map(|id| self.data[id])
-    }
-}
-
-impl<T: AttributeBind + AttributeUpdate> IndexMut<T::IdentifierType> for AttributeCompactVec<T> {
-    fn index_mut(&mut self, index: T::IdentifierType) -> &mut Self::Output {
-        &mut self.index_map[index.into()].map(|id| self.data[id])
     }
 }
 

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -11,6 +11,22 @@ use num::ToPrimitive;
 
 // ------ CONTENT
 
+/// Custom storage structure for [attributes]
+///
+/// This structured is used to store user-defined attributes using a vector of `Option<T>` items.
+/// This means that valid attributes value may be separated by an arbitrary number of `None`.
+///
+/// This implementation should favor access logic over locality of reference.
+///
+/// # Generics
+///
+/// - `T: AttributeBind + AttributeUpdate` -- Type of the stored attributes.
+///
+/// # Example
+///
+/// ```text
+///
+/// ```
 pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<Option<T>>,
 }
@@ -52,7 +68,25 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     }
 }
 
-pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate> {
+/// Custom storage structure for [attributes]
+///
+/// This structured is used to store user-defined attributes using two internal collections:
+/// - a vector of `Option<usize>`, effectively acting as a map from identifiers to internal indices
+/// - a vector of `T` items, indexed by values of the first vector
+///
+/// This implementation should favor locality of reference over access logic.
+///
+/// # Generics
+///
+/// - `T: AttributeBind + AttributeUpdate + Default` -- Type of the stored attributes. The
+/// `Default` implementation is required in order to create dummy values for unused slots.
+///
+/// # Example
+///
+/// ```text
+///
+/// ```
+pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Default> {
     unused_data_slots: Vec<usize>,
     index_map: Vec<Option<usize>>,
     data: Vec<T>,

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -157,7 +157,7 @@ mod tests {
     }
 
     macro_rules! generate_sparse {
-        ($name: ident, $stype: ident) => {
+        ($name: ident) => {
             let mut $name = AttrSparseVec::<Temperature>::new(10);
             $name.insert(0, Temperature::from(273.0));
             $name.insert(1, Temperature::from(275.0));
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_get_set_get() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.set(3, Temperature::from(280.0));
         assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_get_replace_get() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.replace(3, Temperature::from(280.0));
         assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
@@ -191,34 +191,34 @@ mod tests {
     #[test]
     #[should_panic]
     fn sparse_vec_get_insert_get() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
         storage.insert(3, Temperature::from(280.0)); // panic
     }
 
     #[test]
     fn sparse_vec_remove() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
     }
 
     #[test]
     fn sparse_vec_remove_remove() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         assert!(storage.remove(3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_get() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         assert!(storage.get(3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_set() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.set(3, Temperature::from(280.0));
         assert!(storage.get(3).is_some());
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn sparse_vec_remove_insert() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.insert(3, Temperature::from(280.0));
         assert!(storage.get(3).is_some());
@@ -235,8 +235,24 @@ mod tests {
     #[test]
     #[should_panic]
     fn sparse_vec_remove_replace() {
-        generate_sparse!(storage, AttrSparseVec);
+        generate_sparse!(storage);
         assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
         storage.replace(3, Temperature::from(280.0)); // panic
+    }
+
+    macro_rules! generate_compact {
+        ($name: ident, $stype: ident) => {
+            let mut $name = AttrCompactVec::<Temperature>::new(10, 10);
+            $name.insert(0, Temperature::from(273.0));
+            $name.insert(1, Temperature::from(275.0));
+            $name.insert(2, Temperature::from(277.0));
+            $name.insert(3, Temperature::from(279.0));
+            $name.insert(4, Temperature::from(281.0));
+            $name.insert(5, Temperature::from(283.0));
+            $name.insert(6, Temperature::from(285.0));
+            $name.insert(7, Temperature::from(287.0));
+            $name.insert(8, Temperature::from(289.0));
+            $name.insert(9, Temperature::from(291.0));
+        };
     }
 }

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -11,11 +11,11 @@ use num::ToPrimitive;
 
 // ------ CONTENT
 
-pub struct AttributeSparseVec<T: AttributeBind + AttributeUpdate> {
+pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<Option<T>>,
 }
 
-impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
+impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     pub fn new(n_attributes: usize) -> Self {
         Self {
             data: (0..n_attributes).map(|_| None).collect(),
@@ -48,13 +48,13 @@ impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
     }
 }
 
-pub struct AttributeCompactVec<T: AttributeBind + AttributeUpdate> {
+pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate> {
     unused_data_slots: Vec<usize>,
     index_map: Vec<Option<usize>>,
     data: Vec<T>,
 }
 
-impl<T: AttributeBind + AttributeUpdate + Default> AttributeCompactVec<T> {
+impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
     pub fn new(n_ids: usize, n_attributes: usize) -> Self {
         Self {
             unused_data_slots: (0..n_attributes).collect(),

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -6,7 +6,36 @@
 
 // ------ IMPORTS
 
+use crate::{AttributeBind, AttributeUpdate};
+use std::ops::{Index, IndexMut};
+
 // ------ CONTENT
+
+pub struct AttributeSparseVec<T: AttributeBind + AttributeUpdate> {
+    inner: Vec<Option<T>>,
+}
+
+impl<T: AttributeBind + AttributeUpdate> AttributeSparseVec<T> {
+    pub fn new(length: usize) -> Self {
+        Self {
+            inner: (0..length).map(|_| None).collect(),
+        }
+    }
+}
+
+impl<T: AttributeBind + AttributeUpdate> Index<T::IdentifierType> for AttributeSparseVec<T> {
+    type Output = Option<T>;
+
+    fn index(&self, index: T::IdentifierType) -> &Self::Output {
+        &self.inner[index.into()]
+    }
+}
+
+impl<T: AttributeBind + AttributeUpdate> IndexMut<T::IdentifierType> for AttributeSparseVec<T> {
+    fn index_mut(&mut self, index: T::IdentifierType) -> &mut Self::Output {
+        &mut self.inner[index.into()]
+    }
+}
 
 // ------ TESTS
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -100,7 +100,7 @@ pub trait AttributeUpdate: Sized {
 /// ```
 pub trait AttributeBind: Sized {
     /// Identifier type of the entity the attribute is bound to.
-    type IdentifierType;
+    type IdentifierType: num::ToPrimitive;
 
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -6,6 +6,7 @@
 // ------ IMPORTS
 
 use crate::OrbitPolicy;
+use std::fmt::Debug;
 
 // ------ CONTENT
 
@@ -100,7 +101,7 @@ pub trait AttributeUpdate: Sized {
 /// ```
 pub trait AttributeBind: Sized {
     /// Identifier type of the entity the attribute is bound to.
-    type IdentifierType;
+    type IdentifierType: Into<usize>;
 
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -6,7 +6,6 @@
 // ------ IMPORTS
 
 use crate::OrbitPolicy;
-use std::fmt::Debug;
 
 // ------ CONTENT
 

--- a/honeycomb-core/src/cells/attributes.rs
+++ b/honeycomb-core/src/cells/attributes.rs
@@ -100,7 +100,7 @@ pub trait AttributeUpdate: Sized {
 /// ```
 pub trait AttributeBind: Sized {
     /// Identifier type of the entity the attribute is bound to.
-    type IdentifierType: Into<usize>;
+    type IdentifierType;
 
     /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.

--- a/honeycomb-core/src/cells/mod.rs
+++ b/honeycomb-core/src/cells/mod.rs
@@ -4,6 +4,7 @@
 
 // ------ MODULE DECLARATIONS
 
+pub mod attribute_collections;
 pub mod attributes;
 pub mod identifiers;
 pub mod orbits;

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 // ------ RE-EXPORTS
 
 pub use cells::{
-    attribute_collections::{AttributeCompactVec, AttributeSparseVec},
+    attribute_collections::{AttrCompactVec, AttrSparseVec},
     attributes::{AttributeBind, AttributeUpdate},
     identifiers::*,
     orbits::{Orbit2, OrbitPolicy},

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod utils;
 // ------ RE-EXPORTS
 
 pub use cells::{
+    attribute_collections::{AttributeCompactVec, AttributeSparseVec},
     attributes::{AttributeBind, AttributeUpdate},
     identifiers::*,
     orbits::{Orbit2, OrbitPolicy},


### PR DESCRIPTION
# Description



Add two basic storage structures for generic attributes: `AttrSparseVec` and `AttrCompactVec`. Their interfaces are very similar; The naming logic is as follows for access methods:

- `get`/`get_mut`: getter; Because of differences in internal storage, the return type is different between the two structure.
- `set`: setter 
- `insert`: setter that fails if there is already a value associated with the specified ID
- `replace`: setter that fails if there is no value associated with the specified ID
- `remove`: get a value & remove it from the storage. Returns `None` if no value is found for the given ID.

Additionally, all these methods will fail if the specified index:
- lands out of bounds
- fails to convert to `usize` (see `ToPrimitive` [trait](https://docs.rs/num/latest/num/trait.ToPrimitive.html) of the num crate)

## Scope

- [x] Code: `honeycomb-core`
- [x] Documentation

## Type of change

- [x] New feature(s)
- [x] Testing

## Other

...

## Necessary follow-up

- [x] Needs documentation: UG
- [x] Other: integrate this into the `CMap2` structure for the vertices

## Mentions

...