### PR TITLE
refactor!: update various return types for better consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@
 
 ## To be released
 
-...
+### Workspace
+
+- implement nighly conditional compilation for doc generation (#66)
+
+### Refactor
+
+#### honeycomb-core
+
+<sup>core definitions and tools for combinatorial map implementation</sup>
+
+- change some main methods return type to have better overall consistency (#67):
+    - `Vector2::normal_dir` now returns a result instead of potentially panicking
+    - `CMap2::vertex` now returns a result instead of panicking if no associated vertex is found
+- remove deprecated items from the last release (#64):
+    - `AttrSparseVec::get_mut`, `AttrCompactVec::get_mut`
+    - `utils::square_cmap2`, `utils::splitsquare_cmap2`
 
 ---
 

--- a/honeycomb-benches/benches/splitsquaremap/shift.rs
+++ b/honeycomb-benches/benches/splitsquaremap/shift.rs
@@ -32,7 +32,7 @@ fn offset(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
     let n_offsets = offsets.len();
     let vertices = map.fetch_vertices();
     vertices.identifiers.iter().for_each(|vertex_id| {
-        let current_value = map.vertex(*vertex_id as DartIdentifier);
+        let current_value = map.vertex(*vertex_id as DartIdentifier).unwrap();
         let _ = map.replace_vertex(
             *vertex_id as VertexIdentifier,
             current_value + offsets[*vertex_id as usize % n_offsets],
@@ -56,7 +56,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
         }
     });
     inner.iter().for_each(|vertex_id| {
-        let current_value = map.vertex(*vertex_id);
+        let current_value = map.vertex(*vertex_id).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,
             current_value + offsets[*vertex_id as usize % n_offsets],

--- a/honeycomb-benches/benches/splitsquaremap/shift.rs
+++ b/honeycomb-benches/benches/splitsquaremap/shift.rs
@@ -32,6 +32,8 @@ fn offset(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
     let n_offsets = offsets.len();
     let vertices = map.fetch_vertices();
     vertices.identifiers.iter().for_each(|vertex_id| {
+        // we can unwrap this safely since we built the grid manually
+        // & know that vertices are correctly defined
         let current_value = map.vertex(*vertex_id as DartIdentifier).unwrap();
         let _ = map.replace_vertex(
             *vertex_id as VertexIdentifier,
@@ -56,6 +58,8 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
         }
     });
     inner.iter().for_each(|vertex_id| {
+        // we can unwrap this safely since we built the grid manually
+        // & know that vertices are correctly defined
         let current_value = map.vertex(*vertex_id).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,

--- a/honeycomb-benches/benches/squaremap/shift.rs
+++ b/honeycomb-benches/benches/squaremap/shift.rs
@@ -32,7 +32,7 @@ fn offset(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
     let n_offsets = offsets.len();
     let vertices = map.fetch_vertices();
     vertices.identifiers.iter().for_each(|vertex_id| {
-        let current_value = map.vertex(*vertex_id as DartIdentifier);
+        let current_value = map.vertex(*vertex_id as DartIdentifier).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,
             current_value + offsets[*vertex_id as usize % n_offsets],
@@ -56,7 +56,7 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
         }
     });
     inner.iter().for_each(|vertex_id| {
-        let current_value = map.vertex(*vertex_id);
+        let current_value = map.vertex(*vertex_id).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,
             current_value + offsets[*vertex_id as usize % n_offsets],

--- a/honeycomb-benches/benches/squaremap/shift.rs
+++ b/honeycomb-benches/benches/squaremap/shift.rs
@@ -32,6 +32,8 @@ fn offset(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
     let n_offsets = offsets.len();
     let vertices = map.fetch_vertices();
     vertices.identifiers.iter().for_each(|vertex_id| {
+        // we can unwrap this safely since we built the grid manually
+        // & know that vertices are correctly defined
         let current_value = map.vertex(*vertex_id as DartIdentifier).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,
@@ -56,6 +58,8 @@ fn offset_if_inner(mut map: CMap2<FloatType>, offsets: &[Vector2<FloatType>]) {
         }
     });
     inner.iter().for_each(|vertex_id| {
+        // we can unwrap this safely since we built the grid manually
+        // & know that vertices are correctly defined
         let current_value = map.vertex(*vertex_id).unwrap();
         let _ = map.replace_vertex(
             *vertex_id,

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -18,17 +18,19 @@ impl<T: CoordsFloat> CMap2<T> {
         self.vertices.n_attributes()
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// Fetch vertex value associated to a given identifier.
     ///
     /// # Arguments
     ///
     /// - `vertex_id: VertexIdentifier` -- Identifier of the given vertex.
     ///
-    /// # Return
+    /// # Return / Errors
     ///
     /// The method returns:
-    /// - `&Some(v: Vertex2)` if there is a vertex associated to this ID.
-    /// - `None` otherwise
+    /// This method return a `Result` taking the following values:
+    /// - `Ok(v: Vertex2)` if there is a vertex associated to this ID.
+    /// - `Err(CMapError::UndefinedVertexID)` -- otherwise
     ///
     /// # Panics
     ///
@@ -36,9 +38,11 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
     ///
-    #[must_use = "returned value is not used, consider removing this method call"]
-    pub fn vertex(&self, vertex_id: VertexIdentifier) -> &Option<Vertex2<T>> {
-        self.vertices.get(&vertex_id)
+    pub fn vertex(&self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
+        if let Some(val) = self.vertices.get(&vertex_id) {
+            return Ok(*val);
+        }
+        Err(CMapError::UndefinedVertex)
     }
 
     /// Insert a vertex in the combinatorial map.

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -26,16 +26,19 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return
     ///
-    /// Return a reference to the [Vertex2] associated to the ID.
+    /// The method returns:
+    /// - `&Some(v: Vertex2)` if there is a vertex associated to this ID.
+    /// - `None` otherwise
     ///
     /// # Panics
     ///
-    /// The method may panic if no vertex is associated to the specified index, or the ID lands
-    /// out of bounds.
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
     ///
     #[must_use = "returned value is not used, consider removing this method call"]
-    pub fn vertex(&self, vertex_id: VertexIdentifier) -> Vertex2<T> {
-        self.vertices.get(&vertex_id).unwrap()
+    pub fn vertex(&self, vertex_id: VertexIdentifier) -> &Option<Vertex2<T>> {
+        self.vertices.get(&vertex_id)
     }
 
     /// Insert a vertex in the combinatorial map.
@@ -49,9 +52,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `vertex_id: VertexIdentifier` -- Vertex identifier to attribute a value to.
     /// - `vertex: impl Into<Vertex2>` -- Value used to create a [Vertex2] value.
     ///
-    /// # Return
-    ///
-    /// Return an option which may contain the previous value associated to the specified vertex ID.
+    /// The method may panic if:
+    /// - **there is already a vertex associated to the specified index**
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
     ///
     pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
         self.vertices.insert(&vertex_id, vertex.into());

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -55,6 +55,8 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `vertex_id: VertexIdentifier` -- Vertex identifier to attribute a value to.
     /// - `vertex: impl Into<Vertex2>` -- Value used to create a [Vertex2] value.
     ///
+    /// # Panics
+    ///
     /// The method may panic if:
     /// - **there is already a vertex associated to the specified index**
     /// - the index lands out of bounds

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -27,7 +27,6 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Return / Errors
     ///
-    /// The method returns:
     /// This method return a `Result` taking the following values:
     /// - `Ok(v: Vertex2)` if there is a vertex associated to this ID.
     /// - `Err(CMapError::UndefinedVertexID)` -- otherwise

--- a/honeycomb-core/src/cmap2/structure.rs
+++ b/honeycomb-core/src/cmap2/structure.rs
@@ -133,7 +133,7 @@ use std::collections::BTreeSet;
 /// assert_eq!(&faces.identifiers, &[1]);
 /// // we can check the vertices
 /// let vertices = map.fetch_vertices();
-/// let mut value_iterator = vertices.identifiers.iter().map(|vertex_id| map.vertex(*vertex_id));
+/// let mut value_iterator = vertices.identifiers.iter().map(|vertex_id| map.vertex(*vertex_id).unwrap());
 /// assert_eq!(value_iterator.next(), Some(Vertex2::from((0.0, 0.0)))); // vertex ID 1
 /// assert_eq!(value_iterator.next(), Some(Vertex2::from((0.0, 1.0)))); // vertex ID 3
 /// assert_eq!(value_iterator.next(), Some(Vertex2::from((1.0, 0.0)))); // vertex ID 5

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -50,10 +50,10 @@ fn example_test() {
     assert_eq!(map.beta::<2>(2), 4);
     assert_eq!(map.vertex_id(2), 2);
     assert_eq!(map.vertex_id(5), 2);
-    assert_eq!(map.vertex(2), Vertex2::from((1.5, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.5, 0.0)));
     assert_eq!(map.vertex_id(3), 3);
     assert_eq!(map.vertex_id(4), 3);
-    assert_eq!(map.vertex(3), Vertex2::from((0.0, 1.5)));
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.5)));
     let edges = map.fetch_edges();
     assert_eq!(&edges.identifiers, &[1, 2, 3, 5, 6]);
 
@@ -62,12 +62,12 @@ fn example_test() {
         map.replace_vertex(2, Vertex2::from((1.0, 0.0))),
         Ok(Vertex2::from((1.5, 0.0)))
     );
-    assert_eq!(map.vertex(2), Vertex2::from((1.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.0, 0.0)));
     assert_eq!(
         map.replace_vertex(3, Vertex2::from((0.0, 1.0))),
         Ok(Vertex2::from((0.0, 1.5)))
     );
-    assert_eq!(map.vertex(3), Vertex2::from((0.0, 1.0)));
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
 
     // separate the diagonal from the rest
     map.one_unsew(1);
@@ -89,10 +89,10 @@ fn example_test() {
     assert_eq!(&edges.identifiers, &[1, 3, 5, 6]);
     let vertices = map.fetch_vertices();
     assert_eq!(&vertices.identifiers, &[1, 3, 5, 6]);
-    assert_eq!(map.vertex(1), Vertex2::from((0.0, 0.0)));
-    assert_eq!(map.vertex(5), Vertex2::from((1.0, 0.0)));
-    assert_eq!(map.vertex(6), Vertex2::from((1.0, 1.0)));
-    assert_eq!(map.vertex(3), Vertex2::from((0.0, 1.0)));
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(5).unwrap(), Vertex2::from((1.0, 0.0)));
+    assert_eq!(map.vertex(6).unwrap(), Vertex2::from((1.0, 1.0)));
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
     // darts
     assert_eq!(map.n_unused_darts(), 2); // there are unused darts since we removed the diagonal
     assert_eq!(map.beta_runtime(1, 1), 5);
@@ -134,8 +134,8 @@ fn two_sew_complete() {
     map.insert_vertex(3, (1.0, 1.0));
     map.insert_vertex(4, (1.0, 0.0));
     map.two_sew(1, 3);
-    assert_eq!(map.vertex(1), Vertex2::from((0.5, 0.0)));
-    assert_eq!(map.vertex(2), Vertex2::from((0.5, 1.0)));
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.5, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
 }
 
 #[test]
@@ -147,15 +147,15 @@ fn two_sew_incomplete() {
     map.insert_vertex(3, (1.0, 1.0));
     map.two_sew(1, 3);
     // missing beta1 image for dart 3
-    assert_eq!(map.vertex(1), Vertex2::from((0.0, 0.0)));
-    assert_eq!(map.vertex(2), Vertex2::from((0.5, 1.0)));
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
     map.two_unsew(1);
     assert_eq!(map.add_free_dart(), 4);
     map.one_link(3, 4);
     map.two_sew(1, 3);
     // missing vertex for dart 4
-    assert_eq!(map.vertex(1), Vertex2::from((0.0, 0.0)));
-    assert_eq!(map.vertex(2), Vertex2::from((0.5, 1.0)));
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn two_sew_no_b1() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 1.0));
     map.two_sew(1, 2);
-    assert_eq!(map.vertex(1), Vertex2::from((0.0, 0.0)));
-    assert_eq!(map.vertex(2), Vertex2::from((1.0, 1.0)));
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.0, 1.0)));
 }
 
 #[test]
@@ -207,7 +207,7 @@ fn one_sew_complete() {
     map.insert_vertex(2, (0.0, 1.0));
     map.insert_vertex(3, (0.0, 2.0));
     map.one_sew(1, 3);
-    assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.5)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.5)));
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn one_sew_incomplete_attributes() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
     map.one_sew(1, 3);
-    assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn one_sew_incomplete_beta() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
     map.one_sew(1, 2);
-    assert_eq!(map.vertex(2), Vertex2::from((0.0, 1.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
 }
 #[test]
 #[should_panic(expected = "No vertex defined on dart 2, use `one_link` instead of `one_sew`")]

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -18,7 +18,7 @@ use std::ops::{
 // ------ CONTENT
 
 /// Coordinates-level error enum
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CoordsError {
     /// Error during the computation of the unit directional vector.
     ///

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -127,8 +127,8 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// # Errors
     ///
-    /// This method will panic if called on a `Vector2` with a norm equal to zero, i.e. a null
-    /// `Vector2`.
+    /// This method will return an error if called on a `Vector2` with a norm equal to zero,
+    /// i.e. a null `Vector2`.
     ///
     /// # Example
     ///
@@ -152,8 +152,8 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// # Errors
     ///
-    /// This method will panic under the same condition as [`Vector2::unit_dir`], i.e. if called
-    /// on a `Vector2` with a norm equal to zero, i.e. a null `Vector2`.
+    /// This method will return an error if called on a `Vector2` with a norm equal to zero,
+    /// i.e. a null `Vector2`.
     ///
     /// # Example
     ///
@@ -359,9 +359,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidUnitDir")]
     fn normal_dir_of_null_vel() {
         let origin: Vector2<FloatType> = Vector2::default();
-        let _ = origin.normal_dir().unwrap(); // panics
+        let err = origin.normal_dir();
+        assert_eq!(err, Err(CoordsError::InvalidUnitDir));
     }
 }

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -29,7 +29,7 @@ use crate::{Coords2, CoordsError, CoordsFloat};
 /// let unit_y = Vector2::unit_y();
 ///
 /// assert_eq!(unit_x.dot(&unit_y), 0.0);
-/// assert_eq!(unit_x.normal_dir(), unit_y);
+/// assert_eq!(unit_x.normal_dir().unwrap(), unit_y);
 ///
 /// let two: FloatType = 2.0;
 /// let x_plus_y: Vector2<FloatType> = unit_x + unit_y;
@@ -362,6 +362,6 @@ mod tests {
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidUnitDir")]
     fn normal_dir_of_null_vel() {
         let origin: Vector2<FloatType> = Vector2::default();
-        let _ = origin.normal_dir(); // panics
+        let _ = origin.normal_dir().unwrap(); // panics
     }
 }

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -134,7 +134,7 @@ impl<T: CoordsFloat> Vector2<T> {
     ///
     /// See [Vector2] example.
     ///
-    pub fn unit_dir(&self) -> Result<Vector2<T>, CoordsError> {
+    pub fn unit_dir(&self) -> Result<Self, CoordsError> {
         let norm = self.norm();
         if norm.is_zero() {
             Err(CoordsError::InvalidUnitDir)
@@ -150,17 +150,16 @@ impl<T: CoordsFloat> Vector2<T> {
     /// Return a [Vector2] indicating the direction of the normal to `self`. The norm of the
     /// returned struct is equal to one.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Because the returned `Vector2` is normalized, this method may panic under the same
-    /// condition as [`Self::unit_dir`].
+    /// This method will panic under the same condition as [`Vector2::unit_dir`], i.e. if called
+    /// on a `Vector2` with a norm equal to zero, i.e. a null `Vector2`.
     ///
     /// # Example
     ///
     /// See [Vector2] example.
     ///
-    #[must_use = "constructed object is not used, consider removing this method call"]
-    pub fn normal_dir(&self) -> Self {
+    pub fn normal_dir(&self) -> Result<Vector2<T>, CoordsError> {
         Self {
             inner: Coords2 {
                 x: -self.inner.y,
@@ -168,7 +167,6 @@ impl<T: CoordsFloat> Vector2<T> {
             },
         }
         .unit_dir()
-        .unwrap()
     }
 
     /// Compute the dot product between two vectors
@@ -342,14 +340,20 @@ mod tests {
     fn normal_dir() {
         let along_x = Vector2::unit_x() * 4.0;
         let along_y = Vector2::unit_y() * 3.0;
-        assert!(almost_equal_vec(&along_x.normal_dir(), &Vector2::unit_y()));
         assert!(almost_equal_vec(
-            &Vector2::unit_x().normal_dir(),
+            &along_x.normal_dir().unwrap(),
             &Vector2::unit_y()
         ));
-        assert!(almost_equal_vec(&along_y.normal_dir(), &-Vector2::unit_x()));
         assert!(almost_equal_vec(
-            &Vector2::unit_y().normal_dir(),
+            &Vector2::unit_x().normal_dir().unwrap(),
+            &Vector2::unit_y()
+        ));
+        assert!(almost_equal_vec(
+            &along_y.normal_dir().unwrap(),
+            &-Vector2::unit_x()
+        ));
+        assert!(almost_equal_vec(
+            &Vector2::unit_y().normal_dir().unwrap(),
             &-Vector2::unit_x()
         ));
     }

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -48,6 +48,8 @@ fn main() {
                 .map(|d_id| map.beta::<2>(d_id))
                 .collect();
             if !neighbors_vertex_cell.contains(&NULL_DART_ID) {
+                // we can unwrap this safely since we built the grid manually
+                // & know that vertices are correctly defined
                 let current_value = map.vertex(*vertex_id).unwrap();
                 let _ = map.replace_vertex(
                     *vertex_id,

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -48,7 +48,7 @@ fn main() {
                 .map(|d_id| map.beta::<2>(d_id))
                 .collect();
             if !neighbors_vertex_cell.contains(&NULL_DART_ID) {
-                let current_value = map.vertex(*vertex_id);
+                let current_value = map.vertex(*vertex_id).unwrap();
                 let _ = map.replace_vertex(
                     *vertex_id,
                     current_value + offsets[*vertex_id as usize % n_offsets],

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -48,7 +48,7 @@ pub struct CMap2RenderHandle<'a, T: CoordsFloat> {
     params: RenderParameters,
     intermediate_buffer: Vec<IntermediateFace<T>>,
     dart_construction_buffer: Vec<Coords2Shader>,
-    _beta_construction_buffer: Vec<Coords2Shader>,
+    beta_construction_buffer: Vec<Coords2Shader>,
     face_construction_buffer: Vec<Coords2Shader>,
     vertices: Vec<Coords2Shader>,
 }
@@ -60,7 +60,7 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
             params: params.unwrap_or_default(),
             intermediate_buffer: Vec::new(),
             dart_construction_buffer: Vec::new(),
-            _beta_construction_buffer: Vec::new(),
+            beta_construction_buffer: Vec::new(),
             face_construction_buffer: Vec::new(),
             vertices: Vec::new(),
         }
@@ -149,7 +149,6 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
         self.dart_construction_buffer.extend(tmp);
     }
 
-    #[allow(dead_code)]
     pub fn build_betas(&mut self) {
         let tmp: Vec<EdgeIdentifier> = self.handle.fetch_edges().identifiers.clone();
         let tmp = tmp
@@ -191,7 +190,7 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
                 ]
                 .into_iter()
             });
-        self._beta_construction_buffer.extend(tmp);
+        self.beta_construction_buffer.extend(tmp);
     }
 
     pub fn build_faces(&mut self) {
@@ -223,7 +222,7 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
         self.vertices.clear();
         self.vertices.append(&mut self.face_construction_buffer);
         self.vertices.append(&mut self.dart_construction_buffer);
-        self.vertices.append(&mut self._beta_construction_buffer);
+        self.vertices.append(&mut self.beta_construction_buffer);
     }
 
     pub fn vertices(&self) -> &[Coords2Shader] {

--- a/honeycomb-render/src/handle.rs
+++ b/honeycomb-render/src/handle.rs
@@ -71,7 +71,7 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
         let faces_ir = faces.identifiers.iter().map(|face_id| {
             // build face data
             let orbit = Orbit2::new(self.handle, OrbitPolicy::Face, *face_id as DartIdentifier)
-                .map(|id| self.handle.vertex(self.handle.vertex_id(id)));
+                .map(|id| self.handle.vertex(self.handle.vertex_id(id)).unwrap());
             let mut tmp = IntermediateFace::new(orbit);
             // apply a first shrink
             tmp.vertices.iter_mut().for_each(|v| {
@@ -100,7 +100,7 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
                     vb -= seg_dir * T::from(self.params.shrink_factor).unwrap();
 
                     let seg = vb - va;
-                    let seg_normal = seg.normal_dir();
+                    let seg_normal = seg.normal_dir().unwrap();
                     let ahs = T::from(self.params.arrow_headsize).unwrap();
                     let at = T::from(self.params.arrow_thickness).unwrap();
                     let mut body_offset = seg_normal * at;
@@ -152,11 +152,14 @@ impl<'a, T: CoordsFloat> CMap2RenderHandle<'a, T> {
             })
             .filter(|(_, b2vid)| *b2vid != NULL_DART_ID)
             .flat_map(|(dart_id, b2dart_id)| {
-                let va = self.handle.vertex(self.handle.vertex_id(dart_id));
-                let vb = self.handle.vertex(self.handle.vertex_id(b2dart_id));
+                let va = self.handle.vertex(self.handle.vertex_id(dart_id)).unwrap();
+                let vb = self
+                    .handle
+                    .vertex(self.handle.vertex_id(b2dart_id))
+                    .unwrap();
                 let seg_dir = vb - va;
                 let center = Vertex2::average(&va, &vb);
-                let seg_normal = seg_dir.normal_dir();
+                let seg_normal = seg_dir.normal_dir().unwrap();
                 let vr = center + seg_dir * T::from(0.01).unwrap();
                 let vl = center - seg_dir * T::from(0.01).unwrap();
                 let vt = center + seg_normal * T::from(0.1).unwrap();


### PR DESCRIPTION
Change the return type of:
- `CMap2::vertex` to not panic if the specified vertex is not defined (return an error instead)
- `Vector2::normal_dir` to not panic if the method is called on a null vector (return the result of the `Vector2::unit_dir` method, which was previously unwraped internally)

The rest of the changes are accomodations for the new return types.

## Scope

- [x] Code: if relevant, add affected target

## Type of change

- [x] Refactor

## Other

- [x] Breaking change
