### PR TITLE
refactor!: update float genericity code

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         features:
-          - single_precision
+          - _single_precision
           - utils
     runs-on: ubuntu-22.04
     steps:
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         features:
-          - single_precision
+          - _single_precision
           - utils
     runs-on: ubuntu-22.04
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <sup>core definitions and tools for combinatorial map implementation</sup>
 
+- replace `CoordsFloat` implementation blocks to automatize implementation
+  for all types that fit the traits requirement (#68)
+- remove `FloatType` from the public API (#68)
 - change some main methods return type to have better overall consistency (#67):
     - `Vector2::normal_dir` now returns a result instead of potentially panicking
     - `CMap2::vertex` now returns a result instead of panicking if no associated vertex is found

--- a/honeycomb-benches/Cargo.toml
+++ b/honeycomb-benches/Cargo.toml
@@ -9,13 +9,23 @@ description = "Core structure benchmarks"
 authors.workspace = true
 publish = false
 
+[features]
+_single_precision = []
+
+# deps
+
+[dependencies]
+cfg-if.workspace = true
+
 [dev-dependencies]
 honeycomb-core = { workspace = true, features = ["utils"] }
 criterion = { workspace = true, features = ["html_reports"] }
 iai-callgrind.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
 
-# Iai-callgrind benchmarks
+# benches
+
+## Iai-callgrind benchmarks
 
 [[bench]]
 name = "prof-cmap2-editing"
@@ -33,7 +43,7 @@ path = "benches/core/cmap2/sewing.rs"
 harness = false
 
 
-# Criterion benchmarks
+## Criterion benchmarks
 
 [[bench]]
 name = "squaremap-init"

--- a/honeycomb-benches/benches/core/cmap2/editing.rs
+++ b/honeycomb-benches/benches/core/cmap2/editing.rs
@@ -14,7 +14,8 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vertex2};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, Vertex2};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };

--- a/honeycomb-benches/benches/core/cmap2/reading.rs
+++ b/honeycomb-benches/benches/core/cmap2/reading.rs
@@ -14,7 +14,8 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };

--- a/honeycomb-benches/benches/core/cmap2/sewing.rs
+++ b/honeycomb-benches/benches/core/cmap2/sewing.rs
@@ -15,7 +15,8 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };

--- a/honeycomb-benches/benches/splitsquaremap/init.rs
+++ b/honeycomb-benches/benches/splitsquaremap/init.rs
@@ -9,7 +9,8 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration, Throughput,
 };
-use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2};
 
 // ------ CONTENT
 

--- a/honeycomb-benches/benches/splitsquaremap/shift.rs
+++ b/honeycomb-benches/benches/splitsquaremap/shift.rs
@@ -22,8 +22,9 @@ use rand::{
     rngs::SmallRng,
 };
 
+use honeycomb_benches::FloatType;
 use honeycomb_core::{
-    utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier, NULL_DART_ID,
+    utils::GridBuilder, CMap2, DartIdentifier, Vector2, VertexIdentifier, NULL_DART_ID,
 };
 
 // ------ CONTENT

--- a/honeycomb-benches/benches/squaremap/init.rs
+++ b/honeycomb-benches/benches/squaremap/init.rs
@@ -9,7 +9,8 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration, Throughput,
 };
-use honeycomb_core::{utils::GridBuilder, CMap2, FloatType};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2};
 
 // ------ CONTENT
 

--- a/honeycomb-benches/benches/squaremap/shift.rs
+++ b/honeycomb-benches/benches/squaremap/shift.rs
@@ -22,8 +22,9 @@ use rand::{
     rngs::SmallRng,
 };
 
+use honeycomb_benches::FloatType;
 use honeycomb_core::{
-    utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, VertexIdentifier, NULL_DART_ID,
+    utils::GridBuilder, CMap2, DartIdentifier, Vector2, VertexIdentifier, NULL_DART_ID,
 };
 
 // ------ CONTENT

