### PR TITLE
feat: add control over grid generation using a builder struct

### DIFF
--- a/honeycomb-benches/benches/core/cmap2/editing.rs
+++ b/honeycomb-benches/benches/core/cmap2/editing.rs
@@ -23,11 +23,11 @@ use std::hint::black_box;
 // ------ CONTENT
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    GridBuilder::unit_squares(n_square).build2()
+    GridBuilder::unit_squares(n_square).build2().unwrap()
 }
 
 fn get_sparse_map(n_square: usize) -> CMap2<FloatType> {
-    let mut map = GridBuilder::unit_squares(n_square).build2();
+    let mut map = GridBuilder::unit_squares(n_square).build2().unwrap();
     map.set_betas(5, [0; 3]); // free dart 5
     map.remove_free_dart(5);
     // because of the way we built the map in the square_cmap2 function & the ID computation

--- a/honeycomb-benches/benches/core/cmap2/editing.rs
+++ b/honeycomb-benches/benches/core/cmap2/editing.rs
@@ -14,7 +14,7 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vertex2};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vertex2};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
@@ -23,11 +23,11 @@ use std::hint::black_box;
 // ------ CONTENT
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    square_cmap2::<FloatType>(n_square)
+    GridBuilder::unit_squares(n_square).build2()
 }
 
 fn get_sparse_map(n_square: usize) -> CMap2<FloatType> {
-    let mut map = square_cmap2::<FloatType>(n_square);
+    let mut map = GridBuilder::unit_squares(n_square).build2();
     map.set_betas(5, [0; 3]); // free dart 5
     map.remove_free_dart(5);
     // because of the way we built the map in the square_cmap2 function & the ID computation

--- a/honeycomb-benches/benches/core/cmap2/reading.rs
+++ b/honeycomb-benches/benches/core/cmap2/reading.rs
@@ -23,7 +23,7 @@ use std::hint::black_box;
 // ------ CONTENT
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    GridBuilder::unit_squares(n_square).build2()
+    GridBuilder::unit_squares(n_square).build2().unwrap()
 }
 
 #[library_benchmark]

--- a/honeycomb-benches/benches/core/cmap2/reading.rs
+++ b/honeycomb-benches/benches/core/cmap2/reading.rs
@@ -14,7 +14,7 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
@@ -23,7 +23,7 @@ use std::hint::black_box;
 // ------ CONTENT
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    square_cmap2::<FloatType>(n_square)
+    GridBuilder::unit_squares(n_square).build2()
 }
 
 #[library_benchmark]

--- a/honeycomb-benches/benches/core/cmap2/sewing.rs
+++ b/honeycomb-benches/benches/core/cmap2/sewing.rs
@@ -28,7 +28,7 @@ fn compute_dims(n_square: usize) -> usize {
 }
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    GridBuilder::unit_squares(n_square).build2()
+    GridBuilder::unit_squares(n_square).build2().unwrap()
 }
 
 fn get_unstructured_map(n_square: usize) -> CMap2<FloatType> {

--- a/honeycomb-benches/benches/core/cmap2/sewing.rs
+++ b/honeycomb-benches/benches/core/cmap2/sewing.rs
@@ -15,7 +15,7 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::square_cmap2, CMap2, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
@@ -28,7 +28,7 @@ fn compute_dims(n_square: usize) -> usize {
 }
 
 fn get_map(n_square: usize) -> CMap2<FloatType> {
-    square_cmap2::<FloatType>(n_square)
+    GridBuilder::unit_squares(n_square).build2()
 }
 
 fn get_unstructured_map(n_square: usize) -> CMap2<FloatType> {

--- a/honeycomb-benches/benches/splitsquaremap/init.rs
+++ b/honeycomb-benches/benches/splitsquaremap/init.rs
@@ -9,7 +9,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration, Throughput,
 };
-use honeycomb_core::{utils::splitsquare_cmap2, CMap2, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
 
 // ------ CONTENT
 
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<FloatType> = splitsquare_cmap2(*n_square);
+                let mut map: CMap2<FloatType> = GridBuilder::split_unit_squares(*n_square).build2();
                 black_box(&mut map);
             })
         });

--- a/honeycomb-benches/benches/splitsquaremap/init.rs
+++ b/honeycomb-benches/benches/splitsquaremap/init.rs
@@ -23,7 +23,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<FloatType> = GridBuilder::split_unit_squares(*n_square).build2();
+                let mut map: CMap2<FloatType> =
+                    GridBuilder::split_unit_squares(*n_square).build2().unwrap();
                 black_box(&mut map);
             })
         });

--- a/honeycomb-benches/benches/splitsquaremap/shift.rs
+++ b/honeycomb-benches/benches/splitsquaremap/shift.rs
@@ -68,7 +68,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<FloatType> = GridBuilder::split_unit_squares(N_SQUARE).build2();
+    let map: CMap2<FloatType> = GridBuilder::split_unit_squares(N_SQUARE).build2().unwrap();
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);

--- a/honeycomb-benches/benches/splitsquaremap/shift.rs
+++ b/honeycomb-benches/benches/splitsquaremap/shift.rs
@@ -24,8 +24,7 @@ use rand::{
 };
 
 use honeycomb_core::{
-    utils::splitsquare_cmap2, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier,
-    NULL_DART_ID,
+    utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier, NULL_DART_ID,
 };
 
 // ------ CONTENT
@@ -69,7 +68,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<FloatType> = splitsquare_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = GridBuilder::split_unit_squares(N_SQUARE).build2();
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);

--- a/honeycomb-benches/benches/squaremap/init.rs
+++ b/honeycomb-benches/benches/squaremap/init.rs
@@ -23,7 +23,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<FloatType> = GridBuilder::unit_squares(*n_square).build2();
+                let mut map: CMap2<FloatType> =
+                    GridBuilder::unit_squares(*n_square).build2().unwrap();
                 black_box(&mut map);
             })
         });

