### PR TITLE
refactor: update render code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## To be released
 
-...
+content from PR #49 / commit ce3948d2e7ccda4e58395ff9e715c946e9b8f744 onward
 
 ---
 

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -11,6 +11,7 @@ fn main() {
     const N_SQUARE: usize = 16;
     let render_params = RenderParameters {
         smaa_mode: SmaaMode::Smaa1X,
+        relative_resize: false,
         ..Default::default()
     };
 

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -95,11 +95,11 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
                     vb -= seg_dir * T::from(self.params.shrink_factor).unwrap();
 
                     let seg = vb - va;
-                    let seg_length = seg.norm();
+                    // let seg_length = seg.norm();
                     let seg_normal = seg.normal_dir();
                     let ahs = T::from(self.params.arrow_headsize).unwrap();
                     let at = T::from(self.params.arrow_thickness).unwrap();
-                    let body_offset = seg_normal * seg_length * at;
+                    let body_offset = seg_normal * at;
 
                     let v1 = va + body_offset;
                     let v2 = va - body_offset;
@@ -108,8 +108,8 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
                     let v4 = v3;
                     let v5 = v1;
                     let v6 = vcenter + body_offset;
-                    let v7 = vcenter + seg_normal * seg_length * ahs;
-                    let v8 = vcenter - seg_normal * seg_length * ahs;
+                    let v7 = vcenter + seg_normal * ahs;
+                    let v8 = vcenter - seg_normal * ahs;
                     let v9 = vb;
                     [
                         Coords2Shader::from((v1, Entity::Dart)),

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -25,6 +25,8 @@ pub struct RenderParameters {
     pub arrow_headsize: f32,
     /// Thickness of the darts.
     pub arrow_thickness: f32,
+    /// Size arrow thcikness and head relatively to their length.
+    pub relative_resize: bool,
 }
 
 impl Default for RenderParameters {
@@ -34,6 +36,7 @@ impl Default for RenderParameters {
             shrink_factor: 0.1,    // need to adjust
             arrow_headsize: 0.05,  // need to adjust
             arrow_thickness: 0.01, // need to adjust
+            relative_resize: true,
         }
     }
 }
@@ -95,21 +98,27 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
                     vb -= seg_dir * T::from(self.params.shrink_factor).unwrap();
 
                     let seg = vb - va;
-                    // let seg_length = seg.norm();
                     let seg_normal = seg.normal_dir();
                     let ahs = T::from(self.params.arrow_headsize).unwrap();
                     let at = T::from(self.params.arrow_thickness).unwrap();
-                    let body_offset = seg_normal * at;
+                    let mut body_offset = seg_normal * at;
+                    let mut head_offset = seg_normal * ahs;
+                    let mut vcenter = vb - seg * ahs;
+                    if self.params.relative_resize {
+                        let seg_length = seg.norm();
+                        body_offset *= seg_length;
+                        head_offset *= seg_length;
+                        vcenter = vb - seg * seg_length * ahs;
+                    }
 
                     let v1 = va + body_offset;
                     let v2 = va - body_offset;
-                    let vcenter = vb - seg * ahs;
                     let v3 = vcenter - body_offset;
                     let v4 = v3;
                     let v5 = v1;
                     let v6 = vcenter + body_offset;
-                    let v7 = vcenter + seg_normal * ahs;
-                    let v8 = vcenter - seg_normal * ahs;
+                    let v7 = vcenter + head_offset;
+                    let v8 = vcenter - head_offset;
                     let v9 = vb;
                     [
                         Coords2Shader::from((v1, Entity::Dart)),

--- a/honeycomb-render/src/representations/intermediates.rs
+++ b/honeycomb-render/src/representations/intermediates.rs
@@ -2,6 +2,7 @@ use honeycomb_core::{Coords2, CoordsFloat, Vertex2};
 
 pub enum Entity {
     Dart,
+    Beta,
     Face,
 }
 

--- a/honeycomb-render/src/runner.rs
+++ b/honeycomb-render/src/runner.rs
@@ -38,6 +38,7 @@ async fn inner<T: CoordsFloat>(
     } else {
         State::new_test(&window, render_params).await
     };
+    println!("I: Press F1 to quit");
     event_loop
         .run(move |event, target| {
             // process events
@@ -46,7 +47,7 @@ async fn inner<T: CoordsFloat>(
                     window_id,
                     event: wevent,
                 } => {
-                    if window_id == state.window().id() && !state.input(&wevent) {
+                    if window_id == state.window().id() && !state.input(&wevent, target) {
                         match wevent {
                             WindowEvent::Resized(new_size) => state.resize(Some(new_size)),
                             WindowEvent::RedrawRequested => {

--- a/honeycomb-render/src/shader_data.rs
+++ b/honeycomb-render/src/shader_data.rs
@@ -43,6 +43,7 @@ impl<T: CoordsFloat> From<(Vertex2<T>, Entity)> for Coords2Shader {
             position: as_f32_array!(v),
             color: match e {
                 Entity::Dart => 0,
+                Entity::Beta => 1,
                 Entity::Face => 2,
             },
         }

--- a/honeycomb-render/src/shaders/shader2.wgsl
+++ b/honeycomb-render/src/shaders/shader2.wgsl
@@ -33,7 +33,7 @@ fn vs_main(
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var color: array<vec4<f32>, 7> = array(
         vec4<f32>(0.1, 0.1, 0.1, 1.0), // 0 -> black darts
-        vec4<f32>(1.0, 0.1, 0.1, 0.1), // 1 ->
+        vec4<f32>(0.3, 0.8, 0.3, 0.1), // 1 -> beta
         vec4<f32>(0.8, 0.3, 0.3, 0.1), // 2 -> face
         vec4<f32>(0.1, 0.1, 1.0, 0.1), // 3 ->
         vec4<f32>(0.1, 1.0, 1.0, 0.1), // 4 ->

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -266,7 +266,7 @@ impl<'a, T: CoordsFloat> State<'a, T> {
         map_handle.build_intermediate();
         map_handle.build_darts();
         map_handle.build_faces();
-        // map_handle.build_betas();
+        map_handle.build_betas();
         map_handle.save_buffered();
 
         let render_slice = map_handle.vertices();

--- a/honeycomb-render/src/state.rs
+++ b/honeycomb-render/src/state.rs
@@ -16,6 +16,9 @@ use std::borrow::Cow;
 use wgpu::util::DeviceExt;
 use wgpu::PrimitiveTopology;
 use winit::dpi::PhysicalSize;
+use winit::event::{ElementState, KeyEvent};
+use winit::event_loop::EventLoopWindowTarget;
+use winit::keyboard::{Key, NamedKey};
 use winit::{event::WindowEvent, window::Window};
 
 // ------ CONTENT
@@ -364,7 +367,22 @@ impl<'a, T: CoordsFloat> State<'a, T> {
         self.window.request_redraw();
     }
 
-    pub fn input(&mut self, event: &WindowEvent) -> bool {
+    pub fn input(&mut self, event: &WindowEvent, target: &EventLoopWindowTarget<()>) -> bool {
+        // early check for exit
+        if let WindowEvent::KeyboardInput {
+            event: KeyEvent {
+                state, logical_key, ..
+            },
+            ..
+        } = event
+        {
+            let is_pressed = *state == ElementState::Pressed;
+            if let Key::Named(key) = logical_key {
+                if is_pressed & (key == &NamedKey::F1) {
+                    target.exit();
+                }
+            }
+        };
         self.camera_controller.process_events(event)
     }
 


### PR DESCRIPTION
- update the rendering code to 
    - draw proper arrows instead of triangles
    - draw beta2 function as diamonds
- add an option to automatically scale arrow thickness/head size according to length
- add a binding to the F1 key to close the render window 

## Scope

- [x] Code: `honeycomb-render`

## Type of change

- [x] New feature(s)
