### PR TITLE
doc: update public items' documentation entries

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -23,10 +23,14 @@ use num::ToPrimitive;
 ///
 /// # Example
 ///
-/// todo
+/// **Currently, this type is not meant to be used directly** when operating on combinatorial maps,
+/// but it is kept public because it should eventually be part of the map building system where
+/// the user will add its own attributes and choose how they are stored. As such, no example
+/// is provided.
 ///
 #[cfg_attr(feature = "utils", derive(Clone))]
 pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
+    /// Inner storage.
     data: Vec<Option<T>>,
 }
 
@@ -48,11 +52,18 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
         }
     }
 
+    /// Extend the inner vector's length
+    ///
+    /// # Arguments
+    ///
+    /// - `length: usize` -- number of `None` instances to append to the current storage.
+    ///
     pub fn extend(&mut self, length: usize) {
         self.data.extend((0..length).map(|_| None));
     }
 
-    pub fn n_vertices(&self) -> usize {
+    /// Return the number of stored attributes (i.e. number of `Some(_)` instances)
+    pub fn n_attributes(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count()
     }
 
@@ -178,14 +189,17 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
 
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrSparseVec<T> {
+    /// Return the amount of space allocated for the storage.
     pub fn allocated_size(&self) -> usize {
         self.data.capacity() * std::mem::size_of::<Option<T>>()
     }
 
+    /// Return the total amount of space used by the storage.
     pub fn effective_size(&self) -> usize {
         self.data.len() * std::mem::size_of::<Option<T>>()
     }
 
+    /// Return the amount of space used by valid entries of the storage.
     pub fn used_size(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count() * std::mem::size_of::<Option<T>>()
     }
@@ -201,21 +215,39 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrSparseVec<T> {
 ///
 /// # Generics
 ///
-/// - `T: AttributeBind + AttributeUpdate + Default` -- Type of the stored attributes. The
-/// `Default` implementation is required in order to create dummy values for unused slots.
+/// - `T: AttributeBind + AttributeUpdate + Clone` -- Type of the stored attributes. The
+/// `Clone` implementation is required in order to return copied values & invalidate internal
+/// storage slot.
 ///
 /// # Example
 ///
-/// todo
+/// **Currently, this type is not meant to be used directly** when operating on combinatorial maps,
+/// but it is kept public because it should eventually be part of the map building system where
+/// the user will add its own attributes and choose how they are stored. As such, no example
+/// is provided.
 ///
 #[cfg_attr(feature = "utils", derive(Clone))]
 pub struct AttrCompactVec<T: AttributeBind + AttributeUpdate + Clone> {
+    /// Tracker of unused internal slots.
     unused_data_slots: Vec<usize>,
+    /// Map between attribute index and internal index.
     index_map: Vec<Option<usize>>,
+    /// Inner storage.
     data: Vec<T>,
 }
 
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
+    /// Constructor
+    ///
+    /// # Arguments
+    ///
+    /// - `n_ids: usize` -- Upper bound of IDs used to index the attribute's values (in practice,
+    /// the number of darts).
+    ///
+    /// # Return
+    ///
+    /// Return a "value-empty" [AttrSparseVec] object.
+    ///
     pub fn new(n_ids: usize) -> Self {
         Self {
             unused_data_slots: Vec::new(),
@@ -224,22 +256,74 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
         }
     }
 
+    /// Extend the inner vector's length
+    ///
+    /// # Arguments
+    ///
+    /// - `length: usize` -- number of `None` instances to append to the current storage.
+    ///
     pub fn extend(&mut self, length: usize) {
         self.index_map.extend((0..length).map(|_| None));
     }
 
-    pub fn n_vertices(&self) -> usize {
+    /// Return the number of stored attributes in the internal storage.
+    pub fn n_attributes(&self) -> usize {
         self.data.len()
     }
 
+    /// Getter
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return an `Option` that may contain a reference to the value associated to `index`, if
+    /// it exists.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn get(&self, index: T::IdentifierType) -> Option<&T> {
         self.index_map[index.to_usize().unwrap()].map(|idx| &self.data[idx])
     }
 
+    /// Getter
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return an `Option` that may contain a mutable reference to the value associated to `index`,
+    /// if it exists.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn get_mut(&mut self, index: T::IdentifierType) -> Option<&mut T> {
         self.index_map[index.to_usize().unwrap()].map(|idx| &mut self.data[idx])
     }
 
+    /// Setter
+    ///
+    /// Set the value of an element at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Panic
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn set(&mut self, index: T::IdentifierType, val: T) {
         if let Some(idx) = self.index_map[index.to_usize().unwrap()] {
             // internal index is defined => there should be associated data
@@ -255,6 +339,22 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
         }
     }
 
+    /// Setter
+    ///
+    /// Insert a value at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Panic
+    ///
+    /// The method may panic if:
+    /// - **there is already a value associated to the specified index**
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn insert(&mut self, index: T::IdentifierType, val: T) {
         let idx = &mut self.index_map[index.to_usize().unwrap()];
         assert!(idx.is_none());
@@ -267,6 +367,23 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
         };
     }
 
+    /// Setter
+    ///
+    /// Replace the value of an element at a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    /// - `val: T` -- Attribute value.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return an option containing the old value if it existed.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn replace(&mut self, index: T::IdentifierType, val: T) -> Option<T> {
         let idx = &self.index_map[index.to_usize().unwrap()];
         assert!(idx.is_some());
@@ -274,6 +391,21 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
         Some(self.data.swap_remove(idx.unwrap()))
     }
 
