### PR TITLE
fix: address various unwanted behaviors

### DIFF
--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -690,9 +690,11 @@ impl<T: CoordsFloat> CMap2<T> {
         // if that is not the case, the sewing operation becomes a linking operation
         let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
         if b2lhs_dart_id == NULL_DART_ID {
-            // WARNING: UNWANTED BEHAVIOR
-            // there should be a check in order to ensure that vertex(rhs_dart) is defined
-            // otherwise, panic because the user should call link, not sew
+            assert!(
+                self.vertices.get(&(self.vertex_id(rhs_dart_id))).is_some(),
+                "{}",
+                format!("No vertex defined on vertex {rhs_dart_id}, use `one_link` instead of `one_sew`")
+            );
             self.one_link(lhs_dart_id, rhs_dart_id);
         } else {
             let b2lhs_vid_old = self.vertex_id(b2lhs_dart_id);
@@ -1599,7 +1601,7 @@ mod tests {
         assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.0)));
     }
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "No vertex defined on vertex 2, use `one_link` instead of `one_sew`")]
     fn one_sew_no_attributes() {
         let mut map: CMap2<FloatType> = CMap2::new(2);
         map.one_sew(1, 2); // should panic

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -693,7 +693,9 @@ impl<T: CoordsFloat> CMap2<T> {
             assert!(
                 self.vertices.get(&(self.vertex_id(rhs_dart_id))).is_some(),
                 "{}",
-                format!("No vertex defined on vertex {rhs_dart_id}, use `one_link` instead of `one_sew`")
+                format!(
+                    "No vertex defined on dart {rhs_dart_id}, use `one_link` instead of `one_sew`"
+                )
             );
             self.one_link(lhs_dart_id, rhs_dart_id);
         } else {
@@ -747,6 +749,11 @@ impl<T: CoordsFloat> CMap2<T> {
                 // WARNING: UNWANTED BEHAVIOR
                 // there should be a check in order to ensure that each dart has associated vertices
                 // otherwise, panic because the user should call link, not sew
+                assert!(
+                    self.vertices.get(&(self.vertex_id(lhs_dart_id))).is_some() | self.vertices.get(&(self.vertex_id(rhs_dart_id))).is_some(),
+                    "{}",
+                    format!("No vertices defined on either darts {lhs_dart_id}/{rhs_dart_id} , use `two_link` instead of `two_sew`")
+                );
                 self.two_link(lhs_dart_id, rhs_dart_id);
             }
             // update vertex associated to b1rhs/lhs
@@ -1543,7 +1550,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(
+        expected = "No vertices defined on either darts 1/2 , use `two_link` instead of `two_sew`"
+    )]
     fn two_sew_no_attributes() {
         let mut map: CMap2<FloatType> = CMap2::new(2);
         map.two_sew(1, 2); // should panic
@@ -1601,7 +1610,7 @@ mod tests {
         assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.0)));
     }
     #[test]
-    #[should_panic(expected = "No vertex defined on vertex 2, use `one_link` instead of `one_sew`")]
+    #[should_panic(expected = "No vertex defined on dart 2, use `one_link` instead of `one_sew`")]
     fn one_sew_no_attributes() {
         let mut map: CMap2<FloatType> = CMap2::new(2);
         map.one_sew(1, 2); // should panic

--- a/honeycomb-core/src/twomap.rs
+++ b/honeycomb-core/src/twomap.rs
@@ -1541,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    //#[should_panic]
+    #[should_panic]
     fn two_sew_no_attributes() {
         let mut map: CMap2<FloatType> = CMap2::new(2);
         map.two_sew(1, 2); // should panic
@@ -1599,7 +1599,7 @@ mod tests {
         assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.0)));
     }
     #[test]
-    //#[should_panic]
+    #[should_panic]
     fn one_sew_no_attributes() {
         let mut map: CMap2<FloatType> = CMap2::new(2);
         map.one_sew(1, 2); // should panic

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -81,39 +81,43 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
 
     pub fn build_darts(&mut self) {
         // get all faces
-        let tmp = self.intermediate_buffer.iter().flat_map(|face| {
-            (0..face.n_vertices).flat_map(|id| {
-                let mut v1 = face.vertices[id];
-                let mut v6 = face.vertices[(id + 1) % face.n_vertices];
+        let tmp = self
+            .intermediate_buffer
+            .iter()
+            .filter(|face| face.n_vertices > 1)
+            .flat_map(|face| {
+                (0..face.n_vertices).flat_map(|id| {
+                    let mut v1 = face.vertices[id];
+                    let mut v6 = face.vertices[(id + 1) % face.n_vertices];
 
-                let seg_dir = (v6 - v1).unit_dir().unwrap();
-                v1 += seg_dir * T::from(self.params.shrink_factor).unwrap();
-                v6 -= seg_dir * T::from(self.params.shrink_factor).unwrap();
+                    let seg_dir = (v6 - v1).unit_dir().unwrap();
+                    v1 += seg_dir * T::from(self.params.shrink_factor).unwrap();
+                    v6 -= seg_dir * T::from(self.params.shrink_factor).unwrap();
 
-                let seg = v6 - v1;
-                let seg_length = seg.norm();
-                let seg_dir = seg.unit_dir().unwrap();
-                let seg_normal = seg.normal_dir();
-                let ahs = T::from(self.params.arrow_headsize).unwrap();
-                let at = T::from(self.params.arrow_thickness).unwrap();
+                    let seg = v6 - v1;
+                    let seg_length = seg.norm();
+                    let seg_dir = seg.unit_dir().unwrap();
+                    let seg_normal = seg.normal_dir();
+                    let ahs = T::from(self.params.arrow_headsize).unwrap();
+                    let at = T::from(self.params.arrow_thickness).unwrap();
 
-                let vcenter = v6 - seg_dir * ahs;
-                let v2 = vcenter - seg_normal * at;
-                let v3 = vcenter + seg_normal * at;
-                let v4 = vcenter + seg_normal * (ahs * seg_length);
-                let v5 = vcenter - seg_normal * (ahs * seg_length);
+                    let vcenter = v6 - seg_dir * ahs;
+                    let v2 = vcenter - seg_normal * at;
+                    let v3 = vcenter + seg_normal * at;
+                    let v4 = vcenter + seg_normal * (ahs * seg_length);
+                    let v5 = vcenter - seg_normal * (ahs * seg_length);
 
-                [
-                    Coords2Shader::from((v1, Entity::Dart)),
-                    Coords2Shader::from((v2, Entity::Dart)),
-                    Coords2Shader::from((v3, Entity::Dart)),
-                    Coords2Shader::from((v4, Entity::Dart)),
-                    Coords2Shader::from((v5, Entity::Dart)),
-                    Coords2Shader::from((v6, Entity::Dart)),
-                ]
-                .into_iter()
-            })
-        });
+                    [
+                        Coords2Shader::from((v1, Entity::Dart)),
+                        Coords2Shader::from((v2, Entity::Dart)),
+                        Coords2Shader::from((v3, Entity::Dart)),
+                        Coords2Shader::from((v4, Entity::Dart)),
+                        Coords2Shader::from((v5, Entity::Dart)),
+                        Coords2Shader::from((v6, Entity::Dart)),
+                    ]
+                    .into_iter()
+                })
+            });
         self.dart_construction_buffer.extend(tmp);
     }
 


### PR DESCRIPTION
Fix the following unwanted behaviors:
- `i_sew` executing instead of panicking when no associated attributes are defined on the given darts
- skip over rendering darts for faces that have one or less vertex

## Scope

- [x] Code: `honeycomb-core`, `honeycomb-render`

## Type of change

- [x] Fix
