### PR TITLE
refactor: reimplement vertex in `CMap2` as attributes

### DIFF
--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -25,6 +25,7 @@ use num::ToPrimitive;
 ///
 /// todo
 ///
+#[cfg_attr(feature = "utils", derive(Clone))]
 pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<Option<T>>,
 }
@@ -184,6 +185,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
 ///
 /// todo
 ///
+#[cfg_attr(feature = "utils", derive(Clone))]
 pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Default> {
     unused_data_slots: Vec<usize>,
     index_map: Vec<Option<usize>>,

--- a/honeycomb-core/src/cells/attribute_collections.rs
+++ b/honeycomb-core/src/cells/attribute_collections.rs
@@ -48,6 +48,10 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
         }
     }
 
+    pub fn extend(&mut self, length: usize) {
+        self.data.extend((0..length).map(|_| None));
+    }
+
     /// Getter
     ///
     /// # Arguments
@@ -199,6 +203,12 @@ impl<T: AttributeBind + AttributeUpdate + Default> AttrCompactVec<T> {
             index_map: vec![None; n_ids],
             data: Vec::new(),
         }
+    }
+
+    pub fn extend(&mut self, length: usize) {
+        let tmp = self.index_map.len();
+        self.index_map.extend((0..length).map(|_| None));
+        self.unused_data_slots.extend((tmp..tmp + length).rev());
     }
 
     pub fn get(&self, index: T::IdentifierType) -> Option<&T> {

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -162,6 +162,7 @@ const CMAP2_BETA: usize = 3;
 /// assert!(map.is_free(d6));
 ///
 /// // create the corresponding three vertices
+/// map.add_vertices(3);
 /// let v4 = 3;
 /// let v5 = 4;
 /// let v6 = 5;
@@ -275,13 +276,6 @@ pub struct CMap2<T: CoordsFloat> {
     n_vertices: usize,
 }
 
-macro_rules! stretch {
-    ($slf: ident, $replaced: expr, $replacer: expr) => {
-        $slf.dart_data.associated_cells[$replaced as usize].vertex_id =
-            $slf.dart_data.associated_cells[$replacer as usize].vertex_id
-    };
-}
-
 impl<T: CoordsFloat> CMap2<T> {
     /// Creates a new 2D combinatorial map.
     ///
@@ -307,7 +301,7 @@ impl<T: CoordsFloat> CMap2<T> {
         let betas = vec![[0; CMAP2_BETA]; n_darts + 1];
 
         Self {
-            vertices: AttrCompactVec::new(n_darts),
+            vertices: AttrCompactVec::new(n_darts + 1),
             unused_vertices: BTreeSet::new(),
             faces: Vec::with_capacity(n_darts / 3),
             dart_data: DartData::new(n_darts),
@@ -791,15 +785,8 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// See [CMap2] example.
     ///
-    pub fn add_vertices(&mut self, n_vertices: usize) -> VertexIdentifier {
-        unimplemented!()
-        /*
-        let new_id = self.n_vertices as VertexIdentifier;
-        self.n_vertices += n_vertices;
-        self.vertices
-            .extend((0..n_vertices).map(|_| Vertex2::default()));
-        new_id
-         */
+    pub fn add_vertices(&mut self, n_vertices: usize) {
+        self.vertices.extend(n_vertices);
     }
 
     /// Insert a vertex in the combinatorial map.
@@ -821,12 +808,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// See [CMap2] example.
     ///
     pub fn insert_vertex(&mut self, vertex: Option<Vertex2<T>>) -> VertexIdentifier {
-        if let Some(new_id) = self.unused_vertices.pop_first() {
-            self.set_vertex(new_id, vertex.unwrap_or_default()).unwrap();
-            new_id
-        } else {
-            self.add_vertex(vertex)
-        }
+        unimplemented!()
     }
 
     /// Remove a vertex from the combinatorial map.

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -162,11 +162,12 @@ const CMAP2_BETA: usize = 3;
 /// assert!(map.is_free(d6));
 ///
 /// // create the corresponding three vertices
-/// let v4 = map.add_vertex(Some([15.0, 0.0].into())); // v4
-/// let v5 = map.add_vertices(2); // v5, v6
-/// let v6 = v5 + 1;
-/// map.set_vertex(v5, [5.0, 10.0])?; // v5
-/// map.set_vertex(v6, [15.0, 10.0])?; // v6
+/// let v4 = 3;
+/// let v5 = 4;
+/// let v6 = 5;
+/// map.set_vertex(v4, [15.0, 0.0])?;
+/// map.set_vertex(v5, [5.0, 10.0])?;
+/// map.set_vertex(v6, [15.0, 10.0])?;
 /// // associate dart to vertices
 /// map.set_vertexid(d4, v4);
 /// map.set_vertexid(d5, v5);

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1129,28 +1129,23 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.vertices.remove(rhs_vid),
                 );
 
-                match tmp {
-                    #[rustfmt::skip]
-                    (
-                        Some(b1l_vertex),
-                        Some(l_vertex),
-                        Some(b1r_vertex),
-                        Some(r_vertex)
-                    ) => {
-                        let lhs_vector = b1l_vertex - l_vertex;
-                        let rhs_vector = b1r_vertex - r_vertex;
-                        // dot product should be negative if the two darts have opposite direction
-                        // we could also put restriction on the angle made by the two darts to prevent
-                        // drastic deformation
-                        assert!(
-                            lhs_vector.dot(&rhs_vector) < T::zero(),
-                            "Dart {} and {} do not have consistent orientation for 2-sewing",
-                            lhs_dart_id,
-                            rhs_dart_id
-                        );
-                    }
-                    (_, _, _, _) => {}
-                }
+                #[rustfmt::skip]
+                if let (
+                    Some(b1l_vertex), Some(l_vertex),
+                    Some(b1r_vertex), Some(r_vertex)
+                ) = tmp {
+                    let lhs_vector = b1l_vertex - l_vertex;
+                    let rhs_vector = b1r_vertex - r_vertex;
+                    // dot product should be negative if the two darts have opposite direction
+                    // we could also put restriction on the angle made by the two darts to prevent
+                    // drastic deformation
+                    assert!(
+                        lhs_vector.dot(&rhs_vector) < T::zero(),
+                        "Dart {} and {} do not have consistent orientation for 2-sewing",
+                        lhs_dart_id,
+                        rhs_dart_id
+                    );
+                };
 
                 // create b1_lhs/rhs darts vertex
                 #[rustfmt::skip]

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1207,11 +1207,14 @@ impl<T: CoordsFloat> CMap2<T> {
         self.betas[rhs_dart_id as usize][0] = 0; // set beta_0(rhs_dart) to NullDart
 
         // --- geometrical update
-        let vertex = self.vertices.remove(self.vertexid(lhs_dart_id)).unwrap();
-        assert!(self.vertices.remove(self.vertexid(rhs_dart_id)).is_none()); // currently necessary
-        let (v1, v2) = Vertex2::split(vertex);
-        self.vertices.insert(self.vertexid(lhs_dart_id), v1);
-        self.vertices.insert(self.vertexid(rhs_dart_id), v2);
+        let b2lid = self.beta::<2>(lhs_dart_id);
+        if b2lid != NULL_DART_ID {
+            let vertex = self.vertices.remove(self.vertexid(b2lid)).unwrap();
+            assert!(self.vertices.remove(self.vertexid(rhs_dart_id)).is_none()); // currently necessary
+            let (v1, v2) = Vertex2::split(vertex);
+            self.vertices.insert(self.vertexid(b2lid), v1);
+            self.vertices.insert(self.vertexid(rhs_dart_id), v2);
+        }
     }
 
     /// 2-unsewing operation.

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -12,8 +12,8 @@
 
 use super::dart::CellIdentifiers;
 use crate::{
-    CoordsFloat, DartData, DartIdentifier, Face, FaceIdentifier, SewPolicy, UnsewPolicy, Vertex2,
-    VertexIdentifier, NULL_DART_ID,
+    AttrCompactVec, CoordsFloat, DartData, DartIdentifier, Face, FaceIdentifier, SewPolicy,
+    UnsewPolicy, Vertex2, VertexIdentifier, NULL_DART_ID,
 };
 
 use std::collections::BTreeSet;
@@ -255,7 +255,7 @@ const CMAP2_BETA: usize = 3;
 #[cfg_attr(feature = "utils", derive(Clone))]
 pub struct CMap2<T: CoordsFloat> {
     /// List of vertices making up the represented mesh
-    vertices: Vec<Vertex2<T>>,
+    vertices: AttrCompactVec<Vertex2<T>>,
     /// List of free vertex identifiers, i.e. empty spots
     /// in the current vertex list
     unused_vertices: BTreeSet<VertexIdentifier>,
@@ -303,11 +303,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// See [CMap2] example.
     ///
     pub fn new(n_darts: usize, n_vertices: usize) -> Self {
-        let vertices = vec![Vertex2::default(); n_vertices];
         let betas = vec![[0; CMAP2_BETA]; n_darts + 1];
 
         Self {
-            vertices,
+            vertices: AttrCompactVec::new(n_darts),
             unused_vertices: BTreeSet::new(),
             faces: Vec::with_capacity(n_darts / 3),
             dart_data: DartData::new(n_darts),
@@ -450,7 +449,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// See [CMap2] example.
     ///
     pub fn vertex(&self, vertex_id: VertexIdentifier) -> &Vertex2<T> {
-        &self.vertices[vertex_id as usize]
+        &self.vertices.get(vertex_id).unwrap()
     }
 
     /// Fetch face structure associated to a given identifier.
@@ -767,10 +766,13 @@ impl<T: CoordsFloat> CMap2<T> {
     /// See [CMap2] example.
     ///
     pub fn add_vertex(&mut self, vertex: Option<Vertex2<T>>) -> VertexIdentifier {
+        unimplemented!()
+        /*
         let new_id = self.n_vertices as VertexIdentifier;
         self.n_vertices += 1;
         self.vertices.push(vertex.unwrap_or_default());
         new_id
+         */
     }
 
     /// Add multiple vertices to the combinatorial map.
@@ -789,11 +791,14 @@ impl<T: CoordsFloat> CMap2<T> {
     /// See [CMap2] example.
     ///
     pub fn add_vertices(&mut self, n_vertices: usize) -> VertexIdentifier {
+        unimplemented!()
+        /*
         let new_id = self.n_vertices as VertexIdentifier;
         self.n_vertices += n_vertices;
         self.vertices
             .extend((0..n_vertices).map(|_| Vertex2::default()));
         new_id
+         */
     }
 
     /// Insert a vertex in the combinatorial map.
@@ -882,11 +887,8 @@ impl<T: CoordsFloat> CMap2<T> {
         vertex_id: VertexIdentifier,
         vertex: impl Into<Vertex2<T>>,
     ) -> Result<(), CMapError> {
-        if let Some(val) = self.vertices.get_mut(vertex_id as usize) {
-            *val = vertex.into();
-            return Ok(());
-        }
-        Err(CMapError::VertexOOB)
+        self.vertices.set(vertex_id, vertex.into());
+        Ok(())
     }
 
     /// Set the values of the *β<sub>i</sub>* function of a dart.


### PR DESCRIPTION
# Description

Replace the current vertex storage (`Vec<Vertex2`) by the structure implemented in #34. The implementation is currently 
hardcoded into `CMap2` but the user should eventually be able to add its own attributes.

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] Refactor

## Other

...

## Necessary follow-up

...

## Mentions

...