+    /// Remove an item from the storage and return it
+    ///
+    /// # Arguments
+    ///
+    /// - `index: T::IdentifierType` -- Cell index.
+    ///
+    /// # Return / Panic
+    ///
+    /// Return the item associated to the specified index. Note that the method will not panic if
+    /// there was not one, it will simply return `None`.
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    ///
     pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
         self.index_map.push(None);
         if let Some(tmp) = self.index_map.swap_remove(index.to_usize().unwrap()) {
@@ -286,18 +418,21 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
 
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
+    /// Return the amount of space allocated for the storage.
     pub fn allocated_size(&self) -> usize {
         self.unused_data_slots.capacity() * std::mem::size_of::<usize>()
             + self.index_map.capacity() * std::mem::size_of::<Option<usize>>()
             + self.data.capacity() * std::mem::size_of::<T>()
     }
 
+    /// Return the total amount of space used by the storage.
     pub fn effective_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.len() * std::mem::size_of::<Option<usize>>()
             + self.data.len() * std::mem::size_of::<T>()
     }
 
+    /// Return the amount of space used by valid entries of the storage.
     pub fn used_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.iter().filter(|val| val.is_some()).count()

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -73,9 +73,11 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return a reference to the value indexed by `index`.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -91,9 +93,11 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return a mutable reference to the value indexed by `index`.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -112,7 +116,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -131,7 +135,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// The method may panic if:
     /// - **there is already a value associated to the specified index**
@@ -153,9 +157,11 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return an option containing the old value if it existed.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -172,10 +178,12 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return the item associated to the specified index. Note that the method will not panic if
     /// there was not one, it will simply return `None`.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -277,10 +285,12 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return an `Option` that may contain a reference to the value associated to `index`, if
     /// it exists.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -296,10 +306,12 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return an `Option` that may contain a mutable reference to the value associated to `index`,
     /// if it exists.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -318,7 +330,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -348,7 +360,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// The method may panic if:
     /// - **there is already a value associated to the specified index**
@@ -376,9 +388,11 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - `index: T::IdentifierType` -- Cell index.
     /// - `val: T` -- Attribute value.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return an option containing the old value if it existed.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
@@ -397,10 +411,12 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// - `index: T::IdentifierType` -- Cell index.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return the item associated to the specified index. Note that the method will not panic if
     /// there was not one, it will simply return `None`.
+    ///
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -1,7 +1,7 @@
 //! Attribute storage structures
 //!
 //! This module contains all code used to describe custom collections used to store attributes
-//! (see [AttributeBind], [AttributeUpdate]).
+//! (see [`AttributeBind`], [`AttributeUpdate`]).
 
 // ------ IMPORTS
 
@@ -44,7 +44,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// # Return
     ///
