### PR TITLE
feat: add more examples based on benchmarks

### DIFF
--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 [dev-dependencies]
 honeycomb-core = { workspace = true, features = ["utils"] }
 honeycomb-render = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
 
 [[example]]
 name = "memory_usage"
@@ -32,3 +33,7 @@ path = "examples/render/splitsquaremap.rs"
 [[example]]
 name = "render_squaremap"
 path = "examples/render/squaremap.rs"
+
+[[example]]
+name = "render_squaremap_shift"
+path = "examples/render/squaremap_shift.rs"

--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -37,3 +37,11 @@ path = "examples/render/squaremap.rs"
 [[example]]
 name = "render_squaremap_shift"
 path = "examples/render/squaremap_shift.rs"
+
+[[example]]
+name = "render_squaremap_split_diff"
+path = "examples/render/squaremap_split_diff.rs"
+
+[[example]]
+name = "render_squaremap_split_some"
+path = "examples/render/squaremap_split_some.rs"

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -7,6 +7,7 @@ use rand::{
     rngs::SmallRng,
     SeedableRng,
 };
+use std::time::Instant;
 
 fn main() {
     const N_SQUARE: usize = 16;
@@ -14,33 +15,49 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
 
+    println!("I: Start map initialization...");
+    let now = Instant::now();
+    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let elapsed = now.elapsed();
+    println!("I: Finished initializing in {}μs", elapsed.as_micros());
+
+    println!("I: Start offset generation...");
+    let now = Instant::now();
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);
     let range: Uniform<FloatType> = Uniform::new(-0.5, 0.5);
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
-
     let offsets: Vec<Vector2<FloatType>> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
     let n_offsets = offsets.len();
+    let elapsed = now.elapsed();
+    println!(
+        "I: Finished generating offsets in {}μs",
+        elapsed.as_micros()
+    );
 
-    let vertices = map.fetch_vertices();
-
-    vertices.identifiers.iter().for_each(|vertex_id| {
-        let neighbors_vertex_cell: Vec<DartIdentifier> = map
-            .i_cell::<0>(*vertex_id as DartIdentifier)
-            .map(|d_id| map.beta::<2>(d_id))
-            .collect();
-        if !neighbors_vertex_cell.contains(&NULL_DART_ID) {
-            let current_value = map.vertex(*vertex_id);
-            let _ = map.replace_vertex(
-                *vertex_id,
-                current_value + offsets[*vertex_id as usize % n_offsets],
-            );
-        }
-    });
+    println!("I: Start shifting inner vertices...");
+    let now = Instant::now();
+    map.fetch_vertices()
+        .identifiers
+        .iter()
+        .for_each(|vertex_id| {
+            let neighbors_vertex_cell: Vec<DartIdentifier> = map
+                .i_cell::<0>(*vertex_id as DartIdentifier)
+                .map(|d_id| map.beta::<2>(d_id))
+                .collect();
+            if !neighbors_vertex_cell.contains(&NULL_DART_ID) {
+                let current_value = map.vertex(*vertex_id);
+                let _ = map.replace_vertex(
+                    *vertex_id,
+                    current_value + offsets[*vertex_id as usize % n_offsets],
+                );
+            }
+        });
+    let elapsed = now.elapsed();
+    println!("I: Finished shifting in {}μs", elapsed.as_micros());
 
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -1,0 +1,46 @@
+use honeycomb_core::{
+    utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID,
+};
+use honeycomb_render::*;
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::SmallRng,
+    SeedableRng,
+};
+
+fn main() {
+    const N_SQUARE: usize = 16;
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+
+    let seed: u64 = 9817498146784;
+    let mut rngx = SmallRng::seed_from_u64(seed);
+    let mut rngy = SmallRng::seed_from_u64(seed);
+    let range: Uniform<FloatType> = Uniform::new(-0.5, 0.5);
+    let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
+    let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
+
+    let offsets: Vec<Vector2<FloatType>> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
+    let n_offsets = offsets.len();
+
+    let vertices = map.fetch_vertices();
+
+    vertices.identifiers.iter().for_each(|vertex_id| {
+        let neighbors_vertex_cell: Vec<DartIdentifier> = map
+            .i_cell::<0>(*vertex_id as DartIdentifier)
+            .map(|d_id| map.beta::<2>(d_id))
+            .collect();
+        if !neighbors_vertex_cell.contains(&NULL_DART_ID) {
+            let current_value = map.vertex(*vertex_id);
+            let _ = map.replace_vertex(
+                *vertex_id,
+                current_value + offsets[*vertex_id as usize % n_offsets],
+            );
+        }
+    });
+
+    Runner::default().run(render_params, Some(&map));
+}

