### PR TITLE
fix: add a hardcap to frames rendered per second of the visualizer

### DIFF
--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -19,13 +19,7 @@ pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
     0.0, 0.0, 0.0, 1.0,
 );
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
-        pub const SPEED_FACTOR: f32 = 0.005;
-    } else {
-        pub const SPEED_FACTOR: f32 = 0.05;
-    }
-}
+pub const SPEED_FACTOR: f32 = 0.005;
 
 pub struct Camera {
     pub eye: cgmath::Point3<f32>,
@@ -136,7 +130,7 @@ impl CameraController {
         }
     }
 
-    pub fn update_camera(&mut self, camera: &mut Camera) {
+    pub fn update_camera(&mut self, camera: &mut Camera, delta_t: f32) {
         use cgmath::InnerSpace;
         let forward = camera.target - camera.eye;
         let forward_dir = forward.normalize();

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -19,7 +19,7 @@ pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
     0.0, 0.0, 0.0, 1.0,
 );
 
-pub const SPEED_FACTOR: f32 = 0.005;
+pub const SPEED_FACTOR: f32 = 0.015;
 
 pub struct Camera {
     pub eye: cgmath::Point3<f32>,

--- a/honeycomb-render/src/camera.rs
+++ b/honeycomb-render/src/camera.rs
@@ -130,7 +130,7 @@ impl CameraController {
         }
     }
 
-    pub fn update_camera(&mut self, camera: &mut Camera, delta_t: f32) {
+    pub fn update_camera(&mut self, camera: &mut Camera) {
         use cgmath::InnerSpace;
         let forward = camera.target - camera.eye;
         let forward_dir = forward.normalize();

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -33,9 +33,13 @@ async fn inner<T: CoordsFloat>(
     } else {
         State::new_test(&window, render_params).await
     };
-
+    let mut instant = std::time::Instant::now();
     event_loop
         .run(move |event, target| {
+            // update time elapsed since last frame
+            state.delta_t = instant.elapsed();
+            instant = std::time::Instant::now();
+            // process events
             match event {
                 Event::WindowEvent {
                     window_id,

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
 
 const TARGET_FPS: f32 = 240.;
 
-/// This yields an approximate 60 FPS
+/// This yields an approximate 240 FPS
 const MS_PER_FRAME: u128 = (1000. / TARGET_FPS) as u128;
 
 async fn inner<T: CoordsFloat>(

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -61,7 +61,6 @@ pub struct State<'a, T: CoordsFloat> {
     smaa_target: smaa::SmaaTarget,
     map_handle: Option<CMap2RenderHandle<'a, T>>,
     window: &'a Window,
-    pub delta_t: std::time::Duration,
 }
 
 async fn inner(
@@ -294,7 +293,6 @@ impl<'a, T: CoordsFloat> State<'a, T> {
             smaa_target,
             map_handle: Some(map_handle),
             window,
-            delta_t: std::time::Duration::default(),
         }
     }
 
@@ -351,7 +349,6 @@ impl<'a, T: CoordsFloat> State<'a, T> {
             smaa_target,
             map_handle: None,
             window,
-            delta_t: std::time::Duration::default(),
         }
     }
 
@@ -372,8 +369,7 @@ impl<'a, T: CoordsFloat> State<'a, T> {
     }
 
     pub fn update(&mut self) {
-        self.camera_controller
-            .update_camera(&mut self.camera, self.delta_t.as_secs_f32());
+        self.camera_controller.update_camera(&mut self.camera);
         self.camera_uniform.update_view_proj(&self.camera);
         self.queue.write_buffer(
             &self.camera_buffer,

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -49,7 +49,7 @@ pub struct State<'a, T: CoordsFloat> {
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
-    size: winit::dpi::PhysicalSize<u32>,
+    size: PhysicalSize<u32>,
     render_pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     num_vertices: u32,
@@ -356,7 +356,7 @@ impl<'a, T: CoordsFloat> State<'a, T> {
         self.window
     }
 
-    pub fn resize(&mut self, new_size_opt: Option<winit::dpi::PhysicalSize<u32>>) {
+    pub fn resize(&mut self, new_size_opt: Option<PhysicalSize<u32>>) {
         let new_size = new_size_opt.unwrap_or(self.size);
         self.config.width = new_size.width.max(1);
         self.config.height = new_size.height.max(1);

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -61,6 +61,7 @@ pub struct State<'a, T: CoordsFloat> {
     smaa_target: smaa::SmaaTarget,
     map_handle: Option<CMap2RenderHandle<'a, T>>,
     window: &'a Window,
+    pub delta_t: std::time::Duration,
 }
 
 async fn inner(
@@ -293,6 +294,7 @@ impl<'a, T: CoordsFloat> State<'a, T> {
             smaa_target,
             map_handle: Some(map_handle),
             window,
+            delta_t: std::time::Duration::default(),
         }
     }
 
@@ -349,6 +351,7 @@ impl<'a, T: CoordsFloat> State<'a, T> {
             smaa_target,
             map_handle: None,
             window,
+            delta_t: std::time::Duration::default(),
         }
     }
 
@@ -369,7 +372,8 @@ impl<'a, T: CoordsFloat> State<'a, T> {
     }
 
     pub fn update(&mut self) {
-        self.camera_controller.update_camera(&mut self.camera);
+        self.camera_controller
+            .update_camera(&mut self.camera, self.delta_t.as_secs_f32());
         self.camera_uniform.update_view_proj(&self.camera);
         self.queue.write_buffer(
             &self.camera_buffer,


### PR DESCRIPTION
Add a 240FPS hardcap on FPS of the rendering tool. While this does not de-correlates input speed from machine performance, the cap is very easily reached so the effect is almost the same.

## Scope

- [x] Code: `honeycomb-render`

## Type of change

- [x] Fix: closes #20 
