### PR TITLE
ci: add test coverage computation & upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,7 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: Install grcov
         run: cargo install grcov
+      - uses: Swatinem/rust-cache@v2
       # generate raw coverage data
       # excluding the benchmark / example crates to remove some bias
       - name: Build code

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,15 +41,16 @@ jobs:
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
       # generate lcov file using grcov
       - name: Run grcov
-        run: grcov . \
-          --binary-path ./target/debug/ \
-          -s . \
-          -t lcov \
-          --branch \
-          --ignore-not-existing \
-          --ignore '../*' \
-          --ignore "/*" \
-          -o target/coverage/tests.lcov
+        run: |
+          grcov . \
+            --binary-path ./target/debug/ \
+            -s . \
+            -t lcov \
+            --branch \
+            --ignore-not-existing \
+            --ignore '../*' \
+            --ignore "/*" \
+            -o target/coverage/tests.lcov
       # upload results
       - name: Upload reports to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,59 @@
+name: codecov
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: 1
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      # install requirements
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+      - name: Install grcov
+        run: cargo install grcov
+      # generate raw coverage data
+      # excluding the benchmark / example crates to remove some bias
+      - name: Build code
+        run: cargo build --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples
+        env:
+          RUSTFLAGS: "-Cinstrument-coverage"
+          LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
+      - name: Run tests
+        run: cargo test --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples
+        env:
+          RUSTFLAGS: "-Cinstrument-coverage"
+          LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
+      # generate lcov file using grcov
+      - name: Run grcov
+        run: grcov . \
+          --binary-path ./target/debug/deps/ \
+          -s . \
+          -t lcov \
+          --branch \
+          --ignore-not-existing \
+          --ignore '../*' \
+          --ignore "/*" \
+          -o target/coverage/tests.lcov
+      # upload results
+      - name: Upload reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/tests.lcov
+          slug: LIHPC-Computational-Geometry/honeycomb

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       # generate lcov file using grcov
       - name: Run grcov
         run: grcov . \
-          --binary-path ./target/debug/deps/ \
+          --binary-path ./target/debug/ \
           -s . \
           -t lcov \
           --branch \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,11 +50,11 @@ jobs:
             --ignore-not-existing \
             --ignore '../*' \
             --ignore "/*" \
-            -o target/coverage/tests.lcov
+            -o target/tests.lcov
       # upload results
       - name: Upload reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/coverage/tests.lcov
+          files: target/tests.lcov
           slug: LIHPC-Computational-Geometry/honeycomb

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Check Format
         run: cargo fmt -- --check
   clippy:
@@ -31,6 +32,7 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Run Clippy
         run: cargo clippy --features ${{ matrix.features }} -- -D warnings
   tests:
@@ -45,5 +47,6 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Run Tests
         run: cargo test --features ${{ matrix.features }} --all

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Cargo.lock
 # ignore csv & svg files in root directory
 /*.csv
 /*.svg
+
+# ignore coverage-related files
+*.profraw
+*.lcov

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Rust Tests](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml/badge.svg)](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml)
 [![Documentation](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/doc.yml/badge.svg)][UG]
 [![Build Status](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/build.yml/badge.svg)](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/build.yml)
+[![codecov](https://codecov.io/github/LIHPC-Computational-Geometry/honeycomb/graph/badge.svg?token=QSN0TWFXO1)](https://codecov.io/github/LIHPC-Computational-Geometry/honeycomb)
 
 Honeycomb aims to provide a safe, efficient and scalable implementation of
 combinatorial maps for meshing applications. More specifically, the goal is


### PR DESCRIPTION
# Description

Add a new workflow to compute the test coverage of Rust code. The data is compiled into an `lcov` file & uploaded to codecov for hosting.

## Scope

- [x] CI

## Type of change

- [x] New feature(s)
- [x] Fix: closes #8 

## Other

...

## Necessary follow-up

...

## Mentions

...