--- a/honeycomb-examples/examples/render/squaremap_split_diff.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_diff.rs
@@ -1,0 +1,58 @@
+use honeycomb_core::{
+    utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID,
+};
+use honeycomb_render::*;
+use rand::distributions::Bernoulli;
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::SmallRng,
+    SeedableRng,
+};
+
+fn main() {
+    const N_SQUARE: usize = 16;
+    const P_BERNOULLI: f64 = 0.6;
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+
+    let seed: u64 = 9817498146784;
+    let rng = SmallRng::seed_from_u64(seed);
+    let dist = Bernoulli::new(P_BERNOULLI).unwrap();
+    let splits: Vec<bool> = dist.sample_iter(rng).take(N_SQUARE.pow(2)).collect();
+    let n_split = splits.len();
+
+    map.fetch_faces().identifiers.iter().for_each(|square| {
+        let square = *square as DartIdentifier;
+        let (ddown, dright, dup, dleft) = (square, square + 1, square + 2, square + 3);
+        // in a parallel impl, we would create all new darts before-hand
+        let dsplit1 = map.add_free_darts(2);
+        let dsplit2 = dsplit1 + 1;
+
+        let (dbefore1, dbefore2, dafter1, dafter2) = if splits[square as usize % n_split] {
+            (ddown, dup, dleft, dright)
+        } else {
+            (dright, dleft, ddown, dup)
+        };
+
+        // unsew the square & duplicate vertices to avoid data loss
+        // this duplication effectively means that there are two existing vertices
+        // for a short time, before being merged back by the sewing ops
+        map.one_unsew(dbefore1);
+        map.one_unsew(dbefore2);
+        // link the two new dart in order to
+        map.two_link(dsplit1, dsplit2);
+        // define beta1 of the new darts, i.e. tell them where they point to
+        map.one_sew(dsplit1, dafter1);
+        map.one_sew(dsplit2, dafter2);
+
+        // sew the original darts to the new darts
+        map.one_sew(dbefore1, dsplit1);
+        map.one_sew(dbefore2, dsplit2);
+        // fuse the edges; this is where duplicated vertices are merged back together
+    });
+
+    Runner::default().run(render_params, Some(&map));
+}

--- a/honeycomb-examples/examples/render/squaremap_split_some.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_some.rs
@@ -1,13 +1,8 @@
-use honeycomb_core::{
-    utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID,
-};
+use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
 use honeycomb_render::*;
 use rand::distributions::Bernoulli;