--- a/honeycomb-benches/benches/squaremap/init.rs
+++ b/honeycomb-benches/benches/squaremap/init.rs
@@ -9,7 +9,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration, Throughput,
 };
-use honeycomb_core::{utils::square_cmap2, CMap2, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
 
 // ------ CONTENT
 
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.throughput(Throughput::Elements(n_square.pow(2) as u64));
         group.bench_with_input(BenchmarkId::new("init", ""), &n_square, |b, n_square| {
             b.iter(|| {
-                let mut map: CMap2<FloatType> = square_cmap2(*n_square);
+                let mut map: CMap2<FloatType> = GridBuilder::unit_squares(*n_square).build2();
                 black_box(&mut map);
             })
         });

--- a/honeycomb-benches/benches/squaremap/shift.rs
+++ b/honeycomb-benches/benches/squaremap/shift.rs
@@ -68,7 +68,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
+    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);

--- a/honeycomb-benches/benches/squaremap/shift.rs
+++ b/honeycomb-benches/benches/squaremap/shift.rs
@@ -24,7 +24,7 @@ use rand::{
 };
 
 use honeycomb_core::{
-    utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier, NULL_DART_ID,
+    utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier, NULL_DART_ID,
 };
 
 // ------ CONTENT
@@ -68,7 +68,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     const N_SQUARE: usize = 2_usize.pow(11);
-    let map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);

--- a/honeycomb-benches/benches/squaremap/split.rs
+++ b/honeycomb-benches/benches/squaremap/split.rs
@@ -19,13 +19,12 @@
 // ------ IMPORTS
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 use rand::{
     distributions::{Bernoulli, Distribution},
     rngs::SmallRng,
     SeedableRng,
 };
-
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
 
 // ------ CONTENT
 
