### PR TITLE
chore: process clippy lints that were previously allowed

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -46,7 +46,8 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// Return a [`AttrSparseVec`] object full of `None`.
     ///
-    #[must_use] pub fn new(n_ids: usize) -> Self {
+    #[must_use = "constructed object is not used, consider removing this function call"]
+    pub fn new(n_ids: usize) -> Self {
         Self {
             data: (0..n_ids).map(|_| None).collect(),
         }
@@ -63,7 +64,8 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     }
 
     /// Return the number of stored attributes (i.e. number of `Some(_)` instances)
-    #[must_use] pub fn n_attributes(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_attributes(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count()
     }
 
@@ -83,7 +85,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn get(&self, index: T::IdentifierType) -> &Option<T> {
+    pub fn get(&self, index: &T::IdentifierType) -> &Option<T> {
         &self.data[index.to_usize().unwrap()]
     }
 
@@ -104,7 +106,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index cannot be converted to `usize`
     ///
     #[deprecated]
-    pub fn get_mut(&mut self, index: T::IdentifierType) -> &mut Option<T> {
+    pub fn get_mut(&mut self, index: &T::IdentifierType) -> &mut Option<T> {
         &mut self.data[index.to_usize().unwrap()]
     }
 
@@ -123,7 +125,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn set(&mut self, index: T::IdentifierType, val: T) {
+    pub fn set(&mut self, index: &T::IdentifierType, val: T) {
         self.data[index.to_usize().unwrap()] = Some(val);
     }
 
@@ -143,7 +145,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn insert(&mut self, index: T::IdentifierType, val: T) {
+    pub fn insert(&mut self, index: &T::IdentifierType, val: T) {
         let tmp = &mut self.data[index.to_usize().unwrap()];
         assert!(tmp.is_none());
         *tmp = Some(val);
@@ -168,7 +170,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn replace(&mut self, index: T::IdentifierType, val: T) -> Option<T> {
+    pub fn replace(&mut self, index: &T::IdentifierType, val: T) -> Option<T> {
         self.data.push(Some(val));
         self.data.swap_remove(index.to_usize().unwrap())
     }
@@ -190,7 +192,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
+    pub fn remove(&mut self, index: &T::IdentifierType) -> Option<T> {
         self.data.push(None);
         self.data.swap_remove(index.to_usize().unwrap())
     }
@@ -199,17 +201,20 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrSparseVec<T> {
     /// Return the amount of space allocated for the storage.
-    #[must_use] pub fn allocated_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn allocated_size(&self) -> usize {
         self.data.capacity() * std::mem::size_of::<Option<T>>()
     }
 
     /// Return the total amount of space used by the storage.
-    #[must_use] pub fn effective_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn effective_size(&self) -> usize {
         self.data.len() * std::mem::size_of::<Option<T>>()
     }
 
     /// Return the amount of space used by valid entries of the storage.
-    #[must_use] pub fn used_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn used_size(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count() * std::mem::size_of::<Option<T>>()
     }
 }
@@ -257,7 +262,8 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// Return a "value-empty" [`AttrSparseVec`] object.
     ///
-    #[must_use] pub fn new(n_ids: usize) -> Self {
+    #[must_use = "constructed object is not used, consider removing this function call"]
+    pub fn new(n_ids: usize) -> Self {
         Self {
             unused_data_slots: Vec::new(),
             index_map: vec![None; n_ids],
@@ -276,12 +282,14 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     }
 
     /// Return the number of stored attributes in the internal storage.
-    #[must_use] pub fn n_attributes(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_attributes(&self) -> usize {
         self.data.len()
     }
 
     /// Return the number of stored, used attributes in the internal storage.
-    #[must_use] pub fn n_used_attributes(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_used_attributes(&self) -> usize {
         self.data.len() - self.unused_data_slots.len()
     }
 
@@ -302,7 +310,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn get(&self, index: T::IdentifierType) -> Option<&T> {
+    pub fn get(&self, index: &T::IdentifierType) -> Option<&T> {
         self.index_map[index.to_usize().unwrap()].map(|idx| &self.data[idx])
     }
 
@@ -324,7 +332,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index cannot be converted to `usize`
     ///
     #[deprecated]
-    pub fn get_mut(&mut self, index: T::IdentifierType) -> Option<&mut T> {
+    pub fn get_mut(&mut self, index: &T::IdentifierType) -> Option<&mut T> {
         self.index_map[index.to_usize().unwrap()].map(|idx| &mut self.data[idx])
     }
 
@@ -343,7 +351,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn set(&mut self, index: T::IdentifierType, val: T) {
+    pub fn set(&mut self, index: &T::IdentifierType, val: T) {
         if let Some(idx) = self.index_map[index.to_usize().unwrap()] {
             // internal index is defined => there should be associated data
             self.data[idx] = val;
@@ -374,7 +382,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn insert(&mut self, index: T::IdentifierType, val: T) {
+    pub fn insert(&mut self, index: &T::IdentifierType, val: T) {
         let idx = &mut self.index_map[index.to_usize().unwrap()];
         assert!(idx.is_none());
         *idx = if let Some(unused_idx) = self.unused_data_slots.pop() {
@@ -405,7 +413,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn replace(&mut self, index: T::IdentifierType, val: T) -> Option<T> {
+    pub fn replace(&mut self, index: &T::IdentifierType, val: T) -> Option<T> {
         let idx = &self.index_map[index.to_usize().unwrap()];
         assert!(idx.is_some());
         self.data.push(val);
@@ -429,7 +437,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    pub fn remove(&mut self, index: T::IdentifierType) -> Option<T> {
+    pub fn remove(&mut self, index: &T::IdentifierType) -> Option<T> {
         self.index_map.push(None);
         if let Some(tmp) = self.index_map.swap_remove(index.to_usize().unwrap()) {
             self.unused_data_slots.push(tmp);
@@ -442,21 +450,24 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// Return the amount of space allocated for the storage.
-    #[must_use] pub fn allocated_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn allocated_size(&self) -> usize {
         self.unused_data_slots.capacity() * std::mem::size_of::<usize>()
             + self.index_map.capacity() * std::mem::size_of::<Option<usize>>()
             + self.data.capacity() * std::mem::size_of::<T>()
     }
 
     /// Return the total amount of space used by the storage.
-    #[must_use] pub fn effective_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn effective_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.len() * std::mem::size_of::<Option<usize>>()
             + self.data.len() * std::mem::size_of::<T>()
     }
 
     /// Return the amount of space used by valid entries of the storage.
-    #[must_use] pub fn used_size(&self) -> usize {
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn used_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.iter().filter(|val| val.is_some()).count()
                 * std::mem::size_of::<Option<usize>>()
@@ -474,16 +485,16 @@ mod tests {
     macro_rules! generate_sparse {
         ($name: ident) => {
             let mut $name = AttrSparseVec::<Temperature>::new(10);
-            $name.insert(0, Temperature::from(273.0));
-            $name.insert(1, Temperature::from(275.0));
-            $name.insert(2, Temperature::from(277.0));
-            $name.insert(3, Temperature::from(279.0));
-            $name.insert(4, Temperature::from(281.0));
-            $name.insert(5, Temperature::from(283.0));
-            $name.insert(6, Temperature::from(285.0));
-            $name.insert(7, Temperature::from(287.0));
-            $name.insert(8, Temperature::from(289.0));
-            $name.insert(9, Temperature::from(291.0));
+            $name.insert(&0, Temperature::from(273.0));
+            $name.insert(&1, Temperature::from(275.0));
+            $name.insert(&2, Temperature::from(277.0));
+            $name.insert(&3, Temperature::from(279.0));
+            $name.insert(&4, Temperature::from(281.0));
+            $name.insert(&5, Temperature::from(283.0));
+            $name.insert(&6, Temperature::from(285.0));
+            $name.insert(&7, Temperature::from(287.0));
+            $name.insert(&8, Temperature::from(289.0));
+            $name.insert(&9, Temperature::from(291.0));
         };
     }
 
@@ -491,95 +502,95 @@ mod tests {
     fn sparse_vec_n_attributes() {
         generate_sparse!(storage);
         assert_eq!(storage.n_attributes(), 10);
-        let _ = storage.remove(3);
+        let _ = storage.remove(&3);
         assert_eq!(storage.n_attributes(), 9);
         // extend does not affect the number of attributes
         storage.extend(10);
-        assert!(storage.get(15).is_none());
+        assert!(storage.get(&15).is_none());
         assert_eq!(storage.n_attributes(), 9);
     }
 
     #[test]
     fn sparse_vec_get_set_get() {
         generate_sparse!(storage);
-        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
-        storage.set(3, Temperature::from(280.0));
-        assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
+        assert_eq!(storage.get(&3), &Some(Temperature::from(279.0)));
+        storage.set(&3, Temperature::from(280.0));
+        assert_eq!(storage.get(&3), &Some(Temperature::from(280.0)));
     }
 
     #[test]
     fn sparse_vec_get_replace_get() {
         generate_sparse!(storage);
-        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
-        storage.replace(3, Temperature::from(280.0));
-        assert_eq!(storage.get(3), &Some(Temperature::from(280.0)));
+        assert_eq!(storage.get(&3), &Some(Temperature::from(279.0)));
+        storage.replace(&3, Temperature::from(280.0));
+        assert_eq!(storage.get(&3), &Some(Temperature::from(280.0)));
     }
 
     #[test]
     #[should_panic(expected = "assertion failed: tmp.is_none()")]
     fn sparse_vec_insert_already_existing() {
         generate_sparse!(storage);
-        assert_eq!(storage.get(3), &Some(Temperature::from(279.0)));
-        storage.insert(3, Temperature::from(280.0)); // panic
+        assert_eq!(storage.get(&3), &Some(Temperature::from(279.0)));
+        storage.insert(&3, Temperature::from(280.0)); // panic
     }
 
     #[test]
     fn sparse_vec_remove() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
     }
 
     #[test]
     fn sparse_vec_remove_remove() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        assert!(storage.remove(3).is_none());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        assert!(storage.remove(&3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_get() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        assert!(storage.get(3).is_none());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        assert!(storage.get(&3).is_none());
     }
 
     #[test]
     fn sparse_vec_remove_set() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.set(3, Temperature::from(280.0));
-        assert!(storage.get(3).is_some());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.set(&3, Temperature::from(280.0));
+        assert!(storage.get(&3).is_some());
     }
 
     #[test]
     fn sparse_vec_remove_insert() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.insert(3, Temperature::from(280.0));
-        assert!(storage.get(3).is_some());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.insert(&3, Temperature::from(280.0));
+        assert!(storage.get(&3).is_some());
     }
 
     #[test]
     #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
     fn sparse_vec_replace_already_removed() {
         generate_sparse!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.replace(3, Temperature::from(280.0)).unwrap(); // panic
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.replace(&3, Temperature::from(280.0)).unwrap(); // panic
     }
 
     macro_rules! generate_compact {
         ($name: ident) => {
             let mut $name = AttrCompactVec::<Temperature>::new(10);
-            $name.insert(0, Temperature::from(273.0));
-            $name.insert(1, Temperature::from(275.0));
-            $name.insert(2, Temperature::from(277.0));
-            $name.insert(3, Temperature::from(279.0));
-            $name.insert(4, Temperature::from(281.0));
-            $name.insert(5, Temperature::from(283.0));
-            $name.insert(6, Temperature::from(285.0));
-            $name.insert(7, Temperature::from(287.0));
-            $name.insert(8, Temperature::from(289.0));
-            $name.insert(9, Temperature::from(291.0));
+            $name.insert(&0, Temperature::from(273.0));
+            $name.insert(&1, Temperature::from(275.0));
+            $name.insert(&2, Temperature::from(277.0));
+            $name.insert(&3, Temperature::from(279.0));
+            $name.insert(&4, Temperature::from(281.0));
+            $name.insert(&5, Temperature::from(283.0));
+            $name.insert(&6, Temperature::from(285.0));
+            $name.insert(&7, Temperature::from(287.0));
+            $name.insert(&8, Temperature::from(289.0));
+            $name.insert(&9, Temperature::from(291.0));
         };
     }
 
@@ -587,11 +598,11 @@ mod tests {
     fn compact_vec_n_attributes() {
         generate_compact!(storage);
         assert_eq!(storage.n_attributes(), 10);
-        let _ = storage.remove(3);
+        let _ = storage.remove(&3);
         assert_eq!(storage.n_attributes(), 10);
         // extend does not affect the number of attributes
         storage.extend(10);
-        assert!(storage.get(15).is_none());
+        assert!(storage.get(&15).is_none());
         assert_eq!(storage.n_attributes(), 10);
     }
 
@@ -599,11 +610,11 @@ mod tests {
     fn compact_vec_n_used_attributes() {
         generate_compact!(storage);
         assert_eq!(storage.n_used_attributes(), 10);
-        let _ = storage.remove(3);
+        let _ = storage.remove(&3);
         assert_eq!(storage.n_used_attributes(), 9);
         // extend does not affect the number of attributes
         storage.extend(10);
-        assert!(storage.get(15).is_none());
+        assert!(storage.get(&15).is_none());
         assert_eq!(storage.n_used_attributes(), 9);
     }
 
@@ -614,13 +625,13 @@ mod tests {
         // extend does not affect the number of attributes
         storage.extend(10);
         assert_eq!(storage.n_attributes(), 10);
-        storage.set(10, Temperature::from(293.0));
+        storage.set(&10, Temperature::from(293.0));
         assert_eq!(storage.n_attributes(), 11);
-        storage.set(11, Temperature::from(295.0));
+        storage.set(&11, Temperature::from(295.0));
         assert_eq!(storage.n_attributes(), 12);
-        storage.set(12, Temperature::from(297.0));
+        storage.set(&12, Temperature::from(297.0));
         assert_eq!(storage.n_attributes(), 13);
-        let _ = storage.remove(3);
+        let _ = storage.remove(&3);
         assert_eq!(storage.n_attributes(), 13);
         assert_eq!(storage.n_used_attributes(), 12);
     }
@@ -628,68 +639,68 @@ mod tests {
     #[test]
     fn compact_vec_get_set_get() {
         generate_compact!(storage);
-        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
-        storage.set(3, Temperature::from(280.0));
-        assert_eq!(storage.get(3), Some(&Temperature::from(280.0)));
+        assert_eq!(storage.get(&3), Some(&Temperature::from(279.0)));
+        storage.set(&3, Temperature::from(280.0));
+        assert_eq!(storage.get(&3), Some(&Temperature::from(280.0)));
     }
 
     #[test]
     fn compact_vec_get_replace_get() {
         generate_compact!(storage);
-        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
-        storage.replace(3, Temperature::from(280.0));
-        assert_eq!(storage.get(3), Some(&Temperature::from(280.0)));
+        assert_eq!(storage.get(&3), Some(&Temperature::from(279.0)));
+        storage.replace(&3, Temperature::from(280.0));
+        assert_eq!(storage.get(&3), Some(&Temperature::from(280.0)));
     }
 
     #[test]
     #[should_panic(expected = "assertion failed: idx.is_none()")]
     fn compact_vec_insert_already_existing() {
         generate_compact!(storage);
-        assert_eq!(storage.get(3), Some(&Temperature::from(279.0)));
-        storage.insert(3, Temperature::from(280.0)); // panic
+        assert_eq!(storage.get(&3), Some(&Temperature::from(279.0)));
+        storage.insert(&3, Temperature::from(280.0)); // panic
     }
 
     #[test]
     fn compact_vec_remove() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
     }
 
     #[test]
     fn compact_vec_remove_remove() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        assert!(storage.remove(3).is_none());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        assert!(storage.remove(&3).is_none());
     }
 
     #[test]
     fn compact_vec_remove_get() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        assert!(storage.get(3).is_none());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        assert!(storage.get(&3).is_none());
     }
 
     #[test]
     fn compact_vec_remove_set() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.set(3, Temperature::from(280.0));
-        assert!(storage.get(3).is_some());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.set(&3, Temperature::from(280.0));
+        assert!(storage.get(&3).is_some());
     }
 
     #[test]
     fn compact_vec_remove_insert() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.insert(3, Temperature::from(280.0));
-        assert!(storage.get(3).is_some());
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.insert(&3, Temperature::from(280.0));
+        assert!(storage.get(&3).is_some());
     }
 
     #[test]
     #[should_panic(expected = "assertion failed: idx.is_some()")]
     fn compact_vec_replace_already_removed() {
         generate_compact!(storage);
-        assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-        storage.replace(3, Temperature::from(280.0)); // panic
+        assert_eq!(storage.remove(&3), Some(Temperature::from(279.0)));
+        storage.replace(&3, Temperature::from(280.0)); // panic
     }
 }

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -46,7 +46,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     ///
     /// Return a [`AttrSparseVec`] object full of `None`.
     ///
-    pub fn new(n_ids: usize) -> Self {
+    #[must_use] pub fn new(n_ids: usize) -> Self {
         Self {
             data: (0..n_ids).map(|_| None).collect(),
         }
@@ -63,7 +63,7 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
     }
 
     /// Return the number of stored attributes (i.e. number of `Some(_)` instances)
-    pub fn n_attributes(&self) -> usize {
+    #[must_use] pub fn n_attributes(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count()
     }
 
@@ -199,17 +199,17 @@ impl<T: AttributeBind + AttributeUpdate> AttrSparseVec<T> {
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrSparseVec<T> {
     /// Return the amount of space allocated for the storage.
-    pub fn allocated_size(&self) -> usize {
+    #[must_use] pub fn allocated_size(&self) -> usize {
         self.data.capacity() * std::mem::size_of::<Option<T>>()
     }
 
     /// Return the total amount of space used by the storage.
-    pub fn effective_size(&self) -> usize {
+    #[must_use] pub fn effective_size(&self) -> usize {
         self.data.len() * std::mem::size_of::<Option<T>>()
     }
 
     /// Return the amount of space used by valid entries of the storage.
-    pub fn used_size(&self) -> usize {
+    #[must_use] pub fn used_size(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count() * std::mem::size_of::<Option<T>>()
     }
 }
@@ -257,7 +257,7 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     ///
     /// Return a "value-empty" [`AttrSparseVec`] object.
     ///
-    pub fn new(n_ids: usize) -> Self {
+    #[must_use] pub fn new(n_ids: usize) -> Self {
         Self {
             unused_data_slots: Vec::new(),
             index_map: vec![None; n_ids],
@@ -276,12 +276,12 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     }
 
     /// Return the number of stored attributes in the internal storage.
-    pub fn n_attributes(&self) -> usize {
+    #[must_use] pub fn n_attributes(&self) -> usize {
         self.data.len()
     }
 
     /// Return the number of stored, used attributes in the internal storage.
-    pub fn n_used_attributes(&self) -> usize {
+    #[must_use] pub fn n_used_attributes(&self) -> usize {
         self.data.len() - self.unused_data_slots.len()
     }
 
@@ -442,21 +442,21 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
 #[cfg(feature = "utils")]
 impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
     /// Return the amount of space allocated for the storage.
-    pub fn allocated_size(&self) -> usize {
+    #[must_use] pub fn allocated_size(&self) -> usize {
         self.unused_data_slots.capacity() * std::mem::size_of::<usize>()
             + self.index_map.capacity() * std::mem::size_of::<Option<usize>>()
             + self.data.capacity() * std::mem::size_of::<T>()
     }
 
     /// Return the total amount of space used by the storage.
-    pub fn effective_size(&self) -> usize {
+    #[must_use] pub fn effective_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.len() * std::mem::size_of::<Option<usize>>()
             + self.data.len() * std::mem::size_of::<T>()
     }
 
     /// Return the amount of space used by valid entries of the storage.
-    pub fn used_size(&self) -> usize {
+    #[must_use] pub fn used_size(&self) -> usize {
         self.unused_data_slots.len() * std::mem::size_of::<usize>()
             + self.index_map.iter().filter(|val| val.is_some()).count()
                 * std::mem::size_of::<Option<usize>>()

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -123,7 +123,7 @@ mod tests {
 
         assert_eq!(Temperature::split(t_new), (t_ref, t_ref)); // or Temperature::_
         assert_eq!(Temperature::merge_undefined(Some(t_ref)), t_ref);
-        assert_eq!(Temperature::merge_undefined(None), Temperature::from(0.0))
+        assert_eq!(Temperature::merge_undefined(None), Temperature::from(0.0));
     }
 
     #[test]

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -96,6 +96,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     ///
     /// See [`CMap2`] example.
     ///
+    #[must_use = "orbits are lazy and do nothing unless consumed"]
     pub fn new(
         map_handle: &'a CMap2<T>,
         orbit_policy: OrbitPolicy<'a>,
@@ -119,6 +120,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     }
 
     /// Return a boolean indicating whether the starting dart is isolated or not
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn is_isolated(&self) -> bool {
         // this is boolean tells us if the orbit is either:
         // a) unaltered (pending.len() == 1)

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -177,8 +177,6 @@ impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
                         // i.e. we need to visit it later
                         self.pending.push_back(image2);
                     }
-
-                    Some(d)
                 }
                 OrbitPolicy::Edge => {
                     // THIS CODE IS ONLY VALID IN 2D
@@ -188,7 +186,6 @@ impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
                         // i.e. we need to visit it later
                         self.pending.push_back(image);
                     }
-                    Some(d)
                 }
                 OrbitPolicy::Face => {
                     // THIS CODE IS ONLY VALID IN 2D
@@ -199,21 +196,19 @@ impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
                         // i.e. we need to visit it later
                         self.pending.push_back(image);
                     }
-                    Some(d)
                 }
                 OrbitPolicy::Custom(beta_slice) => {
-                    beta_slice.iter().for_each(|beta_id| {
+                    for beta_id in beta_slice {
                         let image = self.map_handle.beta_runtime(*beta_id, d);
                         if self.marked.insert(image) {
                             // if true, we did not see this dart yet
                             // i.e. we need to visit it later
                             self.pending.push_back(image);
                         }
-                    });
-
-                    Some(d)
+                    }
                 }
             }
+            Some(d)
         } else {
             None
         }

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -27,7 +27,6 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::if_not_else)]
-#![allow(clippy::range_plus_one)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -23,8 +23,6 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cast_possible_truncation)]
-// --- some to work through later
-#![allow(clippy::needless_pass_by_value)]
 
 // ------ MODULE DECLARATIONS
 mod attributes;

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -24,8 +24,6 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cast_possible_truncation)]
 // --- some to work through later
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -26,7 +26,6 @@
 // --- some to work through later
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::return_self_not_must_use)]
-#![allow(clippy::if_not_else)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -24,7 +24,6 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::cast_possible_truncation)]
 // --- some to work through later
-#![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
 
 // ------ MODULE DECLARATIONS

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -29,7 +29,6 @@
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::if_not_else)]
 #![allow(clippy::range_plus_one)]