-use rand::{
-    distributions::{Distribution, Uniform},
-    rngs::SmallRng,
-    SeedableRng,
-};
+use rand::{distributions::Distribution, rngs::SmallRng, SeedableRng};
+use std::time::Instant;
 
 fn main() {
     const N_SQUARE: usize = 16;
@@ -16,7 +11,12 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
+
+    println!("I: Start map initialization...");
+    let now = Instant::now();
     let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let elapsed = now.elapsed();
+    println!("I: Finished initializing in {}μs", elapsed.as_micros());
 
     let seed: u64 = 9817498146784;
     let rng = SmallRng::seed_from_u64(seed);
@@ -24,6 +24,8 @@ fn main() {
     let splits: Vec<bool> = dist.sample_iter(rng).take(N_SQUARE.pow(2)).collect();
     let n_split = splits.len();
 
+    println!("I: Start quad split process...");
+    let now = Instant::now();
     map.fetch_faces()
         .identifiers
         .iter()
@@ -50,6 +52,8 @@ fn main() {
             map.one_sew(d3, dsplit2);
             // fuse the edges; this is where duplicated vertices are merged back together
         });
+    let elapsed = now.elapsed();
+    println!("I: Finished splitting in {}μs", elapsed.as_micros());
 
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/src/lib.rs
+++ b/honeycomb-examples/src/lib.rs
@@ -13,7 +13,13 @@
 //!
 //! - `render_default_no_aa` -- Render a hardcoded arrow without anti-aliasing.
 //! - `render_default_smaa1x` -- Render a hardcoded arrow with anti-aliasing.
-//! - `render_splitsquaremap` -- Render a map generated using functions provided by
-//!   the **honeycomb-benches** crate.
-//! - `render_squaremap` -- Render a map generated using functions provided by the
-//!   **honeycomb-benches** crate.
+//! - `render_splitsquaremap` -- Render a map generated using functions defined in the `utils`
+//!   module of the core crate
+//! - `render_squaremap` -- Render a map generated using functions  defined in the `utils` module
+//!   of the core crate.
+//! - `render_squaremap_shift` -- Render a map computed by the `squaremap-shift` benchmark. Inner
+//!   vertices are shifted by a random offset value.
+//! - `render_squaremap_split_diff` -- Render a map computed by the `squaremap-splitquads`
+//!   benchmark. All quads are split diagonally, which diagonal chosen at random.
+//! - `render_squaremap_split_some` -- Render a map computed by the `squaremap-splitquads`
+//!   benchmark. Only some quads are split diagonally, chosen at random.

--- a/honeycomb-guide/src/index.md
+++ b/honeycomb-guide/src/index.md
@@ -1,6 +1,6 @@
 # The Honeycomb User Guide
 
-[![Current Version](https://img.shields.io/crates/v/honeycomb-render?label=latest%20release)][CIOHC]
+[![Current Version](https://img.shields.io/crates/v/honeycomb-render?label=latest%20release)](https://crates.io/crates/honeycomb-core)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/LIHPC-Computational-Geometry/honeycomb/latest)][GH]
 [![Build Status](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/build.yml/badge.svg)](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/build.yml)
 [![Rust Tests](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml/badge.svg)](https://github.com/LIHPC-Computational-Geometry/honeycomb/actions/workflows/rust-test.yml)

--- a/honeycomb-guide/src/project-structure/honeycomb-examples.md
+++ b/honeycomb-guide/src/project-structure/honeycomb-examples.md
@@ -17,13 +17,16 @@ cargo run --example <EXAMPLE>
 
 The following examples are available:
 
-| Name                    | Description                                                                                                                                 |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `memory_usage`          | Outputs the memory usage of a given map as three *csv* files. These files can be used to generate charts using the `memory_usage.py` script |
-| `render_default_no_aa`  | Render a hardcoded arrow without anti-aliasing                                                                                              |
-| `render_default_smaa1x` | Render a hardcoded arrow with anti-aliasing                                                                                                 |
-| `render_splitsquaremap` | Render a map generated using functions provided by the **honeycomb-utils** crate                                                            |
-| `render_squaremap`      | Render a map generated using functions provided by the **honeycomb-utils** crate                                                            |
+| Name                          | Description                                                                                                                                 |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `memory_usage`                | Outputs the memory usage of a given map as three *csv* files. These files can be used to generate charts using the `memory_usage.py` script |
+| `render_default_no_aa`        | Render a hardcoded arrow without anti-aliasing                                                                                              |
+| `render_default_smaa1x`       | Render a hardcoded arrow with anti-aliasing                                                                                                 |
+| `render_splitsquaremap`       | Render a map generated using functions provided by the `utils` module of the core crate                                                     |
+| `render_squaremap`            | Render a map generated using functions provided by the `utils` module of the core crate                                                     |
+| `render_squaremap_shift`      | Render a map computed by the `squaremap-shift` benchmark. Inner vertices are shifted by a random offset value.                              |
+| `render_squaremap_split_diff` | Render a map computed by the `squaremap-splitquads` benchmark. All quads are split diagonally, which diagonal chosen at random.             |
+| `render_squaremap_split_some` | Render a map computed by the `squaremap-splitquads` benchmark. Only some quads are split diagonally, chosen at random.                      |
 
 ### Scripts
 


### PR DESCRIPTION
Add three new examples: 

- `render_squaremap_shift`
- `render_squaremap_split_diff`
- `render_squaremap_split_some`

All of these are based on the eponymous benchmarks. The shifting one only shifts inner vertices of the grid. Also, these examples will print some timing information at execution; There's no reason for it other than "it's cool".

## Scope

- [x] Code: `honeycomb-examples`

## Type of change

- [x] New feature(s)

## Other

- [x] New dependency: `honeycomb-examples` now uses the rand crate for the new examples

