### PR TITLE
chore: update changelog and manifests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,12 +31,12 @@ jobs:
       # generate raw coverage data
       # excluding the benchmark / example crates to remove some bias
       - name: Build code
-        run: cargo build --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples
+        run: cargo build --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
       - name: Run tests
-        run: cargo test --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples
+        run: cargo test --features utils --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## To be released
 
+...
+
+---
+
+## 0.2.0
+
 **This update contains breaking changes**
 
 ### New features
@@ -66,6 +72,11 @@ aspects of the project</sup>
 - add support for incomplete vertex orbits in `Orbit2` implementation (#36)
 - remove `darts`, `embed` modules and their content (#42)
     - move ID aliases to `cells` and `cells::collections` modules
+- update the `CMap2` quickstart example (#43)
+- change the `CMap2::n_darts` method's return type to be more intuitive (#45)
+    - add the `CMap2::n_unused_darts` method to provide an alternative to the old method
+- remove the `CMap2::set_beta` method because of the lack of valid use case (#45)
+- gate the `CMap2::set_betas` behind the `utils` feature (#45)
 
 #### honeycomb-guide
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ honeycomb-render = { version = "0.2.0", path = "./honeycomb-render" }
 # common
 cfg-if = "1"
 
+# core
+num = "0.4.2"
+
 # benchmarks
 criterion = "0.5.1"
 iai-callgrind = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [workspace]
 
 resolver = "2"
-members = ["honeycomb-benches", "honeycomb-core", "honeycomb-render", "honeycomb-examples"]
+members = [
+    "honeycomb-benches",
+    "honeycomb-core",
+    "honeycomb-render",
+    "honeycomb-examples"
+]
 
 [workspace.package]
 edition = "2021"
@@ -23,18 +28,18 @@ honeycomb-render = { version = "0.2.0", path = "./honeycomb-render" }
 cfg-if = "1"
 
 # benchmarks
-criterion = { version = "0.5.1", features = ["html_reports"] }
+criterion = "0.5.1"
 iai-callgrind = "0.10.2"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = "0.8.5"
 
 # render
-wgpu = "0.19.4"
-winit = "0.29.15"
+bytemuck = "1.15.0"
+cgmath = "0.18.0"
 env_logger = "0.11.3"
 pollster = "0.3.0"
-cgmath = "0.18.0"
-bytemuck = { version = "1.15.0" }
 smaa = "0.13.0"
+wgpu = "0.19.4"
+winit = "0.29.15"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
 [workspace]
 
+resolver = "2"
 members = ["honeycomb-benches", "honeycomb-core", "honeycomb-render", "honeycomb-examples"]
 
-resolver = "2"
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+version = "0.2.0"
+homepage = "https://lihpc-computational-geometry.github.io/honeycomb/"
+repository = "https://github.com/LIHPC-Computational-Geometry/honeycomb"
+description = "Combinatorial map implementation for meshing applications"
+authors = ["Isaie Muron <isaie.muron@cea.fr>", "Cedric Chevalier <cedric.chevalier@cea.fr>"]
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ license = "MIT OR Apache-2.0"
 version = "0.2.0"
 homepage = "https://lihpc-computational-geometry.github.io/honeycomb/"
 repository = "https://github.com/LIHPC-Computational-Geometry/honeycomb"
+readme = "README.md"
 description = "Combinatorial map implementation for meshing applications"
+categories = ["data-structures", "mathematics", "science"]
+keywords = ["mesh", "meshing"]
 authors = ["Isaie Muron <isaie.muron@cea.fr>", "Cedric Chevalier <cedric.chevalier@cea.fr>"]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ winit = "0.29.15"
 env_logger = "0.11.3"
 pollster = "0.3.0"
 cgmath = "0.18.0"
-bytemuck = { version = "1.15.0", features = ["derive"] }
+bytemuck = { version = "1.15.0" }
 smaa = "0.13.0"
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,28 @@ description = "Combinatorial map implementation for meshing applications"
 authors = ["Isaie Muron <isaie.muron@cea.fr>", "Cedric Chevalier <cedric.chevalier@cea.fr>"]
 
 [workspace.dependencies]
+# members
 honeycomb-benches = { version = "0.2.0", path = "./honeycomb-benches" }
 honeycomb-core = { version = "0.2.0", path = "./honeycomb-core" }
 honeycomb-examples = { version = "0.2.0", path = "./honeycomb-examples" }
 honeycomb-render = { version = "0.2.0", path = "./honeycomb-render" }
+
+# common
+cfg-if = "1"
+
+# benchmarks
+criterion = { version = "0.5.1", features = ["html_reports"] }
+iai-callgrind = "0.10.2"
+rand = { version = "0.8.5", features = ["small_rng"] }
+
+# render
+wgpu = "0.19.4"
+winit = "0.29.15"
+env_logger = "0.11.3"
+pollster = "0.3.0"
+cgmath = "0.18.0"
+bytemuck = { version = "1.15.0", features = ["derive"] }
+smaa = "0.13.0"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,11 @@ repository = "https://github.com/LIHPC-Computational-Geometry/honeycomb"
 description = "Combinatorial map implementation for meshing applications"
 authors = ["Isaie Muron <isaie.muron@cea.fr>", "Cedric Chevalier <cedric.chevalier@cea.fr>"]
 
+[workspace.dependencies]
+honeycomb-benches = { version = "0.2.0", path = "./honeycomb-benches" }
+honeycomb-core = { version = "0.2.0", path = "./honeycomb-core" }
+honeycomb-examples = { version = "0.2.0", path = "./honeycomb-examples" }
+honeycomb-render = { version = "0.2.0", path = "./honeycomb-render" }
+
 [profile.bench]
 debug = true

--- a/honeycomb-benches/Cargo.toml
+++ b/honeycomb-benches/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 publish = false
 
 [dev-dependencies]
-honeycomb-core = { path = "../honeycomb-core", features = ["utils"] }
+honeycomb-core = { workspace = true, features = ["utils"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 iai-callgrind = "0.10"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/honeycomb-benches/Cargo.toml
+++ b/honeycomb-benches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeycomb-benches"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/honeycomb-benches/Cargo.toml
+++ b/honeycomb-benches/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
 name = "honeycomb-benches"
-version = "0.2.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Core structure benchmarks"
+authors.workspace = true
+publish = false
 
 [dev-dependencies]
 honeycomb-core = { path = "../honeycomb-core", features = ["utils"] }
-criterion = { version = "*", features = ["html_reports"] }
-iai-callgrind = "*"
-rand = { version = "*", features = ["small_rng"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+iai-callgrind = "0.10"
+rand = { version = "0.8", features = ["small_rng"] }
 
 # Iai-callgrind benchmarks
 

--- a/honeycomb-benches/Cargo.toml
+++ b/honeycomb-benches/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 
 [dev-dependencies]
 honeycomb-core = { workspace = true, features = ["utils"] }
-criterion = { version = "0.5", features = ["html_reports"] }
-iai-callgrind = "0.10"
-rand = { version = "0.8", features = ["small_rng"] }
+criterion = { workspace = true, features = ["html_reports"] }
+iai-callgrind.workspace = true
+rand = { workspace = true, features = ["small_rng"] }
 
 # Iai-callgrind benchmarks
 

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -5,7 +5,10 @@ license.workspace = true
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Core structure implementation"
+readme.workspace = true
+description = "Core structure implementation for combinatorial maps"
+categories.workspace = true
+keywords.workspace = true
 authors.workspace = true
 publish = true
 

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "honeycomb-core"
-version = "0.2.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Core structure implementation"
+authors.workspace = true
+publish = true
 
 [features]
 utils = []

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeycomb-core"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [features]

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -14,5 +14,5 @@ utils = []
 single_precision = []
 
 [dependencies]
-cfg-if = "1"
-num = "0.4"
+cfg-if.workspace = true
+num.workspace = true

--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeycomb-examples"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "honeycomb-examples"
-version = "0.2.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Usage examples"
+authors.workspace = true
+publish = false
 
 [dev-dependencies]
 honeycomb-core = { path = "../honeycomb-core", features = ["utils"] }

--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -10,8 +10,8 @@ authors.workspace = true
 publish = false
 
 [dev-dependencies]
-honeycomb-core = { path = "../honeycomb-core", features = ["utils"] }
-honeycomb-render = { path = "../honeycomb-render" }
+honeycomb-core = { workspace = true, features = ["utils"] }
+honeycomb-render = { workspace = true }
 
 [[example]]
 name = "memory_usage"

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "honeycomb-render"
-version = "0.2.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Visualization tool"
+authors.workspace = true
+publish = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -13,20 +13,20 @@ publish = true
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cfg-if = "1"
-wgpu = "0.19"
-winit = "0.29"
-env_logger = "0.11"
-pollster = "0.3"
-cgmath = "0.18"
-bytemuck = { version = "1.14", features = ["derive"] }
+bytemuck = { workspace = true, features = ["derive"] }
+cfg-if.workspace = true
+cgmath.workspace = true
+env_logger.workspace = true
 honeycomb-core.workspace = true
-smaa = "0.13"
+pollster.workspace = true
+smaa.workspace = true
+wgpu.workspace = true
+winit.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 console_log = "1.0"
-wgpu = { version = "0.19", features = ["webgl"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Document", "Window", "Element"] }
+wgpu = { workspace = true, features = ["webgl"] }

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -5,7 +5,10 @@ license.workspace = true
 version.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Visualization tool"
+readme.workspace = true
+description = "Visualization tool for combinatorial maps"
+categories.workspace = true
+keywords.workspace = true
 authors.workspace = true
 publish = true
 

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.11"
 pollster = "0.3"
 cgmath = "0.18"
 bytemuck = { version = "1.14", features = ["derive"] }
-honeycomb-core = { path = "../honeycomb-core" }
+honeycomb-core.workspace = true
 smaa = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "honeycomb-render"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Collection of small changes before the `0.2.0` release:
- bump package versions
- add project information to the manifests for an eventual publish on crates.io
- update the changelog file
- exclude `honeycomb-render` from the coverage report

## Scope

- [x] Repository

## Type of change

- [x] Chore: closes #41 