--- a/honeycomb-benches/benches/squaremap/split.rs
+++ b/honeycomb-benches/benches/squaremap/split.rs
@@ -19,7 +19,8 @@
 // ------ IMPORTS
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
+use honeycomb_benches::FloatType;
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier};
 use rand::{
     distributions::{Bernoulli, Distribution},
     rngs::SmallRng,

--- a/honeycomb-benches/src/lib.rs
+++ b/honeycomb-benches/src/lib.rs
@@ -19,3 +19,17 @@
 //! - `prof-cmap2-editing` - `CMap2` editing methods benchmarks
 //! - `prof-cmap2-reading` - `CMap2` reading methods benchmarks
 //! - `prof-cmap2-sewing-unsewing` - `CMap2` (un)sewing methods benchmarks
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "_single_precision")] {
+        /// Floating-point type alias.
+        ///
+        /// This is mostly used to run tests using both `f64` and `f32`.
+        pub type FloatType = f32;
+    } else {
+        /// Floating-point type alias.
+        ///
+        /// This is mostly used to run tests using both `f64` and `f32`.
+        pub type FloatType = f64;
+    }
+}

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -14,7 +14,9 @@ publish = true
 
 [features]
 utils = []
-single_precision = []
+_single_precision = []
+
+# deps
 
 [dependencies]
 cfg-if.workspace = true

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -219,7 +219,7 @@ impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CMap2, DartIdentifier, FloatType, Orbit2, OrbitPolicy};
+    use crate::{common::FloatType, CMap2, DartIdentifier, Orbit2, OrbitPolicy};
 
     fn simple_map() -> CMap2<FloatType> {
         let mut map: CMap2<FloatType> = CMap2::new(6);

--- a/honeycomb-core/src/cmap2/structure.rs
+++ b/honeycomb-core/src/cmap2/structure.rs
@@ -65,10 +65,10 @@ use std::collections::BTreeSet;
 /// # use honeycomb_core::CMapError;
 /// # fn main() -> Result<(), CMapError> {
 ///
-/// use honeycomb_core::{CMap2, FloatType, Orbit2, OrbitPolicy, Vertex2};
+/// use honeycomb_core::{CMap2, Orbit2, OrbitPolicy, Vertex2};
 ///
 /// // build a triangle
-/// let mut map: CMap2<FloatType> = CMap2::new(3); // three darts
+/// let mut map: CMap2<f64> = CMap2::new(3); // three darts
 /// map.one_link(1, 2); // beta1(1) = 2 & beta0(2) = 1
 /// map.one_link(2, 3); // beta1(2) = 3 & beta0(3) = 2
 /// map.one_link(3, 1); // beta1(3) = 1 & beta0(1) = 3

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -1,6 +1,6 @@
 // ------ IMPORTS
 
-use crate::{CMap2, FloatType, Orbit2, OrbitPolicy, Vertex2};
+use crate::{common::FloatType, CMap2, Orbit2, OrbitPolicy, Vertex2};
 
 // ------ CONTENT
 

--- a/honeycomb-core/src/common.rs
+++ b/honeycomb-core/src/common.rs
@@ -50,5 +50,4 @@ pub trait CoordsFloat:
 {
 }
 
-impl CoordsFloat for f32 {}
-impl CoordsFloat for f64 {}
+impl<T: num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign> CoordsFloat for T {}

--- a/honeycomb-core/src/common.rs
+++ b/honeycomb-core/src/common.rs
@@ -28,8 +28,19 @@ pub enum CMapError {
     UndefinedVertex,
 }
 
-// --- decimal types
+// --- generic decimal trait
 
+/// Common trait implemented by types used for coordinate representation.
+pub trait CoordsFloat:
+    num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign
+{
+}
+
+impl<T: num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign> CoordsFloat for T {}
+
+// --- test utility
+
+#[cfg(test)]
 cfg_if::cfg_if! {
     if #[cfg(feature = "single_precision")] {
         /// Floating-point type alias.
@@ -43,11 +54,3 @@ cfg_if::cfg_if! {
         pub type FloatType = f64;
     }
 }
-
-/// Common trait implemented by types used for coordinate representation.
-pub trait CoordsFloat:
-    num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign
-{
-}
-
-impl<T: num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign> CoordsFloat for T {}

--- a/honeycomb-core/src/common.rs
+++ b/honeycomb-core/src/common.rs
@@ -42,7 +42,7 @@ impl<T: num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign> Co
 
 #[cfg(test)]
 cfg_if::cfg_if! {
-    if #[cfg(feature = "single_precision")] {
+    if #[cfg(feature = "_single_precision")] {
         /// Floating-point type alias.
         ///
         /// This is mostly used to run tests using both `f64` and `f32`.

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -14,7 +14,6 @@
 //! Optional features can be enabled when compiling this crate:
 //!
 //! - `utils` -- provides additionnal implementations for map generation, benchmarking & debugging
-//! - `single_precision` -- uses `f32` instead of `f64` for coordinates representation in tests
 
 // ------ CUSTOM LINTS
 

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod utils;
 
 // ------ RE-EXPORTS
 
+// --- PUBLIC API
+
 pub use attributes::{
     collections::{AttrCompactVec, AttrSparseVec},
     traits::{AttributeBind, AttributeUpdate},
@@ -53,7 +55,7 @@ pub use cells::{
     orbits::{Orbit2, OrbitPolicy},
 };
 pub use cmap2::CMap2;
-pub use common::{CMapError, CoordsFloat, DartIdentifier, FloatType, NULL_DART_ID};
+pub use common::{CMapError, CoordsFloat, DartIdentifier, NULL_DART_ID};
 pub use spatial_repr::{
     coords::{Coords2, CoordsError},
     vector::Vector2,

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -215,7 +215,7 @@ impl<T: CoordsFloat> IndexMut<usize> for Coords2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FloatType;
+    use crate::common::FloatType;
 
     fn almost_equal(lhs: &Coords2<FloatType>, rhs: &Coords2<FloatType>) -> bool {
         const EPS: FloatType = 10.0e-12;

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -6,8 +6,6 @@
 
 // ------ IMPORTS
 
-#[cfg(doc)]
-use crate::FloatType;
 use crate::{CoordsFloat, Vector2, Vertex2};
 
 use std::iter::Sum;
@@ -26,10 +24,7 @@ pub enum CoordsError {
     InvalidUnitDir,
 }
 
-/// 2-dimensional coordinates structure
-///
-/// The floating type used for coordinate representation is determined by the user. For tests, it
-/// can be controled using features and the [`FloatType`] alias.
+/// Bare-bone 2-dimensional coordinates representation
 ///
 /// # Generics
 ///

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -291,7 +291,7 @@ impl<T: CoordsFloat> std::ops::Neg for Vector2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FloatType;
+    use crate::common::FloatType;
 
     macro_rules! almost_equal {
         ($f1: expr, $f2: expr) => {

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -23,7 +23,7 @@ use crate::{Coords2, CoordsError, CoordsFloat};
 /// ```
 /// # use honeycomb_core::CoordsError;
 /// # fn main() -> Result<(), CoordsError> {
-/// use honeycomb_core::{Vector2, FloatType};
+/// use honeycomb_core::Vector2;
 ///
 /// let unit_x = Vector2::unit_x();
 /// let unit_y = Vector2::unit_y();
@@ -31,8 +31,8 @@ use crate::{Coords2, CoordsError, CoordsFloat};
 /// assert_eq!(unit_x.dot(&unit_y), 0.0);
 /// assert_eq!(unit_x.normal_dir().unwrap(), unit_y);
 ///
-/// let two: FloatType = 2.0;
-/// let x_plus_y: Vector2<FloatType> = unit_x + unit_y;
+/// let two: f64 = 2.0;
+/// let x_plus_y: Vector2<f64> = unit_x + unit_y;
 ///
 /// assert_eq!(x_plus_y.norm(), two.sqrt());
 /// assert_eq!(x_plus_y.unit_dir()?, Vector2::from((1.0 / two.sqrt(), 1.0 / two.sqrt())));

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -25,7 +25,7 @@ use crate::{
 /// ```
 /// # use honeycomb_core::CoordsError;
 /// # fn main() -> Result<(), CoordsError> {
-/// use honeycomb_core::{Vector2, Vertex2, FloatType};
+/// use honeycomb_core::{Vector2, Vertex2};
 ///
 /// let v1 = Vertex2::from((1.0, 0.0));
 /// let v2 = Vertex2::from((1.0, 1.0));
@@ -33,9 +33,9 @@ use crate::{
 /// assert_eq!(v1.x(), 1.0);
 /// assert_eq!(v1.y(), 0.0);
 ///
-/// let two: FloatType = 2.0;
+/// let two: f64 = 2.0;
 /// // vectorAB = vertexB - vertexA
-/// let v2_minus_v1: Vector2<FloatType> = v2 - v1;
+/// let v2_minus_v1: Vector2<f64> = v2 - v1;
 ///
 /// assert_eq!(v2_minus_v1.norm(), 1.0);
 /// assert_eq!(v2_minus_v1.unit_dir()?, Vector2::unit_y());

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -255,7 +255,7 @@ impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FloatType;
+    use crate::common::FloatType;
 
     #[test]
     fn add_vertex_vector() {

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -512,6 +512,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FloatType;
 
     #[test]
     fn build_nc_lpc_l() {
@@ -603,7 +604,7 @@ mod tests {
 
     #[test]
     fn square_cmap2_correctness() {
-        let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2().unwrap();
+        let cmap: CMap2<FloatType> = GridBuilder::unit_squares(2).build2().unwrap();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction
@@ -704,7 +705,7 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     #[test]
     fn splitsquare_cmap2_correctness() {
-        let cmap: CMap2<f64> = GridBuilder::split_unit_squares(2).build2().unwrap();
+        let cmap: CMap2<FloatType> = GridBuilder::split_unit_squares(2).build2().unwrap();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -512,7 +512,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::FloatType;
+    use crate::common::FloatType;
 
     #[test]
     fn build_nc_lpc_l() {

--- a/honeycomb-examples/examples/memory_usage/compute.rs
+++ b/honeycomb-examples/examples/memory_usage/compute.rs
@@ -1,8 +1,8 @@
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier};
 
 pub fn main() {
     // create a 3x3 grid & remove the central square
-    let mut cmap: CMap2<FloatType> = GridBuilder::unit_squares(3).build2().unwrap();
+    let mut cmap: CMap2<f64> = GridBuilder::unit_squares(3).build2().unwrap();
     // darts making up the central square
     let (d1, d2, d3, d4): (
         DartIdentifier,

--- a/honeycomb-examples/examples/render/squaremap_shift.rs
+++ b/honeycomb-examples/examples/render/squaremap_shift.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType, Vector2, NULL_DART_ID};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, Vector2, NULL_DART_ID};
 use honeycomb_render::*;
 use rand::{
     distributions::{Distribution, Uniform},
@@ -16,7 +16,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
+    let mut map: CMap2<f32> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 
@@ -25,11 +25,11 @@ fn main() {
     let seed: u64 = 9817498146784;
     let mut rngx = SmallRng::seed_from_u64(seed);
     let mut rngy = SmallRng::seed_from_u64(seed);
-    let range: Uniform<FloatType> =
+    let range: Uniform<f32> =
         Uniform::new(-0.5, 0.5).expect("Could not initialize the uniform distribution");
     let xs = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngx));
     let ys = (0..(N_SQUARE + 1).pow(2)).map(|_| range.sample(&mut rngy));
-    let offsets: Vec<Vector2<FloatType>> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
+    let offsets: Vec<Vector2<f32>> = xs.zip(ys).map(|(x, y)| (x, y).into()).collect();
     let n_offsets = offsets.len();
     let elapsed = now.elapsed();
     println!(

--- a/honeycomb-examples/examples/render/squaremap_split_diff.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_diff.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier};
 use honeycomb_render::*;
 use rand::distributions::Bernoulli;
 use rand::{distributions::Distribution, rngs::SmallRng};
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
+    let mut map: CMap2<f32> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 

--- a/honeycomb-examples/examples/render/squaremap_split_some.rs
+++ b/honeycomb-examples/examples/render/squaremap_split_some.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier, FloatType};
+use honeycomb_core::{utils::GridBuilder, CMap2, DartIdentifier};
 use honeycomb_render::*;
 use rand::distributions::Bernoulli;
 use rand::{distributions::Distribution, rngs::SmallRng};
@@ -14,7 +14,7 @@ fn main() {
 
     println!("I: Start map initialization...");
     let now = Instant::now();
-    let mut map: CMap2<FloatType> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
+    let mut map: CMap2<f32> = GridBuilder::unit_squares(N_SQUARE).build2().unwrap();
     let elapsed = now.elapsed();
     println!("I: Finished initializing in {}μs", elapsed.as_micros());
 


### PR DESCRIPTION
- remove  the manual `CoordsFloat` implementation for `f32` and `f64` in favor of a generic impl block; Now, all type implementing traits required by `CoordsFloat` will automatically implement `CoordsFloat`
- remove `FloatType` from the public API & rename the `single_precision` feature to `_single_precision`; `FloatType` is now only used in tests & benchmarks

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Other

- [x] Breaking change