@@ -143,7 +142,7 @@ fn split_diff(mut map: CMap2<FloatType>, split: &[bool]) {
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
     let seed: u64 = 9817498146784;
     let rng = SmallRng::seed_from_u64(seed);
     let dist = Bernoulli::new(P_BERNOULLI).unwrap();

--- a/honeycomb-benches/benches/squaremap/split.rs
+++ b/honeycomb-benches/benches/squaremap/split.rs
@@ -142,7 +142,7 @@ fn split_diff(mut map: CMap2<FloatType>, split: &[bool]) {
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
+    let map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let seed: u64 = 9817498146784;
     let rng = SmallRng::seed_from_u64(seed);
     let dist = Bernoulli::new(P_BERNOULLI).unwrap();

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -596,6 +596,22 @@ mod tests {
     }
 
     #[test]
+    fn build_incomplete() {
+        assert!(GridBuilder::default()
+            .len_per_cell([1.0_f64, 1.0_f64, 1.0_f64])
+            .build2()
+            .is_err());
+        assert!(<GridBuilder<f64>>::default()
+            .n_cells([4, 4, 0])
+            .build2()
+            .is_err());
+        assert!(GridBuilder::default()
+            .lens([4.0_f64, 4.0_f64, 4.0_f64])
+            .build2()
+            .is_err());
+    }
+
+    #[test]
     fn square_cmap2_correctness() {
         let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2().unwrap();
 

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -18,6 +18,22 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 
 // --- INNER ROUTINES
 
+/// todo
+///
+/// # Arguments
+///
+/// - `arg: type` --
+///
+/// # Return / Panic
+///
+///
+///
+/// # Example
+///
+/// ```text
+///
+/// ```
+///
 fn build2_grid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
@@ -106,6 +122,22 @@ fn build2_grid<T: CoordsFloat>(
     map
 }
 
+/// todo
+///
+/// # Arguments
+///
+/// - `arg: type` --
+///
+/// # Return / Panic
+///
+///
+///
+/// # Example
+///
+/// ```text
+///
+/// ```
+///
 fn build2_splitgrid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
@@ -224,6 +256,47 @@ pub struct GridBuilder<T: CoordsFloat> {
     len_per_cell: Option<[T; 3]>,
     lens: Option<[T; 3]>,
     split_quads: bool,
+}
+
+// editing methods
+impl<T: CoordsFloat> GridBuilder<T> {
+    // n_cells
+
+    #[must_use]
+    pub fn n_cells(mut self, n_cells: [usize; 3]) -> Self {
+        self.n_cells = Some(n_cells);
+        self
+    }
+
+    #[must_use]
+    pub fn n_cells_x(mut self, n_cells: usize) -> Self {
+        if let Some([nx, _, _]) = &mut self.n_cells {
+            *nx = n_cells;
+        } else {
+            self.n_cells = Some([n_cells, 0, 0]);
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn n_cells_y(mut self, n_cells: usize) -> Self {
+        if let Some([_, ny, _]) = &mut self.n_cells {
+            *ny = n_cells;
+        } else {
+            self.n_cells = Some([0, n_cells, 0]);
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn n_cells_z(mut self, n_cells: usize) -> Self {
+        if let Some([_, _, nz]) = &mut self.n_cells {
+            *nz = n_cells;
+        } else {
+            self.n_cells = Some([0, 0, n_cells]);
+        }
+        self
+    }
 }
 
 // building methods

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -258,45 +258,63 @@ pub struct GridBuilder<T: CoordsFloat> {
     split_quads: bool,
 }
 
+macro_rules! setters {
+    ($fld: ident, $fldx: ident, $fldy: ident, $fldz: ident, $zero: expr, $fldty: ty) => {
+        #[must_use]
+        pub fn $fld(mut self, $fld: [$fldty; 3]) -> Self {
+            self.$fld = Some($fld);
+            self
+        }
+
+        #[must_use]
+        pub fn $fldx(mut self, $fld: $fldty) -> Self {
+            if let Some([ptr, _, _]) = &mut self.$fld {
+                *ptr = $fld;
+            } else {
+                self.$fld = Some([$fld, $zero, $zero]);
+            }
+            self
+        }
+
+        #[must_use]
+        pub fn $fldy(mut self, $fld: $fldty) -> Self {
+            if let Some([_, ptr, _]) = &mut self.$fld {
+                *ptr = $fld;
+            } else {
+                self.$fld = Some([$zero, $fld, $zero]);
+            }
+            self
+        }
+
+        #[must_use]
+        pub fn $fldz(mut self, $fld: $fldty) -> Self {
+            if let Some([_, _, ptr]) = &mut self.$fld {
+                *ptr = $fld;
+            } else {
+                self.$fld = Some([$zero, $zero, $fld]);
+            }
+            self
+        }
+    };
+}
+
 // editing methods
 impl<T: CoordsFloat> GridBuilder<T> {
     // n_cells
+    setters!(n_cells, n_cells_x, n_cells_y, n_cells_z, 0, usize);
 
-    #[must_use]
-    pub fn n_cells(mut self, n_cells: [usize; 3]) -> Self {
-        self.n_cells = Some(n_cells);
-        self
-    }
+    // len_per_cell
+    setters!(
+        len_per_cell,
+        len_per_cell_x,
+        len_per_cell_y,
+        len_per_cell_z,
+        T::zero(),
+        T
+    );
 
-    #[must_use]
-    pub fn n_cells_x(mut self, n_cells: usize) -> Self {
-        if let Some([nx, _, _]) = &mut self.n_cells {
-            *nx = n_cells;
-        } else {
-            self.n_cells = Some([n_cells, 0, 0]);
-        }
-        self
-    }
-
-    #[must_use]
-    pub fn n_cells_y(mut self, n_cells: usize) -> Self {
-        if let Some([_, ny, _]) = &mut self.n_cells {
-            *ny = n_cells;
-        } else {
-            self.n_cells = Some([0, n_cells, 0]);
-        }
-        self
-    }
-
-    #[must_use]
-    pub fn n_cells_z(mut self, n_cells: usize) -> Self {
-        if let Some([_, _, nz]) = &mut self.n_cells {
-            *nz = n_cells;
-        } else {
-            self.n_cells = Some([0, 0, n_cells]);
-        }
-        self
-    }
+    // lens
+    setters!(lens, lens_x, lens_y, lens_z, T::zero(), T);
 }
 
 // building methods

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -213,12 +213,12 @@ fn build2_splitgrid<T: CoordsFloat>(
 /// This enum is used to describe all non-panic errors that can occur when using a builder
 /// structure.
 #[derive(Debug)]
-pub enum BuilderError<'a> {
+pub enum BuilderError {
     /// The builder is missing one or multiple parameters in order to proceed with the requested
     /// operation.
-    MissingParameters(&'a str),
+    MissingParameters(&'static str),
     /// One or multiple of the builder's fields are invalid.
-    InvalidParameters(&'a str),
+    InvalidParameters(&'static str),
 }
 
 /// Builder structure for specialized [`CMap2`].
@@ -361,7 +361,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
     ///
     /// See [`GridBuilder`] example.
     ///
-    pub fn build2<'a>(self) -> Result<CMap2<T>, BuilderError<'a>> {
+    pub fn build2(self) -> Result<CMap2<T>, BuilderError> {
         // preprocess parameters
         let (ns_square, lens_per_cell): ([usize; 2], [T; 2]) = match (
             self.n_cells,

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -110,7 +110,98 @@ fn build2_splitgrid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
 ) -> CMap2<T> {
-    todo!()
+    let mut map: CMap2<T> = CMap2::new(6 * n_square_x * n_square_y);
+
+    // first, topology
+    (0..n_square_y).for_each(|y_idx| {
+        (0..n_square_x).for_each(|x_idx| {
+            let d1 = (1 + 6 * (x_idx + n_square_x * y_idx)) as DartIdentifier;
+            let (d2, d3, d4, d5, d6) = (d1 + 1, d1 + 2, d1 + 3, d1 + 4, d1 + 5);
+            // bottom left triangle
+            map.one_link(d1, d2);
+            map.one_link(d2, d3);
+            map.one_link(d3, d1);
+            // top right triangle
+            map.one_link(d4, d5);
+            map.one_link(d5, d6);
+            map.one_link(d6, d4);
+            // diagonal
+            map.two_link(d2, d4);
+
+            // if there is a right neighbor, sew sew
+            if x_idx != n_square_x - 1 {
+                let right_neighbor = d1 + 8;
+                map.two_link(d5, right_neighbor);
+            }
+            // if there is an up neighbor, sew sew
+            if y_idx != n_square_x - 1 {
+                let up_neighbor = d1 + (6 * n_square_x) as DartIdentifier;
+                map.two_link(d6, up_neighbor);
+            }
+        });
+    });
+
+    // then cells
+    (0..=n_square_y).for_each(|y_idx| {
+        (0..=n_square_x).for_each(|x_idx| {
+            // update the associated 0-cell
+            if (y_idx < n_square_y) & (x_idx < n_square_x) {
+                let base_dart = (1 + 6 * (x_idx + n_square_x * y_idx)) as DartIdentifier;
+                let vertex_id = map.vertex_id(base_dart);
+                map.insert_vertex(
+                    vertex_id,
+                    (
+                        T::from(x_idx).unwrap() * len_per_x,
+                        T::from(y_idx).unwrap() * len_per_y,
+                    ),
+                );
+                let last_column = x_idx == n_square_x - 1;
+                let last_row = y_idx == n_square_y - 1;
+                if last_column {
+                    // that last column of 0-cell needs special treatment
+                    // bc there are no "horizontal" associated dart
+                    let vertex_id = map.vertex_id(base_dart + 4);
+                    map.insert_vertex(
+                        vertex_id,
+                        (
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx).unwrap() * len_per_y,
+                        ),
+                    );
+                }
+                if last_row {
+                    // same as the case on x
+                    let vertex_id = map.vertex_id(base_dart + 2);
+                    map.insert_vertex(
+                        vertex_id,
+                        (
+                            T::from(x_idx).unwrap() * len_per_x,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
+                        ),
+                    );
+                }
+                if last_row & last_column {
+                    // need to do the upper right corner
+                    let vertex_id = map.vertex_id(base_dart + 5);
+                    map.insert_vertex(
+                        vertex_id,
+                        (
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
+                        ),
+                    );
+                }
+            }
+        });
+    });
+
+    // rebuild faces
+    assert_eq!(
+        map.fetch_faces().identifiers.len(),
+        n_square_x * n_square_y * 2
+    );
+
+    map
 }
 
 // --- PUBLIC API
@@ -244,83 +335,7 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 ///
 #[must_use = "constructed object is not used, consider removing this function call"]
 pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
-    let mut map: CMap2<T> = CMap2::new(6 * n_square.pow(2));
-
-    // first, topology
-    (0..n_square).for_each(|y_idx| {
-        (0..n_square).for_each(|x_idx| {
-            let d1 = (1 + 6 * (x_idx + n_square * y_idx)) as DartIdentifier;
-            let (d2, d3, d4, d5, d6) = (d1 + 1, d1 + 2, d1 + 3, d1 + 4, d1 + 5);
-            // bottom left triangle
-            map.one_link(d1, d2);
-            map.one_link(d2, d3);
-            map.one_link(d3, d1);
-            // top right triangle
-            map.one_link(d4, d5);
-            map.one_link(d5, d6);
-            map.one_link(d6, d4);
-            // diagonal
-            map.two_link(d2, d4);
-
-            // if there is a right neighbor, sew sew
-            if x_idx != n_square - 1 {
-                let right_neighbor = d1 + 8;
-                map.two_link(d5, right_neighbor);
-            }
-            // if there is an up neighbor, sew sew
-            if y_idx != n_square - 1 {
-                let up_neighbor = d1 + (6 * n_square) as DartIdentifier;
-                map.two_link(d6, up_neighbor);
-            }
-        });
-    });
-
-    // then cells
-    (0..=n_square).for_each(|y_idx| {
-        (0..=n_square).for_each(|x_idx| {
-            // update the associated 0-cell
-            if (y_idx < n_square) & (x_idx < n_square) {
-                let base_dart = (1 + 6 * (x_idx + n_square * y_idx)) as DartIdentifier;
-                let vertex_id = map.vertex_id(base_dart);
-                map.insert_vertex(
-                    vertex_id,
-                    (T::from(x_idx).unwrap(), T::from(y_idx).unwrap()),
-                );
-                let last_column = x_idx == n_square - 1;
-                let last_row = y_idx == n_square - 1;
-                if last_column {
-                    // that last column of 0-cell needs special treatment
-                    // bc there are no "horizontal" associated dart
-                    let vertex_id = map.vertex_id(base_dart + 4);
-                    map.insert_vertex(
-                        vertex_id,
-                        (T::from(x_idx + 1).unwrap(), T::from(y_idx).unwrap()),
-                    );
-                }
-                if last_row {
-                    // same as the case on x
-                    let vertex_id = map.vertex_id(base_dart + 2);
-                    map.insert_vertex(
-                        vertex_id,
-                        (T::from(x_idx).unwrap(), T::from(y_idx + 1).unwrap()),
-                    );
-                }
-                if last_row & last_column {
-                    // need to do the upper right corner
-                    let vertex_id = map.vertex_id(base_dart + 5);
-                    map.insert_vertex(
-                        vertex_id,
-                        (T::from(x_idx + 1).unwrap(), T::from(y_idx + 1).unwrap()),
-                    );
-                }
-            }
-        });
-    });
-
-    // rebuild faces
-    assert_eq!(map.fetch_faces().identifiers.len(), n_square.pow(2) * 2);
-
-    map
+    build2_splitgrid([n_square, n_square], [T::one(), T::one()])
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -256,6 +256,26 @@ impl<T: CoordsFloat> GridBuilder<T> {
     }
 }
 
+// predefinite constructs
+impl<T: CoordsFloat> GridBuilder<T> {
+    pub fn unit_squares(n_square: usize) -> Self {
+        Self {
+            ns_cell: Some([n_square; 3]),
+            lens_per_cell: Some([T::one(); 3]),
+            ..Default::default()
+        }
+    }
+
+    pub fn split_unit_squares(n_square: usize) -> Self {
+        Self {
+            ns_cell: Some([n_square; 3]),
+            lens_per_cell: Some([T::one(); 3]),
+            split_quads: true,
+            ..Default::default()
+        }
+    }
+}
+
 /// Generate a [`CMap2`] representing a mesh made up of squares.
 ///
 /// This function builds and returns a 2-map representing a square mesh

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -238,7 +238,16 @@ fn build2_splitgrid<T: CoordsFloat>(
 
 // --- PUBLIC API
 
-/// Builder structure for specialized [`CMap2`]
+/// Builder structure for specialized [`CMap2`].
+///
+/// The user must specify two out of these three characteristics:
+///
+/// - `n_cells: [usize; 3]` - The number of cells per axis
+/// - `len_per_cell: [T; 3]` - The dimensions of cells per axis
+/// - `lens: [T; 3]` -The dimensions of the grid per axis
+///
+/// This can be done using the provided eponymous methods. The structure can then be used to
+/// generate a [`CMap2`] using [`GridBuilder::build2`].
 ///
 /// # Generics
 ///
@@ -246,8 +255,19 @@ fn build2_splitgrid<T: CoordsFloat>(
 ///
 /// # Example
 ///
+/// The following code generates a map that can be visualized by running the example
+/// `render_squaremap_parameterized`:
+///
 /// ```rust
-/// todo!()
+/// # fn main() {
+/// use honeycomb_core::{CMap2, utils::GridBuilder};
+///
+/// let map = GridBuilder::default()
+///                 .n_cells([10, 5, 0])
+///                 .len_per_cell_x(1.0_f64)
+///                 .len_per_cell_y(2.0_f64)
+///                 .build2();
+/// # }
 /// ```
 ///
 #[derive(Default)]
@@ -260,13 +280,15 @@ pub struct GridBuilder<T: CoordsFloat> {
 
 macro_rules! setters {
     ($fld: ident, $fldx: ident, $fldy: ident, $fldz: ident, $zero: expr, $fldty: ty) => {
-        #[must_use]
+        /// Set values for all dimensions
+        #[must_use = "unused builder object, consider removing this method call"]
         pub fn $fld(mut self, $fld: [$fldty; 3]) -> Self {
             self.$fld = Some($fld);
             self
         }
 
-        #[must_use]
+        /// Set x-axis value
+        #[must_use = "unused builder object, consider removing this method call"]
         pub fn $fldx(mut self, $fld: $fldty) -> Self {
             if let Some([ptr, _, _]) = &mut self.$fld {
                 *ptr = $fld;
@@ -276,7 +298,8 @@ macro_rules! setters {
             self
         }
 
-        #[must_use]
+        /// Set y-axis value
+        #[must_use = "unused builder object, consider removing this method call"]
         pub fn $fldy(mut self, $fld: $fldty) -> Self {
             if let Some([_, ptr, _]) = &mut self.$fld {
                 *ptr = $fld;
@@ -286,7 +309,8 @@ macro_rules! setters {
             self
         }
 
-        #[must_use]
+        /// Set z-axis value
+        #[must_use = "unused builder object, consider removing this method call"]
         pub fn $fldz(mut self, $fld: $fldty) -> Self {
             if let Some([_, _, ptr]) = &mut self.$fld {
                 *ptr = $fld;

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -226,6 +226,7 @@ pub struct GridBuilder<T: CoordsFloat> {
     split_quads: bool,
 }
 
+// building methods
 impl<T: CoordsFloat> GridBuilder<T> {
     /// Consumes the builder and produce a [`CMap2`] object.
     ///

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -16,6 +16,30 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 
 // ------ CONTENT
 
+// --- INNER ROUTINES
+
+fn build2_grid<T: CoordsFloat>(builder: GridBuilder<T>) -> CMap2<T> {
+    todo!()
+}
+
+fn build2_splitgrid<T: CoordsFloat>(builder: GridBuilder<T>) -> CMap2<T> {
+    todo!()
+}
+
+// --- PUBLIC API
+
+pub struct GridBuilder<T: CoordsFloat> {
+    ns_cell: Option<[usize; 3]>,
+    lens_per_cell: Option<[T; 3]>,
+    lens: Option<[T; 3]>,
+}
+
+impl<T: CoordsFloat> GridBuilder<T> {
+    pub fn build2(self) -> CMap2<T> {
+        todo!()
+    }
+}
+
 /// Generate a [`CMap2`] representing a mesh made up of squares.
 ///
 /// This function builds and returns a 2-map representing a square mesh

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -206,20 +206,51 @@ fn build2_splitgrid<T: CoordsFloat>(
 
 // --- PUBLIC API
 
+/// Builder structure for specialized [`CMap2`]
+///
+/// # Generics
+///
+/// - `T: CoordsFloat` -- Generic type of the future [`CMap2`] instance.
+///
+/// # Example
+///
+/// ```rust
+/// todo!()
+/// ```
+///
 #[derive(Default)]
 pub struct GridBuilder<T: CoordsFloat> {
-    ns_cell: Option<[usize; 3]>,
-    lens_per_cell: Option<[T; 3]>,
+    n_cells: Option<[usize; 3]>,
+    len_per_cell: Option<[T; 3]>,
     lens: Option<[T; 3]>,
     split_quads: bool,
 }
 
 impl<T: CoordsFloat> GridBuilder<T> {
+    /// Consumes the builder and produce a [`CMap2`] object.
+    ///
+    /// # Return
+    ///
+    /// Return a [`CMap2`] instance representing an orthogonal grid, which characteristics are
+    /// determined by the attributes of the consumed object.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the provided information is not sufficient to generate a grid.
+    /// Two of these three fields should be provided:
+    /// - The number of cells per axis
+    /// - The dimensions of cells per axis
+    /// - The dimensions of the grid per axis
+    ///
+    /// # Example
+    ///
+    /// See [`GridBuilder`] example.
+    ///
     pub fn build2(self) -> CMap2<T> {
         // preprocess parameters
         let (ns_square, lens_per_cell): ([usize; 2], [T; 2]) = match (
-            self.ns_cell,
-            self.lens_per_cell,
+            self.n_cells,
+            self.len_per_cell,
             self.lens,
         ) {
             // from # cells and lengths per cell
@@ -301,8 +332,8 @@ impl<T: CoordsFloat> GridBuilder<T> {
     #[must_use = "unused builder object, consider removing this function call"]
     pub fn unit_squares(n_square: usize) -> Self {
         Self {
-            ns_cell: Some([n_square; 3]),
-            lens_per_cell: Some([T::one(); 3]),
+            n_cells: Some([n_square; 3]),
+            len_per_cell: Some([T::one(); 3]),
             ..Default::default()
         }
     }
@@ -337,8 +368,8 @@ impl<T: CoordsFloat> GridBuilder<T> {
     #[must_use = "unused builder object, consider removing this function call"]
     pub fn split_unit_squares(n_square: usize) -> Self {
         Self {
-            ns_cell: Some([n_square; 3]),
-            lens_per_cell: Some([T::one(); 3]),
+            n_cells: Some([n_square; 3]),
+            len_per_cell: Some([T::one(); 3]),
             split_quads: true,
             ..Default::default()
         }
@@ -385,7 +416,7 @@ mod tests {
 
     #[test]
     fn square_cmap2_correctness() {
-        let cmap: CMap2<f64> = square_cmap2(2);
+        let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction
@@ -486,7 +517,7 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     #[test]
     fn splitsquare_cmap2_correctness() {
-        let cmap: CMap2<f64> = splitsquare_cmap2(2);
+        let cmap: CMap2<f64> = GridBuilder::split_unit_squares(2).build2();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -251,7 +251,7 @@ pub enum BuilderError<'a> {
 /// # }
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct GridBuilder<T: CoordsFloat> {
     n_cells: Option<[usize; 3]>,
     len_per_cell: Option<[T; 3]>,
@@ -320,6 +320,13 @@ impl<T: CoordsFloat> GridBuilder<T> {
 
     // lens
     setters!(lens, lens_x, lens_y, lens_z, T::zero(), T);
+
+    /// Indicate whether to split quads of the grid
+    #[must_use = "unused builder object, consider removing this method call"]
+    pub fn split_quads(mut self, split: bool) -> Self {
+        self.split_quads = split;
+        self
+    }
 }
 
 // building methods
@@ -550,6 +557,43 @@ pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_nc_lpc_l() {
+        let builder = GridBuilder::default()
+            .n_cells([4, 4, 0])
+            .len_per_cell([1.0_f64, 1.0_f64, 1.0_f64])
+            .lens([4.0_f64, 4.0_f64, 4.0_f64]);
+        assert!(builder.clone().build2().is_ok());
+        assert!(builder.split_quads(true).build2().is_ok());
+    }
+
+    #[test]
+    fn build_nc_lpc() {
+        let builder = GridBuilder::default()
+            .n_cells([4, 4, 0])
+            .len_per_cell([1.0_f64, 1.0_f64, 1.0_f64]);
+        assert!(builder.clone().build2().is_ok());
+        assert!(builder.split_quads(true).build2().is_ok());
+    }
+
+    #[test]
+    fn build_nc_l() {
+        let builder = GridBuilder::default()
+            .n_cells([4, 4, 0])
+            .lens([4.0_f64, 4.0_f64, 4.0_f64]);
+        assert!(builder.clone().build2().is_ok());
+        assert!(builder.split_quads(true).build2().is_ok());
+    }
+
+    #[test]
+    fn build_lpc_l() {
+        let builder = GridBuilder::default()
+            .len_per_cell([1.0_f64, 1.0_f64, 1.0_f64])
+            .lens([4.0_f64, 4.0_f64, 4.0_f64]);
+        assert!(builder.clone().build2().is_ok());
+        assert!(builder.split_quads(true).build2().is_ok());
+    }
 
     #[test]
     fn square_cmap2_correctness() {

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -18,22 +18,7 @@ use crate::{CMap2, CoordsFloat, DartIdentifier};
 
 // --- INNER ROUTINES
 
-/// todo
-///
-/// # Arguments
-///
-/// - `arg: type` --
-///
-/// # Return / Panic
-///
-///
-///
-/// # Example
-///
-/// ```text
-///
-/// ```
-///
+/// Internal grid-building routine
 fn build2_grid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
@@ -122,22 +107,7 @@ fn build2_grid<T: CoordsFloat>(
     map
 }
 
-/// todo
-///
-/// # Arguments
-///
-/// - `arg: type` --
-///
-/// # Return / Panic
-///
-///
-///
-/// # Example
-///
-/// ```text
-///
-/// ```
-///
+/// Internal grid-building routine
 fn build2_splitgrid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
@@ -238,8 +208,14 @@ fn build2_splitgrid<T: CoordsFloat>(
 
 // --- PUBLIC API
 
+/// Builder-level error enum
+///
+/// This enum is used to describe all non-panic errors that can occur when using a builder
+/// structure.
 #[derive(Debug)]
 pub enum BuilderError<'a> {
+    /// The builder is missing one or multiple parameters in order to proceed with the requested
+    /// operation.
     MissingParameters(&'a str),
 }
 
@@ -433,7 +409,9 @@ impl<T: CoordsFloat> GridBuilder<T> {
                 )
             }
             (_, _, _) => {
-                return Err(BuilderError::MissingParameters("Insufficient building parameters, please specify two out of three grid parameters"));
+                return Err(BuilderError::MissingParameters(
+                    "GridBuilder: insufficient building parameters",
+                ));
             }
         };
 

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -258,6 +258,47 @@ impl<T: CoordsFloat> GridBuilder<T> {
 
 // predefinite constructs
 impl<T: CoordsFloat> GridBuilder<T> {
+    /// Generate a predefined [`GridBuilder`] object.
+    ///
+    /// This object can be used to build a 2-map representing an orthogonal mesh made of
+    /// `n_square * n_square` square cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `n_square: usize` -- Dimension of the desired mesh.
+    ///
+    /// ## Generics
+    ///
+    /// - `const T: CoordsFloat` -- Generic parameter of the returned [`GridBuilder`].
+    ///
+    /// # Return
+    ///
+    /// Returns a parameterized [`GridBuilder`] that can be used to generate a [`CMap2`] using the
+    /// [`GridBuilder::build2`] method.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use honeycomb_core::{CMap2, utils::GridBuilder};
+    ///
+    /// let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2();
+    /// ```
+    ///
+    /// The above code generates the following map:
+    ///
+    /// ![SQUARECMAP2](../../images/CMap2Square.svg)
+    ///
+    /// Note that *β<sub>1</sub>* is only represented in one cell but is defined
+    /// Everywhere following the same pattern. Dart indexing is also consistent
+    /// with the following rules:
+    ///
+    /// - inside a cell, the first dart is the one on the bottom, pointing towards
+    ///   the right. Increments (and *β<sub>1</sub>*) follow the trigonometric
+    ///   orientation.
+    /// - cells are ordered from left to right, from the bottom up. The same rule
+    ///   applies for face IDs.
+    ///
+    #[must_use = "unused builder object, consider removing this function call"]
     pub fn unit_squares(n_square: usize) -> Self {
         Self {
             ns_cell: Some([n_square; 3]),
@@ -266,6 +307,34 @@ impl<T: CoordsFloat> GridBuilder<T> {
         }
     }
 
+    /// Generate a predefined [`GridBuilder`] object.
+    ///
+    /// This object can be used to build a 2-map representing an orthogonal mesh made of
+    /// `n_square * n_square` squares, that are split diagonally for a total of
+    /// `n_square * n_square * 2` cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `n_square: usize` -- Dimension of the desired mesh.
+    ///
+    /// ## Generics
+    ///
+    /// - `const T: CoordsFloat` -- Generic parameter of the returned [`GridBuilder`].
+    ///
+    /// # Return
+    ///
+    /// Returns a parameterized [`GridBuilder`] that can be used to generate a [`CMap2`] using the
+    /// [`GridBuilder::build2`] method.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use honeycomb_core::{CMap2, utils::GridBuilder};
+    ///
+    /// let cmap: CMap2<f64> = GridBuilder::split_unit_squares(2).build2();
+    /// ```
+    ///
+    #[must_use = "unused builder object, consider removing this function call"]
     pub fn split_unit_squares(n_square: usize) -> Self {
         Self {
             ns_cell: Some([n_square; 3]),
@@ -278,50 +347,15 @@ impl<T: CoordsFloat> GridBuilder<T> {
 
 /// Generate a [`CMap2`] representing a mesh made up of squares.
 ///
+/// <div class="warning">
+///
+/// **This function is deprecated, please use [`GridBuilder::unit_squares`] instead.**
+///
+/// </div>
+///
 /// This function builds and returns a 2-map representing a square mesh
 /// made of `n_square * n_square` square cells.
-///
-/// # Arguments
-///
-/// - `n_square: usize` -- Dimension of the returned mesh.
-///
-/// ## Generics
-///
-/// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
-///
-/// # Return
-///
-/// Returns a boundary-less [`CMap2`] of the specified size. The map contains
-/// `4 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
-/// vertices.
-///
-/// # Panics
-///
-/// If this function panics, this is most likely due to a mistake in implementation in the core
-/// crate.
-///
-/// # Example
-///
-/// ```
-/// use honeycomb_core::{CMap2, utils::square_cmap2};
-///
-/// let cmap: CMap2<f64> = square_cmap2(2);
-/// ```
-///
-/// The above code generates the following map:
-///
-/// ![SQUARECMAP2](../../images/CMap2Square.svg)
-///
-/// Note that *β<sub>1</sub>* is only represented in one cell but is defined
-/// Everywhere following the same pattern. Dart indexing is also consistent
-/// with the following rules:
-///
-/// - inside a cell, the first dart is the one on the bottom, pointing towards
-///   the right. Increments (and *β<sub>1</sub>*) follow the trigonometric
-///   orientation.
-/// - cells are ordered from left to right, from the bottom up. The same rule
-///   applies for face IDs.
-///
+#[deprecated(note = "please use the `GridBuilder::unit_squares` function instead")]
 #[must_use = "constructed object is not used, consider removing this function call"]
 pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     build2_grid([n_square, n_square], [T::one(), T::one()])
@@ -329,30 +363,15 @@ pub fn square_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
 
 /// Generate a [`CMap2`] representing a mesh made up of squares split diagonally.
 ///
+/// <div class="warning">
+///
+/// **This function is deprecated, please use [`GridBuilder::unit_squares`] instead.**
+///
+/// </div>
+///
 /// This function builds and returns a 2-map representing a square mesh
 /// made of `n_square * n_square * 2` triangle cells.
-///
-/// # Arguments
-///
-/// - `n_square: usize` -- Dimension of the returned mesh.
-///
-/// ## Generics
-///
-/// - `const T: CoordsFloat` -- Generic parameter of the returned [`CMap2`].
-///
-/// # Return
-///
-/// Returns a boundary-less [`CMap2`] of the specified size. The map contains
-/// `6 * n_square * n_square` darts and `(n_square + 1) * (n_square + 1)`
-/// vertices.
-///
-/// The indexing follows the same logic described in the documentation of [`square_cmap2`].
-///
-/// # Panics
-///
-/// If this function panics, this is most likely due to a mistake in implementation in the core
-/// crate.
-///
+#[deprecated(note = "please use the `GridBuilder::split_unit_squares` function instead")]
 #[must_use = "constructed object is not used, consider removing this function call"]
 pub fn splitsquare_cmap2<T: CoordsFloat>(n_square: usize) -> CMap2<T> {
     build2_splitgrid([n_square, n_square], [T::one(), T::one()])

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -612,6 +612,35 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Specified length per y cell is either null or negative")]
+    fn build_neg_lpc() {
+        let _ = GridBuilder::default()
+            .n_cells([4, 4, 0])
+            .len_per_cell([1.0_f64, -1.0_f64, 1.0_f64])
+            .build2();
+    }
+
+    #[test]
+    #[should_panic(expected = "Specified grid length along x is either null or negative")]
+    fn build_null_l() {
+        let _ = GridBuilder::default()
+            .n_cells([4, 4, 0])
+            .lens([0.0_f64, 4.0_f64, 4.0_f64])
+            .build2();
+    }
+
+    #[test]
+    #[should_panic(expected = "Specified length per x cell is either null or negative")]
+    fn build_neg_lpc_neg_l() {
+        // lpc are parsed first so their panic msg should be the one to pop
+        // x val is parsed first so ...
+        let _ = GridBuilder::default()
+            .len_per_cell([-1.0_f64, -1.0_f64, 1.0_f64])
+            .lens([0.0_f64, 4.0_f64, 4.0_f64])
+            .build2();
+    }
+
+    #[test]
     fn square_cmap2_correctness() {
         let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2().unwrap();
 

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -263,10 +263,10 @@ fn build2_splitgrid<T: CoordsFloat>(
 /// use honeycomb_core::{CMap2, utils::GridBuilder};
 ///
 /// let map = GridBuilder::default()
-///                 .n_cells([10, 5, 0])
-///                 .len_per_cell_x(1.0_f64)
-///                 .len_per_cell_y(2.0_f64)
-///                 .build2();
+///     .n_cells([15, 5, 0])
+///     .len_per_cell_x(1.0_f64)
+///     .len_per_cell_y(3.0_f64)
+///     .build2();
 /// # }
 /// ```
 ///

--- a/honeycomb-core/src/utils/mod.rs
+++ b/honeycomb-core/src/utils/mod.rs
@@ -15,4 +15,4 @@ mod generation;
 
 // ------ PUBLIC RE-EXPORTS
 
-pub use generation::{splitsquare_cmap2, square_cmap2};
+pub use generation::{splitsquare_cmap2, square_cmap2, GridBuilder};

--- a/honeycomb-core/src/utils/mod.rs
+++ b/honeycomb-core/src/utils/mod.rs
@@ -15,4 +15,5 @@ mod generation;
 
 // ------ PUBLIC RE-EXPORTS
 
+#[allow(deprecated)]
 pub use generation::{splitsquare_cmap2, square_cmap2, GridBuilder};

--- a/honeycomb-examples/Cargo.toml
+++ b/honeycomb-examples/Cargo.toml
@@ -35,6 +35,10 @@ name = "render_squaremap"
 path = "examples/render/squaremap.rs"
 
 [[example]]
+name = "render_squaremap_parameterized"
+path = "examples/render/squaremap_parameterized.rs"
+
+[[example]]
 name = "render_squaremap_shift"
 path = "examples/render/squaremap_shift.rs"
 

--- a/honeycomb-examples/examples/memory_usage/compute.rs
+++ b/honeycomb-examples/examples/memory_usage/compute.rs
@@ -1,8 +1,8 @@
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 
 pub fn main() {
     // create a 3x3 grid & remove the central square
-    let mut cmap: CMap2<FloatType> = square_cmap2(3);
+    let mut cmap: CMap2<FloatType> = GridBuilder::unit_squares(3).build2();
     // darts making up the central square
     let (d1, d2, d3, d4): (
         DartIdentifier,

--- a/honeycomb-examples/examples/memory_usage/compute.rs
+++ b/honeycomb-examples/examples/memory_usage/compute.rs
@@ -2,7 +2,7 @@ use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 
 pub fn main() {
     // create a 3x3 grid & remove the central square
-    let mut cmap: CMap2<FloatType> = GridBuilder::unit_squares(3).build2();
+    let mut cmap: CMap2<FloatType> = GridBuilder::unit_squares(3).build2().unwrap();
     // darts making up the central square
     let (d1, d2, d3, d4): (
         DartIdentifier,

--- a/honeycomb-examples/examples/render/splitsquaremap.rs
+++ b/honeycomb-examples/examples/render/splitsquaremap.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::splitsquare_cmap2, CMap2};
+use honeycomb_core::{utils::GridBuilder, CMap2};
 use honeycomb_render::*;
 
 fn main() {
@@ -6,6 +6,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<f32> = splitsquare_cmap2(4);
+    let map: CMap2<f32> = GridBuilder::split_unit_squares(4).build2();
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/splitsquaremap.rs
+++ b/honeycomb-examples/examples/render/splitsquaremap.rs
@@ -6,6 +6,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<f32> = GridBuilder::split_unit_squares(4).build2();
+    let map: CMap2<f32> = GridBuilder::split_unit_squares(4).build2().unwrap();
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/squaremap.rs
+++ b/honeycomb-examples/examples/render/squaremap.rs
@@ -6,6 +6,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<f32> = GridBuilder::unit_squares(4).build2();
+    let map: CMap2<f32> = GridBuilder::unit_squares(4).build2().unwrap();
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/squaremap.rs
+++ b/honeycomb-examples/examples/render/squaremap.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::square_cmap2, CMap2};
+use honeycomb_core::{utils::GridBuilder, CMap2};
 use honeycomb_render::*;
 
 fn main() {
@@ -6,6 +6,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<f32> = square_cmap2(4);
+    let map: CMap2<f32> = GridBuilder::unit_squares(4).build2();
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/squaremap_parameterized.rs
+++ b/honeycomb-examples/examples/render/squaremap_parameterized.rs
@@ -1,0 +1,15 @@
+use honeycomb_core::{utils::GridBuilder, CMap2};
+use honeycomb_render::*;
+
+fn main() {
+    let render_params = RenderParameters {
+        smaa_mode: SmaaMode::Smaa1X,
+        ..Default::default()
+    };
+    let map: CMap2<f64> = GridBuilder::default()
+        .n_cells([15, 5, 0])
+        .len_per_cell_x(1.0_f64)
+        .len_per_cell_y(3.0_f64)
+        .build2();
+    Runner::default().run(render_params, Some(&map));
+}

--- a/honeycomb-examples/examples/render/squaremap_parameterized.rs
+++ b/honeycomb-examples/examples/render/squaremap_parameterized.rs
@@ -10,6 +10,7 @@ fn main() {
         .n_cells([15, 5, 0])
         .len_per_cell_x(1.0_f64)
         .len_per_cell_y(3.0_f64)
-        .build2();
+        .build2()
+        .unwrap();
     Runner::default().run(render_params, Some(&map));
 }

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -1,6 +1,4 @@
-use honeycomb_core::{
-    utils::square_cmap2, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID,
-};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID};
 use honeycomb_render::*;
 use rand::{
     distributions::{Distribution, Uniform},
@@ -18,7 +16,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -16,7 +16,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_split_diff.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_diff.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 use honeycomb_render::*;
 use rand::distributions::Bernoulli;
 use rand::{distributions::Distribution, rngs::SmallRng, SeedableRng};
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_split_diff.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_diff.rs
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_split_some.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_some.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::square_cmap2, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
 use honeycomb_render::*;
 use rand::distributions::Bernoulli;
 use rand::{distributions::Distribution, rngs::SmallRng, SeedableRng};
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = square_cmap2(N_SQUARE);
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_split_some.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_some.rs
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2();
+    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 


### PR DESCRIPTION
- implement a builder structure `GridBuilder` to generate maps representing custom grids
- mark previous generation methods as deprecated and redirect the user to an alternative

## Scope

- [x] Code: `honeycomb-core` for the implementation, other members to remove deprecations

## Type of change

- [x] New feature(s)
- [x] Refactor