-#![allow(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::needless_for_each)]
 #![allow(clippy::needless_pass_by_value)]
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -26,7 +26,6 @@
 // --- some to work through later
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::return_self_not_must_use)]
-#![allow(clippy::match_same_arms)]
 #![allow(clippy::if_not_else)]
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::needless_for_each)]

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -56,6 +56,7 @@ impl<T: CoordsFloat> Coords2<T> {
     ///
     /// Return a unit vector along the `x` axis.
     ///
+    #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn unit_x() -> Coords2<T> {
         Self {
             x: T::one(),
@@ -69,6 +70,7 @@ impl<T: CoordsFloat> Coords2<T> {
     ///
     /// Return a unit vector along the `y` axis.
     ///
+    #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn unit_y() -> Coords2<T> {
         Self {
             x: T::zero(),

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -53,6 +53,7 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// Return a unit vector along the `x` axis.
     ///
+    #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn unit_x() -> Self {
         Self {
             inner: Coords2::unit_x(),
@@ -65,6 +66,7 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// Return a unit vector along the `y` axis.
     ///
+    #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn unit_y() -> Self {
         Self {
             inner: Coords2::unit_y(),
@@ -157,7 +159,8 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// See [Vector2] example.
     ///
-    pub fn normal_dir(&self) -> Vector2<T> {
+    #[must_use = "constructed object is not used, consider removing this method call"]
+    pub fn normal_dir(&self) -> Self {
         Self {
             inner: Coords2 {
                 x: -self.inner.y,

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -235,7 +235,7 @@ impl<T: CoordsFloat> std::ops::Sub<Vector2<T>> for Vector2<T> {
 
 impl<T: CoordsFloat> std::ops::SubAssign<Vector2<T>> for Vector2<T> {
     fn sub_assign(&mut self, rhs: Vector2<T>) {
-        self.inner -= rhs.into_inner()
+        self.inner -= rhs.into_inner();
     }
 }
 

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -134,10 +134,10 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     pub fn unit_dir(&self) -> Result<Vector2<T>, CoordsError> {
         let norm = self.norm();
-        if !norm.is_zero() {
-            Ok(*self / norm)
-        } else {
+        if norm.is_zero() {
             Err(CoordsError::InvalidUnitDir)
+        } else {
+            Ok(*self / norm)
         }
     }
 

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -150,7 +150,7 @@ impl<T: CoordsFloat> std::ops::Add<Vector2<T>> for Vertex2<T> {
 
 impl<T: CoordsFloat> std::ops::AddAssign<Vector2<T>> for Vertex2<T> {
     fn add_assign(&mut self, rhs: Vector2<T>) {
-        self.inner += rhs.into_inner()
+        self.inner += rhs.into_inner();
     }
 }
 
@@ -286,6 +286,6 @@ mod tests {
         let a: Vertex2<FloatType> = Vertex2::from((1.0, 1.0));
         let b: Vertex2<FloatType> = Vertex2::from((1.0, 0.0));
         let ab = b - a;
-        assert_eq!(ab, Vector2::from((0.0, -1.0)))
+        assert_eq!(ab, Vector2::from((0.0, -1.0)));
     }
 }

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -675,7 +675,12 @@ impl<T: CoordsFloat> CMap2<T> {
         // condition is valid if the first one is)
         // if that is not the case, the sewing operation becomes a linking operation
         let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
-        if b2lhs_dart_id != NULL_DART_ID {
+        if b2lhs_dart_id == NULL_DART_ID {
+            // WARNING: UNWANTED BEHAVIOR
+            // there should be a check in order to ensure that vertex(rhs_dart) is defined
+            // otherwise, panic because the user should call link, not sew
+            self.one_link(lhs_dart_id, rhs_dart_id);
+        } else {
             let b2lhs_vid_old = self.vertex_id(b2lhs_dart_id);
             let rhs_vid_old = self.vertex_id(rhs_dart_id);
             let tmp = (
@@ -690,8 +695,6 @@ impl<T: CoordsFloat> CMap2<T> {
             // use b2lhs_vid as the index for the new vertex
             self.one_link(lhs_dart_id, rhs_dart_id);
             self.insert_vertex(self.vertex_id(rhs_dart_id), new_vertex);
-        } else {
-            self.one_link(lhs_dart_id, rhs_dart_id);
         }
     }
 
@@ -724,7 +727,12 @@ impl<T: CoordsFloat> CMap2<T> {
         // match (is lhs 1-free, is rhs 1-free)
         match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
             // trivial case, no update needed
-            (true, true) => self.two_link(lhs_dart_id, rhs_dart_id),
+            (true, true) => {
+                // WARNING: UNWANTED BEHAVIOR
+                // there should be a check in order to ensure that each dart has associated vertices
+                // otherwise, panic because the user should call link, not sew
+                self.two_link(lhs_dart_id, rhs_dart_id);
+            }
             // update vertex associated to b1rhs/lhs
             (true, false) => {
                 // read current values / remove old ones
@@ -845,7 +853,9 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     pub fn one_unsew(&mut self, lhs_dart_id: DartIdentifier) {
         let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
-        if b2lhs_dart_id != NULL_DART_ID {
+        if b2lhs_dart_id == NULL_DART_ID {
+            self.one_unlink(lhs_dart_id);
+        } else {
             // read current values / remove old ones
             let rhs_dart_id = self.beta::<1>(lhs_dart_id);
             // we only need to remove a single vertex since we're unlinking
@@ -856,8 +866,6 @@ impl<T: CoordsFloat> CMap2<T> {
             // reinsert correct values
             let _ = self.replace_vertex(self.vertex_id(b2lhs_dart_id), v1);
             let _ = self.replace_vertex(self.vertex_id(rhs_dart_id), v2);
-        } else {
-            self.one_unlink(lhs_dart_id);
         }
     }
 

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -698,8 +698,8 @@ impl<T: CoordsFloat> CMap2<T> {
             let b2lhs_vid_old = self.vertex_id(b2lhs_dart_id);
             let rhs_vid_old = self.vertex_id(rhs_dart_id);
             let tmp = (
-                self.vertices.remove(b2lhs_vid_old),
-                self.vertices.remove(rhs_vid_old),
+                self.vertices.remove(&b2lhs_vid_old),
+                self.vertices.remove(&rhs_vid_old),
             );
             let new_vertex = match tmp {
                 (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
@@ -753,8 +753,8 @@ impl<T: CoordsFloat> CMap2<T> {
                 let lhs_vid_old = self.vertex_id(lhs_dart_id);
                 let b1rhs_vid_old = self.vertex_id(b1rhs_dart_id);
                 let tmp = (
-                    self.vertices.remove(lhs_vid_old),
-                    self.vertices.remove(b1rhs_vid_old),
+                    self.vertices.remove(&lhs_vid_old),
+                    self.vertices.remove(&b1rhs_vid_old),
                 );
                 let new_vertex = match tmp {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
@@ -772,8 +772,8 @@ impl<T: CoordsFloat> CMap2<T> {
                 let b1lhs_vid_old = self.vertex_id(b1lhs_dart_id);
                 let rhs_vid_old = self.vertex_id(rhs_dart_id);
                 let tmp = (
-                    self.vertices.remove(b1lhs_vid_old),
-                    self.vertices.remove(rhs_vid_old),
+                    self.vertices.remove(&b1lhs_vid_old),
+                    self.vertices.remove(&rhs_vid_old),
                 );
                 let new_vertex = match tmp {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
@@ -792,15 +792,15 @@ impl<T: CoordsFloat> CMap2<T> {
                 let lhs_vid_old = self.vertex_id(lhs_dart_id);
                 let b1rhs_vid_old = self.vertex_id(b1rhs_dart_id);
                 let tmpa = (
-                    self.vertices.remove(lhs_vid_old),
-                    self.vertices.remove(b1rhs_vid_old),
+                    self.vertices.remove(&lhs_vid_old),
+                    self.vertices.remove(&b1rhs_vid_old),
                 );
                 // (b1lhs/rhs) vertex
                 let b1lhs_vid_old = self.vertex_id(b1lhs_dart_id);
                 let rhs_vid_old = self.vertex_id(rhs_dart_id);
                 let tmpb = (
-                    self.vertices.remove(b1lhs_vid_old),
-                    self.vertices.remove(rhs_vid_old),
+                    self.vertices.remove(&b1lhs_vid_old),
+                    self.vertices.remove(&rhs_vid_old),
                 );
 
                 // check orientation
@@ -1057,7 +1057,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     #[must_use = "returned value is not used, consider removing this method call"]
     pub fn vertex(&self, vertex_id: VertexIdentifier) -> Vertex2<T> {
-        self.vertices.get(vertex_id).unwrap()
+        self.vertices.get(&vertex_id).unwrap()
     }
 
     /// Insert a vertex in the combinatorial map.
@@ -1076,7 +1076,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// Return an option which may contain the previous value associated to the specified vertex ID.
     ///
     pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
-        self.vertices.insert(vertex_id, vertex.into());
+        self.vertices.insert(&vertex_id, vertex.into());
     }
 
     #[allow(clippy::missing_errors_doc)]
@@ -1093,7 +1093,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `Err(CMapError::UndefinedVertexID)` -- The vertex was not found in the internal storage
     ///
     pub fn remove_vertex(&mut self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.remove(vertex_id) {
+        if let Some(val) = self.vertices.remove(&vertex_id) {
             return Ok(val);
         }
         Err(CMapError::UndefinedVertex)
@@ -1119,7 +1119,7 @@ impl<T: CoordsFloat> CMap2<T> {
         vertex_id: VertexIdentifier,
         vertex: impl Into<Vertex2<T>>,
     ) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.replace(vertex_id, vertex.into()) {
+        if let Some(val) = self.vertices.replace(&vertex_id, vertex.into()) {
             return Ok(val);
         };
         Err(CMapError::UndefinedVertex)

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -684,8 +684,7 @@ impl<T: CoordsFloat> CMap2<T> {
             );
             let new_vertex = match tmp {
                 (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
-                (Some(val), None) => Vertex2::merge_undefined(Some(val)),
-                (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
+                (Some(val), None) | (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
                 (None, None) => Vertex2::merge_undefined(None),
             };
             // use b2lhs_vid as the index for the new vertex
@@ -737,8 +736,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 );
                 let new_vertex = match tmp {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
-                    (Some(val), None) => Vertex2::merge_undefined(Some(val)),
-                    (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
+                    (Some(val), None) | (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
                     (None, None) => Vertex2::merge_undefined(None),
                 };
                 // update the topology (this is why we need the above lines)
@@ -757,8 +755,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 );
                 let new_vertex = match tmp {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
-                    (Some(val), None) => Vertex2::merge_undefined(Some(val)),
-                    (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
+                    (Some(val), None) | (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
                     (None, None) => Vertex2::merge_undefined(None),
                 };
                 // update the topology (this is why we need the above lines)
@@ -805,15 +802,13 @@ impl<T: CoordsFloat> CMap2<T> {
                 // proceed with new vertices creation & insertion
                 let new_vertexa = match tmpa {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
-                    (Some(val), None) => Vertex2::merge_undefined(Some(val)),
-                    (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
+                    (Some(val), None) | (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
                     (None, None) => Vertex2::merge_undefined(None),
                 };
 
                 let new_vertexb = match tmpb {
                     (Some(val1), Some(val2)) => Vertex2::merge(val1, val2),
-                    (Some(val), None) => Vertex2::merge_undefined(Some(val)),
-                    (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
+                    (Some(val), None) | (None, Some(val)) => Vertex2::merge_undefined(Some(val)),
                     (None, None) => Vertex2::merge_undefined(None),
                 };
                 // update the topology

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -862,7 +862,7 @@ impl<T: CoordsFloat> CMap2<T> {
             let _ = self.replace_vertex(self.vertex_id(b2lhs_dart_id), v1);
             let _ = self.replace_vertex(self.vertex_id(rhs_dart_id), v2);
         } else {
-            self.one_unlink(lhs_dart_id)
+            self.one_unlink(lhs_dart_id);
         }
     }
 
@@ -1057,7 +1057,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// Return an option which may contain the previous value associated to the specified vertex ID.
     ///
     pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
-        self.vertices.insert(vertex_id, vertex.into())
+        self.vertices.insert(vertex_id, vertex.into());
     }
 
     #[allow(clippy::missing_errors_doc)]

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -197,6 +197,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// See [`CMap2`] example.
     ///
+    #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn new(n_darts: usize) -> Self {
         Self {
             vertices: AttrSparseVec::new(n_darts + 1),
@@ -212,11 +213,13 @@ impl<T: CoordsFloat> CMap2<T> {
     // --- read
 
     /// Return information about the current number of darts.
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn n_darts(&self) -> usize {
         self.n_darts
     }
 
     /// Return information about the current number of unused darts.
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn n_unused_darts(&self) -> usize {
         self.unused_darts.len()
     }
@@ -337,6 +340,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The method will panic if *I* is not 0, 1 or 2.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn beta<const I: u8>(&self, dart_id: DartIdentifier) -> DartIdentifier {
         assert!(I < 3);
         self.betas[dart_id as usize][I as usize]
@@ -358,6 +362,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The method will panic if *i* is not 0, 1 or 2.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn beta_runtime(&self, i: u8, dart_id: DartIdentifier) -> DartIdentifier {
         assert!(i < 3);
         match i {
@@ -387,6 +392,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The function will panic if *I* is not 0, 1 or 2.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn is_i_free<const I: u8>(&self, dart_id: DartIdentifier) -> bool {
         self.beta::<I>(dart_id) == NULL_DART_ID
     }
@@ -401,6 +407,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// Return a boolean indicating if the dart is 0-free, 1-free **and** 2-free.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn is_free(&self, dart_id: DartIdentifier) -> bool {
         self.beta::<0>(dart_id) == NULL_DART_ID
             && self.beta::<1>(dart_id) == NULL_DART_ID
@@ -457,6 +464,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// 1. a BFS to compute a given orbit
     /// 2. a minimum computation on the IDs composing the orbit
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn vertex_id(&self, dart_id: DartIdentifier) -> VertexIdentifier {
         // unwraping the result is safe because the orbit is always non empty
         Orbit2::new(self, OrbitPolicy::Vertex, dart_id)
@@ -490,6 +498,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// 1. a BFS to compute a given orbit
     /// 2. a minimum computation on the IDs composing the orbit
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn edge_id(&self, dart_id: DartIdentifier) -> EdgeIdentifier {
         // unwraping the result is safe because the orbit is always non empty
         Orbit2::new(self, OrbitPolicy::Edge, dart_id).min().unwrap() as EdgeIdentifier
@@ -521,6 +530,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// 1. a BFS to compute a given orbit
     /// 2. a minimum computation on the IDs composing the orbit
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn face_id(&self, dart_id: DartIdentifier) -> FaceIdentifier {
         // unwraping the result is safe because the orbit is always non empty
         Orbit2::new(self, OrbitPolicy::Face, dart_id).min().unwrap() as FaceIdentifier
@@ -547,6 +557,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The method will panic if *I* is not 0, 1 or 2.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn i_cell<const I: u8>(&self, dart_id: DartIdentifier) -> Orbit2<T> {
         assert!(I < 3);
         match I {
@@ -564,6 +575,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// Return a [`VertexCollection`] object containing a list of vertex identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn fetch_vertices(&self) -> VertexCollection<T> {
         let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
         // using a set for cells & converting it later to avoid duplicated values
@@ -593,6 +605,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// Return an [`EdgeCollection`] object containing a list of edge identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn fetch_edges(&self) -> EdgeCollection<T> {
         let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
         marked.insert(NULL_DART_ID);
@@ -623,6 +636,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// Return a [`FaceCollection`] object containing a list of face identifiers, whose validity
     /// is ensured through an implicit lifetime condition on the structure and original map.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn fetch_faces(&self) -> FaceCollection<T> {
         let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
         // using a set for cells & converting it later to avoid duplicated values
@@ -1021,6 +1035,7 @@ impl<T: CoordsFloat> CMap2<T> {
 // different kind of attributes for all the i-cells.
 impl<T: CoordsFloat> CMap2<T> {
     /// Return the current number of vertices.
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn n_vertices(&self) -> usize {
         self.vertices.n_attributes()
     }
@@ -1040,6 +1055,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// The method may panic if no vertex is associated to the specified index, or the ID lands
     /// out of bounds.
     ///
+    #[must_use = "returned value is not used, consider removing this method call"]
     pub fn vertex(&self, vertex_id: VertexIdentifier) -> Vertex2<T> {
         self.vertices.get(vertex_id).unwrap()
     }

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -62,7 +62,7 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 /// - cells are ordered from left to right, from the bottom up. The same rule
 ///   applies for face IDs.
 ///
-
+#[must_use = "constructed object is not used, consider removing this function call"]
 pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     let mut map: CMap2<T> = CMap2::new(4 * n_square.pow(2));
 
@@ -162,6 +162,7 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 /// If this function panics, this is most likely due to a mistake in implementation in the core
 /// crate.
 ///
+#[must_use = "constructed object is not used, consider removing this function call"]
 pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     let mut map: CMap2<T> = CMap2::new(6 * n_square.pow(2));
 

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -89,8 +89,8 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     });
 
     // then cells
-    (0..n_square + 1).for_each(|y_idx| {
-        (0..n_square + 1).for_each(|x_idx| {
+    (0..=n_square).for_each(|y_idx| {
+        (0..=n_square).for_each(|x_idx| {
             // update the associated 0-cell
             if (y_idx < n_square) & (x_idx < n_square) {
                 let base_dart = (1 + 4 * x_idx + n_square * 4 * y_idx) as DartIdentifier;
@@ -195,8 +195,8 @@ pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     });
 
     // then cells
-    (0..n_square + 1).for_each(|y_idx| {
-        (0..n_square + 1).for_each(|x_idx| {
+    (0..=n_square).for_each(|y_idx| {
+        (0..=n_square).for_each(|x_idx| {
             // update the associated 0-cell
             if (y_idx < n_square) & (x_idx < n_square) {
                 let base_dart = (1 + 6 * (x_idx + n_square * y_idx)) as DartIdentifier;

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -83,9 +83,9 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
             // if there is an up neighbor, sew sew
             if y_idx != n_square - 1 {
                 let up_neighbor = d1 + (4 * n_square) as DartIdentifier;
-                map.two_link(d3, up_neighbor)
+                map.two_link(d3, up_neighbor);
             }
-        })
+        });
     });
 
     // then cells
@@ -127,7 +127,7 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
                     );
                 }
             }
-        })
+        });
     });
 
     // and then build faces
@@ -189,9 +189,9 @@ pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
             // if there is an up neighbor, sew sew
             if y_idx != n_square - 1 {
                 let up_neighbor = d1 + (6 * n_square) as DartIdentifier;
-                map.two_link(d6, up_neighbor)
+                map.two_link(d6, up_neighbor);
             }
-        })
+        });
     });
 
     // then cells
@@ -233,7 +233,7 @@ pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
                     );
                 }
             }
-        })
+        });
     });
 
     // rebuild faces


### PR DESCRIPTION
Remove specific lints that were previously allowed & fix warnings accordingly

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] Refactor

## Other