-    /// Return a [AttrSparseVec] object full of `None`.
+    /// Return a [`AttrSparseVec`] object full of `None`.
     ///
     pub fn new(n_ids: usize) -> Self {
         Self {
@@ -246,7 +246,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// # Return
     ///
-    /// Return a "value-empty" [AttrSparseVec] object.
+    /// Return a "value-empty" [`AttrSparseVec`] object.
     ///
     pub fn new(n_ids: usize) -> Self {
         Self {

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -1,8 +1,6 @@
-//! Module short description
+//! Attribute modeling code
 //!
-//! Should you interact with this module directly?
-//!
-//! Content description if needed
+//! This module contains all code related to generic attribute modelling and handling.
 
 // ------ MODULE DECLARATIONS
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -9,14 +9,14 @@ use crate::OrbitPolicy;
 
 // ------ CONTENT
 
-/// Generic attribute trait for logical behavior
+/// Generic attribute trait for logical behavior description
 ///
 /// This trait can be implemented for a given attribute in order to define the behavior to
 /// follow when (un)sewing operations result in an update of the attribute.
 ///
 /// # Example
 ///
-/// For an intensive property of a system (e.g. a temperature), a dummy implementation would look
+/// For an intensive property of a system (e.g. a temperature), an implementation would look
 /// like this:
 ///
 /// ```rust

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -79,7 +79,7 @@ pub trait AttributeUpdate: Sized {
 ///
 /// # Example
 ///
-/// Using the same context as the for the [AttributeUpdate] example, we can associate temperature
+/// Using the same context as the for the [`AttributeUpdate`] example, we can associate temperature
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust
@@ -102,7 +102,7 @@ pub trait AttributeBind: Sized {
     /// Identifier type of the entity the attribute is bound to.
     type IdentifierType: num::ToPrimitive;
 
-    /// Return an [OrbitPolicy] that can be used to identify the kind of topological entity to
+    /// Return an [`OrbitPolicy`] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
     fn binds_to<'a>() -> OrbitPolicy<'a>;
 }

--- a/honeycomb-core/src/cells/collections.rs
+++ b/honeycomb-core/src/cells/collections.rs
@@ -1,6 +1,7 @@
-//! i-cell collection structures
+//! i-cell collection implementation
 //!
-//!
+//! This module contains all code used to model collection structures for i-cell identifiers. The
+//! need for a specific structure stems from the need to ensure the validity of identifiers.
 
 // ------ IMPORTS
 

--- a/honeycomb-core/src/cells/collections.rs
+++ b/honeycomb-core/src/cells/collections.rs
@@ -13,7 +13,7 @@ macro_rules! collection_constructor {
     ($coll: ident, $idty: ty) => {
         impl<'a, T: CoordsFloat> $coll<'a, T> {
             /// Constructor
-            pub fn new(_: &'a CMap2<T>, ids: impl IntoIterator<Item = $idty>) -> Self {
+            pub(crate) fn new(_: &'a CMap2<T>, ids: impl IntoIterator<Item = $idty>) -> Self {
                 Self {
                     lifetime_indicator: std::marker::PhantomData::default(),
                     identifiers: ids.into_iter().collect(),

--- a/honeycomb-core/src/cells/collections.rs
+++ b/honeycomb-core/src/cells/collections.rs
@@ -1,8 +1,6 @@
-//! Module short description
+//! i-cell collection structures
 //!
-//! Should you interact with this module directly?
 //!
-//! Content description if needed
 
 // ------ IMPORTS
 
@@ -13,6 +11,7 @@ use crate::{CMap2, CoordsFloat};
 macro_rules! collection_constructor {
     ($coll: ident, $idty: ty) => {
         impl<'a, T: CoordsFloat> $coll<'a, T> {
+            /// Constructor
             pub fn new(_: &'a CMap2<T>, ids: impl IntoIterator<Item = $idty>) -> Self {
                 Self {
                     lifetime_indicator: std::marker::PhantomData::default(),
@@ -30,10 +29,27 @@ macro_rules! collection_constructor {
 /// This is used for better control over memory usage and ID encoding.
 pub type VertexIdentifier = u32;
 
+/// Null value for vertex identifiers
 pub const NULL_VERTEX_ID: VertexIdentifier = 0;
 
+/// Vertex ID collection
+///
+/// # Generics
+///
+/// - `'a` -- Lifetime of a reference to the associated map.
+/// - `T: CoordsFloat` -- Generic of the associated map.
+///
+/// # Example
+///
+/// See the [`CMap2`] quickstart example.
+///
 pub struct VertexCollection<'a, T: CoordsFloat> {
+    /// Lifetime holder
+    ///
+    /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
+    /// if the original map is used in a mutable context.
     lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    /// Collection of vertex identifiers.
     pub identifiers: Vec<VertexIdentifier>,
 }
 
@@ -46,10 +62,27 @@ collection_constructor!(VertexCollection, VertexIdentifier);
 /// This is used for better control over memory usage and ID encoding.
 pub type EdgeIdentifier = u32;
 
+/// Null value for edge identifiers
 pub const NULL_EDGE_ID: EdgeIdentifier = 0;
 
+/// Edge ID collection
+///
+/// # Generics
+///
+/// - `'a` -- Lifetime of a reference to the associated map.
+/// - `T: CoordsFloat` -- Generic of the associated map.
+///
+/// # Example
+///
+/// See the [`CMap2`] quickstart example.
+///
 pub struct EdgeCollection<'a, T: CoordsFloat> {
+    /// Lifetime holder
+    ///
+    /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
+    /// if the original map is used in a mutable context.
     lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    /// Collection of vertex identifiers.
     pub identifiers: Vec<EdgeIdentifier>,
 }
 
@@ -62,10 +95,27 @@ collection_constructor!(EdgeCollection, EdgeIdentifier);
 /// This is used for better control over memory usage and ID encoding.
 pub type FaceIdentifier = u32;
 
+/// Null value for face identifiers
 pub const NULL_FACE_ID: FaceIdentifier = 0;
 
+/// Face ID collection
+///
+/// # Generics
+///
+/// - `'a` -- Lifetime of a reference to the associated map.
+/// - `T: CoordsFloat` -- Generic of the associated map.
+///
+/// # Example
+///
+/// See the [`CMap2`] quickstart example.
+///
 pub struct FaceCollection<'a, T: CoordsFloat> {
+    /// Lifetime holder
+    ///
+    /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
+    /// if the original map is used in a mutable context.
     lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    /// Collection of vertex identifiers.
     pub identifiers: Vec<FaceIdentifier>,
 }
 
@@ -78,4 +128,5 @@ collection_constructor!(FaceCollection, FaceIdentifier);
 /// This is used for better control over memory usage and ID encoding.
 pub type VolumeIdentifier = u32;
 
+/// Null value for volume identifiers
 pub const NULL_VOLUME_ID: VolumeIdentifier = 0;

--- a/honeycomb-core/src/cells/mod.rs
+++ b/honeycomb-core/src/cells/mod.rs
@@ -14,4 +14,5 @@ pub mod orbits;
 /// This is used for better control over memory usage and ID encoding.
 pub type DartIdentifier = u32;
 
+/// Null value for dart identifiers
 pub const NULL_DART_ID: DartIdentifier = 0;

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -118,6 +118,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
         }
     }
 
+    /// Return a boolean indicating whether the starting dart is isolated or not
     pub fn is_isolated(&self) -> bool {
         // this is boolean tells us if the orbit is either:
         // a) unaltered (pending.len() == 1)

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -49,7 +49,7 @@ pub enum OrbitPolicy<'a> {
 /// - we look at the images of the current dart through all beta functions,
 /// adding those to a queue, before moving on to the next dart.
 /// - we apply the beta functions in their specified order (in the case of a
-/// custom [OrbitPolicy]); This guarantees a consistent and predictable result.
+/// custom [`OrbitPolicy`]); This guarantees a consistent and predictable result.
 ///
 /// Both of these points allow the structure to be used for sewing operations
 /// at the cost of some performance (non-trivial parallelization & sequential
@@ -59,7 +59,7 @@ pub enum OrbitPolicy<'a> {
 ///
 /// # Example
 ///
-/// See [CMap2] example.
+/// See [`CMap2`] example.
 ///
 pub struct Orbit2<'a, T: CoordsFloat> {
     /// Reference to the map containing the beta functions used in the BFS.
@@ -92,7 +92,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     ///
     /// # Example
     ///
-    /// See [CMap2] example.
+    /// See [`CMap2`] example.
     ///
     pub fn new(
         map_handle: &'a CMap2<T>,

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeSet, VecDeque};
 
 // ------ CONTENT
 
-/// Enum used to model beta functions defining the search.
+/// Orbit search policy enum.
 ///
 /// This is used to define special cases of orbits that are often used in
 /// algorithms. These special cases correspond to *i-cells*.
@@ -28,13 +28,13 @@ pub enum OrbitPolicy<'a> {
 
 /// Generic 2D orbit implementation
 ///
-/// This structure only contains meta-data about the orbit in its initial
-/// state. All the darts making up the orbit are computed when using the
-/// methods that come with the [Iterator] implementation.
+/// This structure only contains meta-data about the orbit in its initial state. All the darts
+/// making up the orbit are computed when using the methods that come with the [Iterator]
+/// implementation.
 ///
-/// It is not currently possible to iterate over references, the orbit has
-/// to be consumed for its result to be used. This is most likely the best
-/// behavior
+/// It is not currently possible to iterate over references, the orbit has to be consumed for its
+/// result to be used. This is most likely the best behavior since orbits should be consumed upon
+/// traversal to avoid inconsistencies created by a later mutable operation on the map.
 ///
 /// # Generics
 ///
@@ -43,17 +43,16 @@ pub enum OrbitPolicy<'a> {
 ///
 /// # The search algorithm
 ///
-/// The search algorithm used to establish the list of dart included in the
-/// orbit is a [Breadth-first search algorithm][WIKIBFS]. This means that:
+/// The search algorithm used to establish the list of dart included in the orbit is a
+/// [Breadth-first search algorithm][WIKIBFS]. This means that:
 ///
 /// - we look at the images of the current dart through all beta functions,
 /// adding those to a queue, before moving on to the next dart.
 /// - we apply the beta functions in their specified order (in the case of a
 /// custom [`OrbitPolicy`]); This guarantees a consistent and predictable result.
 ///
-/// Both of these points allow the structure to be used for sewing operations
-/// at the cost of some performance (non-trivial parallelization & sequential
-/// consistency requirements).
+/// Both of these points allow the structure to be used for sewing operations at the cost of some
+/// performance (non-trivial parallelization & sequential consistency requirements).
 ///
 /// [WIKIBFS]: https://en.wikipedia.org/wiki/Breadth-first_search
 ///

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -82,9 +82,11 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     /// - `orbit_policy: OrbitPolicy<'a>` -- Policy used by the orbit for the BFS.
     /// - `dart: DartIdentifier` -- Dart of which the structure will compute the orbit.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return an [Orbit2] structure that can be iterated upon to retrieve the orbit's darts.
+    ///
+    /// # Panics
     ///
     /// The method may panic if no beta index is passed along the custom policy. Additionally,
     /// if an invalid beta index is passed through the custom policy (e.g. `3` for a 2D map),

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -14,18 +14,24 @@
 //! - `utils` -- provides additionnal methods for benchmarking and debugging
 //! - `single_precision` -- uses `f32` instead of `f64` for coordinates representation in tests
 
+// ------ CUSTOM LINTS
+
+// --- some though love for the code
+#![warn(missing_docs)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::must_use_candidate)]
+// --- some tolerance
 #![allow(clippy::similar_names)]
+#![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cast_possible_truncation)]
+// --- some to work through later
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::if_not_else)]
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::should_panic_without_expect)]
 #![allow(clippy::float_cmp)]
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -24,6 +24,8 @@
 #![allow(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::return_self_not_must_use)]
 
 // ------ MODULE DECLARATIONS
 mod attributes;

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -14,8 +14,18 @@
 //! - `utils` -- provides additionnal methods for benchmarking and debugging
 //! - `single_precision` -- uses `f32` instead of `f64` for coordinates representation in tests
 
-// ------ MODULE DECLARATIONS
+#![warn(clippy::pedantic)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::match_same_arms)]
+#![allow(clippy::if_not_else)]
+#![allow(clippy::range_plus_one)]
+#![allow(clippy::semicolon_if_nothing_returned)]
+#![allow(clippy::needless_for_each)]
+#![allow(clippy::needless_pass_by_value)]
 
+// ------ MODULE DECLARATIONS
 mod attributes;
 mod cells;
 mod spatial_repr;

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -26,6 +26,8 @@
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::should_panic_without_expect)]
+#![allow(clippy::float_cmp)]
 
 // ------ MODULE DECLARATIONS
 mod attributes;

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -198,7 +198,7 @@ impl<T: CoordsFloat> Index<usize> for Coords2<T> {
         match index {
             0 => &self.x,
             1 => &self.y,
-            i => panic!("cannot index a 2D vector with value {i}"),
+            i => panic!("{}", format!("cannot index a 2D vector with value {i}")),
         }
     }
 }
@@ -208,7 +208,7 @@ impl<T: CoordsFloat> IndexMut<usize> for Coords2<T> {
         match index {
             0 => &mut self.x,
             1 => &mut self.y,
-            i => panic!("cannot index a 2D vector with value {i}"),
+            i => panic!("{}", format!("cannot index a 2D vector with value {i}")),
         }
     }
 }

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -29,7 +29,7 @@ pub enum CoordsError {
 /// 2-dimensional coordinates structure
 ///
 /// The floating type used for coordinate representation is determined by the user. For tests, it
-/// can be controled using features and the [FloatType] alias.
+/// can be controled using features and the [`FloatType`] alias.
 ///
 /// # Generics
 ///

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -17,7 +17,7 @@ use std::ops::{
 
 // ------ CONTENT
 
-/// Coordinates-related error enum
+/// Coordinates-level error enum
 #[derive(Debug)]
 pub enum CoordsError {
     /// Error during the computation of the unit directional vector.

--- a/honeycomb-core/src/spatial_repr/mod.rs
+++ b/honeycomb-core/src/spatial_repr/mod.rs
@@ -17,8 +17,14 @@ use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "single_precision")] {
+        /// Floating-point type alias.
+        ///
+        /// This is mostly used to run tests using both `f64` and `f32`.
         pub type FloatType = f32;
     } else {
+        /// Floating-point type alias.
+        ///
+        /// This is mostly used to run tests using both `f64` and `f32`.
         pub type FloatType = f64;
     }
 }

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains all code used to model vectors as wrappers of a common
 //! type ([Coords2]).
-//!
 
 // ------ IMPORTS
 

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -124,6 +124,11 @@ impl<T: CoordsFloat> Vector2<T> {
     /// Return a [Vector2] indicating the direction of `self`. The norm of the returned
     /// struct is equal to one.
     ///
+    /// # Errors
+    ///
+    /// This method will panic if called on a `Vector2` with a norm equal to zero, i.e. a null
+    /// `Vector2`.
+    ///
     /// # Example
     ///
     /// See [Vector2] example.
@@ -143,6 +148,11 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// Return a [Vector2] indicating the direction of the normal to `self`. The norm of the
     /// returned struct is equal to one.
+    ///
+    /// # Panics
+    ///
+    /// Because the returned `Vector2` is normalized, this method may panic under the same
+    /// condition as [`Self::unit_dir`].
     ///
     /// # Example
     ///

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -94,6 +94,11 @@ impl<T: CoordsFloat> Vertex2<T> {
     ///
     /// Return the mid-point as a new [Vertex2] object.
     ///
+    /// # Panics
+    ///
+    /// This function may panic if it cannot initialize an object `T: CoordsFloat` from the value
+    /// `2.0`. The chance of this happening when using `T = f64` or `T = f32` is most likely zero.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -104,6 +109,7 @@ impl<T: CoordsFloat> Vertex2<T> {
     ///
     /// assert_eq!(Vertex2::average(&origin, &far_far_away), Vertex2::from((1.0, 1.0)));
     /// ```
+    ///
     pub fn average(lhs: &Vertex2<T>, rhs: &Vertex2<T>) -> Vertex2<T> {
         let two = T::from(2.0).unwrap();
         Vertex2::from(((lhs.x() + rhs.x()) / two, (lhs.y() + rhs.y()) / two))

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -2,7 +2,6 @@
 //!
 //! This module contains all code used to model vertices as wrappers of a common
 //! type ([Coords2]).
-//!
 
 // ------ IMPORTS
 

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -3,7 +3,7 @@
 //! This module contains code for the two main structures provided
 //! by the crate:
 //!
-//! - [CMap2], a 2D combinatorial map implementation
+//! - [`CMap2`], a 2D combinatorial map implementation
 //!
 //! The definitions are re-exported, direct interaction with this module
 //! should be minimal, if existing at all.
@@ -69,7 +69,7 @@ const CMAP2_BETA: usize = 3;
 /// Note that we encode *β<sub>0</sub>* as the inverse function of *β<sub>1</sub>*.
 /// This is extremely useful (read *required*) to implement correct and efficient
 /// i-cell computation. Additionally, while *β<sub>0</sub>* can be accessed using
-/// the [Self::beta] method, we do not define 0-sew or 0-unsew operations.
+/// the [`Self::beta`] method, we do not define 0-sew or 0-unsew operations.
 ///
 /// # Generics
 ///
@@ -80,7 +80,7 @@ const CMAP2_BETA: usize = 3;
 /// The following example goes over multiple operations on the mesh in order
 /// to demonstrate general usage of the structure and its methods.
 ///
-/// ![CMAP2_EXAMPLE](../../images/CMap2Example.svg)
+/// ![`CMAP2_EXAMPLE`](../../images/CMap2Example.svg)
 ///
 /// Note that the map we operate on has no boundaries. In addition to the different
 /// operations realized at each step, we insert a few assertions to demonstrate the
@@ -198,7 +198,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Example
     ///
-    /// See [CMap2] example.
+    /// See [`CMap2`] example.
     ///
     pub fn new(n_darts: usize) -> Self {
         Self {
@@ -300,7 +300,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This method may panic if:
     ///
     /// - The dart is not *i*-free for all *i*.
-    /// - The dart is already marked as unused (Refer to [Self::remove_vertex] documentation for
+    /// - The dart is already marked as unused (Refer to [`Self::remove_vertex`] documentation for
     ///   a detailed breakdown of this choice).
     ///
     pub fn remove_free_dart(&mut self, dart_id: DartIdentifier) {
@@ -384,7 +384,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return / Panic
     ///
-    /// Return a boolean indicating if *dart* is i-free, i.e. *β<sub>i</sub>(dart) = NullDart*.
+    /// Return a boolean indicating if *dart* is i-free, i.e. *β<sub>i</sub>(dart) = `NullDart`*.
     ///
     /// The function will panic if *I* is not 0, 1 or 2.
     ///
@@ -556,7 +556,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return / Panic
     ///
-    /// Return a [VertexCollection] object containing a list of vertex identifiers, whose validity
+    /// Return a [`VertexCollection`] object containing a list of vertex identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
     pub fn fetch_vertices(&self) -> VertexCollection<T> {
@@ -585,7 +585,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return / Panic
     ///
-    /// Return an [EdgeCollection] object containing a list of edge identifiers, whose validity
+    /// Return an [`EdgeCollection`] object containing a list of edge identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
     pub fn fetch_edges(&self) -> EdgeCollection<T> {
@@ -615,7 +615,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return / Panic
     ///
-    /// Return a [FaceCollection] object containing a list of face identifiers, whose validity
+    /// Return a [`FaceCollection`] object containing a list of face identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
     pub fn fetch_faces(&self) -> FaceCollection<T> {
@@ -658,7 +658,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `policy: SewPolicy` -- Geometrical sewing policy to follow.
     ///
     /// After the sewing operation, these darts will verify
-    /// *β<sub>1</sub>(lhs_dart) = rhs_dart*. The *β<sub>0</sub>*
+    /// *β<sub>1</sub>(`lhs_dart`) = `rhs_dart`*. The *β<sub>0</sub>*
     /// function is also updated.
     ///
     /// # Panics
@@ -707,7 +707,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `policy: SewPolicy` -- Geometrical sewing policy to follow.
     ///
     /// After the sewing operation, these darts will verify
-    /// *β<sub>2</sub>(lhs_dart) = rhs_dart* and *β<sub>2</sub>(rhs_dart) = lhs_dart*.
+    /// *β<sub>2</sub>(`lhs_dart`) = `rhs_dart`* and *β<sub>2</sub>(`rhs_dart`) = `lhs_dart`*.
     ///
     /// # Panics
     ///

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -80,7 +80,7 @@ const CMAP2_BETA: usize = 3;
 /// The following example goes over multiple operations on the mesh in order
 /// to demonstrate general usage of the structure and its methods.
 ///
-/// ![`CMAP2_EXAMPLE`](../../images/CMap2Example.svg)
+/// ![`CMAP2_EXAMPLE`](../images/CMap2Example.svg)
 ///
 /// Note that the map we operate on has no boundaries. In addition to the different
 /// operations realized at each step, we insert a few assertions to demonstrate the

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -986,7 +986,7 @@ impl<T: CoordsFloat> CMap2<T> {
 impl<T: CoordsFloat> CMap2<T> {
     /// Return the current number of vertices.
     pub fn n_vertices(&self) -> usize {
-        self.vertices.n_vertices()
+        self.vertices.n_attributes()
     }
 
     /// Fetch vertex value associated to a given identifier.

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -22,7 +22,7 @@ use std::{fs::File, io::Write};
 
 // ------ CONTENT
 
-/// Error-modeling enum
+/// Map-level error enum
 ///
 /// This enum is used to describe all non-panic errors that can occur when operating on a map.
 #[derive(Debug, PartialEq)]

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -295,7 +295,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// - `dart_id: DartIdentifier` -- Identifier of the dart to remove.
     ///
-    /// # Panic
+    /// # Panics
     ///
     /// This method may panic if:
     ///
@@ -332,10 +332,12 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `const I: u8` -- Index of the beta function. *I* should
     /// be 0, 1 or 2 for a 2D map.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return the identifier of the dart *d* such that *d = β<sub>i</sub>(dart)*. If the returned
     /// value is the null dart (i.e. a dart ID equal to 0), this means that *dart* is i-free.
+    ///
+    /// # Panics
     ///
     /// The method will panic if *I* is not 0, 1 or 2.
     ///
@@ -355,6 +357,8 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// Return the identifier of the dart *d* such that *d = β<sub>i</sub>(dart)*. If the returned
     /// value is the null dart (i.e. a dart ID equal to 0), this means that *dart* is i-free.
+    ///
+    /// # Panics
     ///
     /// The method will panic if *i* is not 0, 1 or 2.
     ///
@@ -428,6 +432,7 @@ impl<T: CoordsFloat> CMap2<T> {
 
 // --- icell-related code
 impl<T: CoordsFloat> CMap2<T> {
+    #[allow(clippy::missing_panics_doc)]
     /// Fetch vertex identifier associated to a given dart.
     ///
     /// # Arguments
@@ -458,6 +463,7 @@ impl<T: CoordsFloat> CMap2<T> {
             .unwrap() as VertexIdentifier
     }
 
+    #[allow(clippy::missing_panics_doc)]
     /// Fetch edge associated to a given dart.
     ///
     /// # Arguments
@@ -486,6 +492,7 @@ impl<T: CoordsFloat> CMap2<T> {
         Orbit2::new(self, OrbitPolicy::Edge, dart_id).min().unwrap() as EdgeIdentifier
     }
 
+    #[allow(clippy::missing_panics_doc)]
     /// Fetch face associated to a given dart.
     ///
     /// # Arguments
@@ -525,11 +532,15 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `const I: u8` -- Dimension of the cell of interest. *I* should be 0 (vertex), 1 (edge) or
     /// 2 (face) for a 2D map.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Returns an [Orbit2] that can be iterated upon to retrieve all dart member of the cell. Note
     /// that **the dart passed as an argument is included as the first element of the returned
     /// orbit**.
+    ///
+    /// # Panics
+    ///
+    /// The method will panic if *I* is not 0, 1 or 2.
     ///
     pub fn i_cell<const I: u8>(&self, dart_id: DartIdentifier) -> Orbit2<T> {
         assert!(I < 3);
@@ -650,7 +661,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// *β<sub>1</sub>(lhs_dart) = rhs_dart*. The *β<sub>0</sub>*
     /// function is also updated.
     ///
-    /// # Return / Panic
+    /// # Panics
     ///
     /// The method may panic if the two darts are not 1-sewable.
     ///
@@ -698,7 +709,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// After the sewing operation, these darts will verify
     /// *β<sub>2</sub>(lhs_dart) = rhs_dart* and *β<sub>2</sub>(rhs_dart) = lhs_dart*.
     ///
-    /// # Return / Panic
+    /// # Panics
     ///
     /// The method may panic if:
     /// - the two darts are not 2-sewable,
@@ -782,9 +793,8 @@ impl<T: CoordsFloat> CMap2<T> {
                     // drastic deformation
                     assert!(
                         lhs_vector.dot(&rhs_vector) < T::zero(),
-                        "Dart {} and {} do not have consistent orientation for 2-sewing",
-                        lhs_dart_id,
-                        rhs_dart_id
+                        "{}",
+                        format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
                     );
                 };
 
@@ -917,6 +927,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
     /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
     ///
+    /// # Panics
+    ///
+    /// This method may panic if `lhs_dart_id` isn't 1-free or `rhs_dart_id` isn't 0-free.
+    ///
     pub fn one_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
         // we could technically overwrite the value, but these assertions
         // makes it easier to assert algorithm correctness
@@ -936,6 +950,10 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
     /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if one of `lhs_dart_id` or `rhs_dart_id` isn't 2-free.
     ///
     pub fn two_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
         // we could technically overwrite the value, but these assertions
@@ -995,9 +1013,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// - `vertex_id: VertexIdentifier` -- Identifier of the given vertex.
     ///
-    /// # Return / Panic
+    /// # Return
     ///
     /// Return a reference to the [Vertex2] associated to the ID.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if no vertex is associated to the specified index.
     ///
     pub fn vertex(&self, vertex_id: VertexIdentifier) -> Vertex2<T> {
         self.vertices.get(vertex_id).unwrap()
@@ -1022,13 +1044,14 @@ impl<T: CoordsFloat> CMap2<T> {
         self.vertices.insert(vertex_id, vertex.into())
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// Remove a vertex from the combinatorial map.
     ///
     /// # Arguments
     ///
     /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to remove.
     ///
-    /// # Return
+    /// # Return / Errors
     ///
     /// This method return a `Result` taking the following values:
     /// - `Ok(v: Vertex2)` -- The vertex was successfully removed & its value was returned
@@ -1041,6 +1064,7 @@ impl<T: CoordsFloat> CMap2<T> {
         Err(CMapError::UndefinedVertex)
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// Try to overwrite the given vertex with a new value.
     ///
     /// # Arguments
@@ -1048,7 +1072,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to replace.
     /// - `vertex: impl<Into<Vertex2>>` -- New value for the vertex.
     ///
-    /// # Return / Panic
+    /// # Return / Errors
     ///
     /// This method return a `Result` taking the following values:
     /// - `Ok(v: Vertex2)` -- The vertex was successfully overwritten & its previous value was
@@ -1113,6 +1137,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ```
     ///
     /// The output data can be visualized using the `memory_usage.py` script.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if, at any point, the program cannot write into the output file.
     ///
     pub fn allocated_size(&self, rootname: &str) {
         let mut file = File::create(rootname.to_owned() + "_allocated.csv").unwrap();
@@ -1187,6 +1215,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ```
     ///
     /// The output data can be visualized using the `memory_usage.py` script.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if, at any point, the program cannot write into the output file.
     ///
     pub fn effective_size(&self, rootname: &str) {
         let mut file = File::create(rootname.to_owned() + "_effective.csv").unwrap();
@@ -1272,6 +1304,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ```
     ///
     /// The output data can be visualized using the `memory_usage.py` script.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if, at any point, the program cannot write into the output file.
     ///
     pub fn used_size(&self, rootname: &str) {
         let mut file = File::create(rootname.to_owned() + "_used.csv").unwrap();

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -839,6 +839,12 @@ impl<T: CoordsFloat> CMap2<T> {
     /// second dart can be obtained through the *β<sub>1</sub>* function. The
     /// *β<sub>0</sub>* function is also updated.
     ///
+    /// # Panics
+    ///
+    /// The method may panic if there's a missing attribute at the splitting step. While the
+    /// implementation could fall back to a simple unlink operation, it probably should have been
+    /// called by the user, instead of unsew, in the first place.
+    ///
     pub fn one_unsew(&mut self, lhs_dart_id: DartIdentifier) {
         let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
         if b2lhs_dart_id != NULL_DART_ID {
@@ -872,6 +878,12 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// Note that we do not need to take two darts as arguments since the
     /// second dart can be obtained through the *β<sub>2</sub>* function.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if there's a missing attribute at the splitting step. While the
+    /// implementation could fall back to a simple unlink operation, it probably should have been
+    /// called by the user, instead of unsew, in the first place.
     ///
     pub fn two_unsew(&mut self, lhs_dart_id: DartIdentifier) {
         let rhs_dart_id = self.beta::<2>(lhs_dart_id);

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -16,7 +16,7 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 
 // ------ CONTENT
 
-/// Generate a [CMap2] representing a mesh made up of squares.
+/// Generate a [`CMap2`] representing a mesh made up of squares.
 ///
 /// This function builds and returns a 2-map representing a square mesh
 /// made of `n_square * n_square` square cells.
@@ -27,11 +27,11 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 ///
 /// ## Generics
 ///
-/// - `const T: CoordsFloat` -- Generic parameter of the returned [CMap2].
+/// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
 ///
 /// # Return / Panic
 ///
-/// Returns a boundary-less [CMap2] of the specified size. The map contains
+/// Returns a boundary-less [`CMap2`] of the specified size. The map contains
 /// `4 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
 /// vertices.
 ///
@@ -130,7 +130,7 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     map
 }
 
-/// Generate a [CMap2] representing a mesh made up of squares split diagonally.
+/// Generate a [`CMap2`] representing a mesh made up of squares split diagonally.
 ///
 /// This function builds and returns a 2-map representing a square mesh
 /// made of `n_square * n_square * 2` triangle cells.
@@ -141,36 +141,15 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 ///
 /// ## Generics
 ///
-/// - `const T: CoordsFloat` -- Generic parameter of the returned [CMap2].
+/// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
 ///
 /// # Return / Panic
 ///
-/// Returns a boundary-less [CMap2] of the specified size. The map contains
+/// Returns a boundary-less [`CMap2`] of the specified size. The map contains
 /// `6 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
 /// vertices.
 ///
-/// # Example
-///
-/// ```
-/// use honeycomb_core::{CMap2, utils::splitsquare_cmap2};
-///
-/// let cmap: CMap2<f64> = splitsquare_cmap2(2);
-/// ```
-///
-/// The above code generates the following map:
-///
-/// ![SPLITSQUARECMAP2](../../images/CMap2SplitSquare.svg)
-///
-/// Note that *β<sub>1</sub>* is only represented in one cell but is defined
-/// Everywhere following the same pattern. Dart indexing is also consistent
-/// with the following rules:
-///
-/// - inside a cell, the first dart is the one on the bottom, pointing towards
-///   the right. Increments (and *β<sub>1</sub>*) follow the trigonometric
-///   orientation.
-/// - cells are ordered from left to right, from the bottom up. The same rule
-///   applies for face IDs.
-///
+/// The indexing follows the same logic described in the documentation of [`square_cmap2`].
 pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     let mut map: CMap2<T> = CMap2::new(6 * n_square.pow(2));
 

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -29,11 +29,16 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 ///
 /// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
 ///
-/// # Return / Panic
+/// # Return
 ///
 /// Returns a boundary-less [`CMap2`] of the specified size. The map contains
 /// `4 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
 /// vertices.
+///
+/// # Panics
+///
+/// If this function panics, this is most likely due to a mistake in implementation in the core
+/// crate.
 ///
 /// # Example
 ///
@@ -57,6 +62,7 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 /// - cells are ordered from left to right, from the bottom up. The same rule
 ///   applies for face IDs.
 ///
+
 pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     let mut map: CMap2<T> = CMap2::new(4 * n_square.pow(2));
 
@@ -143,13 +149,19 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 ///
 /// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
 ///
-/// # Return / Panic
+/// # Return
 ///
 /// Returns a boundary-less [`CMap2`] of the specified size. The map contains
 /// `6 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
 /// vertices.
 ///
 /// The indexing follows the same logic described in the documentation of [`square_cmap2`].
+///
+/// # Panics
+///
+/// If this function panics, this is most likely due to a mistake in implementation in the core
+/// crate.
+///
 pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     let mut map: CMap2<T> = CMap2::new(6 * n_square.pow(2));
 
@@ -336,6 +348,7 @@ mod tests {
         assert_eq!(cmap.beta::<2>(16), 10);
     }
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn splitsquare_cmap2_correctness() {
         let cmap: CMap2<f64> = splitsquare_cmap2(2);

--- a/honeycomb-core/src/utils/mod.rs
+++ b/honeycomb-core/src/utils/mod.rs
@@ -7,7 +7,7 @@
 //! </div>
 //!
 //! This module implements basic utilities used for tests & benchmarking
-//! of the structures & methods implemented in **honeycomb_core**.
+//! of the structures & methods implemented in `honeycomb_core`.
 
 // ------ MODULE DECLARATIONS
 


### PR DESCRIPTION
Go through all the Rust doc of `honeycomb-core` to update entries & fix miscellaneous stuff. Also add `#![warn(clippy::pedantic)]` over the core crate, with some exceptions to work through later. 

## Scope

- [x] Build script: `honeycomb-core`
- [x] Documentation

## Type of change

- [x] Refactor
- [x] Chore
