### PR TITLE
refactor: remove `FloatType` and all of its usage

### DIFF
--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -219,10 +219,10 @@ impl<'a, T: CoordsFloat> Iterator for Orbit2<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{common::FloatType, CMap2, DartIdentifier, Orbit2, OrbitPolicy};
+    use crate::{CMap2, DartIdentifier, Orbit2, OrbitPolicy};
 
-    fn simple_map() -> CMap2<FloatType> {
-        let mut map: CMap2<FloatType> = CMap2::new(6);
+    fn simple_map() -> CMap2<f64> {
+        let mut map: CMap2<f64> = CMap2::new(6);
         map.one_link(1, 2);
         map.one_link(2, 3);
         map.one_link(3, 1);

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -1,13 +1,13 @@
 // ------ IMPORTS
 
-use crate::{common::FloatType, CMap2, Orbit2, OrbitPolicy, Vertex2};
+use crate::{CMap2, Orbit2, OrbitPolicy, Vertex2};
 
 // ------ CONTENT
 
 #[test]
 fn example_test() {
     // build a triangle
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.one_link(1, 2);
     map.one_link(2, 3);
     map.one_link(3, 1);
@@ -105,7 +105,7 @@ fn example_test() {
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UndefinedVertex")]
 fn remove_vertex_twice() {
     // in its default state, all darts/vertices of a map are considered to be used
-    let mut map: CMap2<FloatType> = CMap2::new(4);
+    let mut map: CMap2<f64> = CMap2::new(4);
     // set vertex 1 as unused
     map.remove_vertex(1).unwrap();
     // set vertex 1 as unused, again
@@ -117,7 +117,7 @@ fn remove_vertex_twice() {
 fn remove_dart_twice() {
     // in its default state, all darts/vertices of a map are considered to be used
     // darts are also free
-    let mut map: CMap2<FloatType> = CMap2::new(4);
+    let mut map: CMap2<f64> = CMap2::new(4);
     // set dart 1 as unused
     map.remove_free_dart(1);
     // set dart 1 as unused, again
@@ -126,7 +126,7 @@ fn remove_dart_twice() {
 
 #[test]
 fn two_sew_complete() {
-    let mut map: CMap2<FloatType> = CMap2::new(4);
+    let mut map: CMap2<f64> = CMap2::new(4);
     map.one_link(1, 2);
     map.one_link(3, 4);
     map.insert_vertex(1, (0.0, 0.0));
@@ -140,7 +140,7 @@ fn two_sew_complete() {
 
 #[test]
 fn two_sew_incomplete() {
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.one_link(1, 2);
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
@@ -160,7 +160,7 @@ fn two_sew_incomplete() {
 
 #[test]
 fn two_sew_no_b1() {
-    let mut map: CMap2<FloatType> = CMap2::new(2);
+    let mut map: CMap2<f64> = CMap2::new(2);
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 1.0));
     map.two_sew(1, 2);
@@ -173,14 +173,14 @@ fn two_sew_no_b1() {
     expected = "No vertices defined on either darts 1/2 , use `two_link` instead of `two_sew`"
 )]
 fn two_sew_no_attributes() {
-    let mut map: CMap2<FloatType> = CMap2::new(2);
+    let mut map: CMap2<f64> = CMap2::new(2);
     map.two_sew(1, 2); // should panic
 }
 
 #[test]
 #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn two_sew_no_attributes_bis() {
-    let mut map: CMap2<FloatType> = CMap2::new(4);
+    let mut map: CMap2<f64> = CMap2::new(4);
     map.one_link(1, 2);
     map.one_link(3, 4);
     map.two_sew(1, 3); // panic
@@ -189,7 +189,7 @@ fn two_sew_no_attributes_bis() {
 #[test]
 #[should_panic(expected = "Dart 1 and 3 do not have consistent orientation for 2-sewing")]
 fn two_sew_bad_orientation() {
-    let mut map: CMap2<FloatType> = CMap2::new(4);
+    let mut map: CMap2<f64> = CMap2::new(4);
     map.one_link(1, 2);
     map.one_link(3, 4);
     map.insert_vertex(1, (0.0, 0.0));
@@ -201,7 +201,7 @@ fn two_sew_bad_orientation() {
 
 #[test]
 fn one_sew_complete() {
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.two_link(1, 2);
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
@@ -212,7 +212,7 @@ fn one_sew_complete() {
 
 #[test]
 fn one_sew_incomplete_attributes() {
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.two_link(1, 2);
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
@@ -222,7 +222,7 @@ fn one_sew_incomplete_attributes() {
 
 #[test]
 fn one_sew_incomplete_beta() {
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (0.0, 1.0));
     map.one_sew(1, 2);
@@ -231,14 +231,14 @@ fn one_sew_incomplete_beta() {
 #[test]
 #[should_panic(expected = "No vertex defined on dart 2, use `one_link` instead of `one_sew`")]
 fn one_sew_no_attributes() {
-    let mut map: CMap2<FloatType> = CMap2::new(2);
+    let mut map: CMap2<f64> = CMap2::new(2);
     map.one_sew(1, 2); // should panic
 }
 
 #[test]
 #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn one_sew_no_attributes_bis() {
-    let mut map: CMap2<FloatType> = CMap2::new(3);
+    let mut map: CMap2<f64> = CMap2::new(3);
     map.two_link(1, 2);
     map.one_sew(1, 3); // panic
 }

--- a/honeycomb-core/src/common.rs
+++ b/honeycomb-core/src/common.rs
@@ -37,20 +37,3 @@ pub trait CoordsFloat:
 }
 
 impl<T: num::Float + Default + AddAssign + SubAssign + MulAssign + DivAssign> CoordsFloat for T {}
-
-// --- test utility
-
-#[cfg(test)]
-cfg_if::cfg_if! {
-    if #[cfg(feature = "_single_precision")] {
-        /// Floating-point type alias.
-        ///
-        /// This is mostly used to run tests using both `f64` and `f32`.
-        pub type FloatType = f32;
-    } else {
-        /// Floating-point type alias.
-        ///
-        /// This is mostly used to run tests using both `f64` and `f32`.
-        pub type FloatType = f64;
-    }
-}

--- a/honeycomb-core/src/spatial_repr/coords.rs
+++ b/honeycomb-core/src/spatial_repr/coords.rs
@@ -215,28 +215,40 @@ impl<T: CoordsFloat> IndexMut<usize> for Coords2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::FloatType;
 
-    fn almost_equal(lhs: &Coords2<FloatType>, rhs: &Coords2<FloatType>) -> bool {
-        const EPS: FloatType = 10.0e-12;
-        ((lhs.x - rhs.x).abs() < EPS) & ((lhs.y - rhs.y).abs() < EPS)
+    macro_rules! almost_equal {
+        ($f1: expr, $f2: expr, $t: ty) => {
+            ($f1 - $f2).abs() < <$t>::EPSILON
+        };
+    }
+    macro_rules! almost_equal_vec {
+        ($lhs: expr, $rhs: expr, $t: ty) => {
+            almost_equal!($lhs.x, $rhs.x, $t) & almost_equal!($lhs.y, $rhs.y, $t)
+        };
     }
 
-    #[test]
-    fn sum() {
-        let collection = [
-            Coords2::unit_x(),
-            Coords2::unit_x(),
-            Coords2::unit_x(),
-            Coords2::unit_y(),
-            Coords2::unit_y(),
-            Coords2::unit_y(),
-        ];
+    macro_rules! generate_sum_test {
+        ($id: ident, $t: ty) => {
+            #[test]
+            fn $id() {
+                let collection = [
+                    Coords2::unit_x(),
+                    Coords2::unit_x(),
+                    Coords2::unit_x(),
+                    Coords2::unit_y(),
+                    Coords2::unit_y(),
+                    Coords2::unit_y(),
+                ];
 
-        let owned_sum: Coords2<FloatType> = collection.into_iter().sum();
-        let borrowed_sum: Coords2<FloatType> = collection.iter().sum();
-        let ref_value: Coords2<FloatType> = Coords2::from((3.0, 3.0));
-        assert!(almost_equal(&owned_sum, &ref_value));
-        assert!(almost_equal(&borrowed_sum, &ref_value));
+                let owned_sum: Coords2<$t> = collection.into_iter().sum();
+                let borrowed_sum: Coords2<$t> = collection.iter().sum();
+                let ref_value: Coords2<$t> = Coords2::from((3.0, 3.0));
+                assert!(almost_equal_vec!(owned_sum, ref_value, $t));
+                assert!(almost_equal_vec!(borrowed_sum, ref_value, $t));
+            }
+        };
     }
+
+    generate_sum_test!(sum_simple, f32);
+    generate_sum_test!(sum_double, f64);
 }

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -294,43 +294,57 @@ mod tests {
     use crate::common::FloatType;
 
     macro_rules! almost_equal {
-        ($f1: expr, $f2: expr) => {
-            ((($f1 - $f2) as FloatType).abs() < FloatType::EPSILON)
+        ($f1: expr, $f2: expr, $t: ty) => {
+            ($f1 - $f2).abs() < <$t>::EPSILON
         };
     }
 
-    fn almost_equal_vec(lhs: &Vector2<FloatType>, rhs: &Vector2<FloatType>) -> bool {
-        almost_equal!(lhs.x(), rhs.x()) & almost_equal!(lhs.y(), rhs.y())
+    macro_rules! almost_equal_vec {
+        ($lhs: expr, $rhs: expr, $t: ty) => {
+            almost_equal!($lhs.x(), $rhs.x(), $t) & almost_equal!($lhs.y(), $rhs.y(), $t)
+        };
     }
 
     #[test]
     fn dot_product() {
-        let along_x = Vector2::unit_x() * 15.0;
-        let along_y = Vector2::unit_y() * 10.0;
-        assert!(almost_equal!(along_x.dot(&along_y), 0.0));
-        assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0));
-        assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0));
+        // double
+        let along_x = Vector2::unit_x() * 15.0_f64;
+        let along_y = Vector2::unit_y() * 10.0_f64;
+        assert!(almost_equal!(along_x.dot(&along_y), 0.0, f64));
+        assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0, f64));
+        assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0, f64));
+
+        // simple
+        let along_x = Vector2::unit_x() * 15.0_f32;
+        let along_y = Vector2::unit_y() * 10.0_f32;
+        assert!(almost_equal!(along_x.dot(&along_y), 0.0, f32));
+        assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0, f32));
+        assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0, f32));
     }
 
     #[test]
     fn unit_dir() {
-        let along_x = Vector2::unit_x() * 4.0;
-        let along_y = Vector2::unit_y() * 3.0;
-        assert!(almost_equal_vec(
-            &along_x.unit_dir().unwrap(),
-            &Vector2::unit_x()
+        let along_x = Vector2::unit_x() * 4.0_f64;
+        let along_y = Vector2::unit_y() * 3.0_f64;
+        assert!(almost_equal_vec!(
+            along_x.unit_dir().unwrap(),
+            Vector2::<f64>::unit_x(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &Vector2::<FloatType>::unit_x().unit_dir().unwrap(),
-            &Vector2::unit_x()
+        assert!(almost_equal_vec!(
+            Vector2::<f64>::unit_x().unit_dir().unwrap(),
+            Vector2::<f64>::unit_x(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &along_y.unit_dir().unwrap(),
-            &Vector2::unit_y()
+        assert!(almost_equal_vec!(
+            along_y.unit_dir().unwrap(),
+            Vector2::<f64>::unit_y(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &(along_x + along_y).unit_dir().unwrap(),
-            &Vector2::from((4.0 / 5.0, 3.0 / 5.0))
+        assert!(almost_equal_vec!(
+            (along_x + along_y).unit_dir().unwrap(),
+            Vector2::<f64>::from((4.0 / 5.0, 3.0 / 5.0)),
+            f64
         ));
         let origin: Vector2<FloatType> = Vector2::default();
         assert!(origin.unit_dir().is_err());
@@ -340,27 +354,31 @@ mod tests {
     fn normal_dir() {
         let along_x = Vector2::unit_x() * 4.0;
         let along_y = Vector2::unit_y() * 3.0;
-        assert!(almost_equal_vec(
-            &along_x.normal_dir().unwrap(),
-            &Vector2::unit_y()
+        assert!(almost_equal_vec!(
+            along_x.normal_dir().unwrap(),
+            Vector2::<f64>::unit_y(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &Vector2::unit_x().normal_dir().unwrap(),
-            &Vector2::unit_y()
+        assert!(almost_equal_vec!(
+            Vector2::<f64>::unit_x().normal_dir().unwrap(),
+            Vector2::<f64>::unit_y(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &along_y.normal_dir().unwrap(),
-            &-Vector2::unit_x()
+        assert!(almost_equal_vec!(
+            along_y.normal_dir().unwrap(),
+            -Vector2::<f64>::unit_x(),
+            f64
         ));
-        assert!(almost_equal_vec(
-            &Vector2::unit_y().normal_dir().unwrap(),
-            &-Vector2::unit_x()
+        assert!(almost_equal_vec!(
+            Vector2::<f64>::unit_y().normal_dir().unwrap(),
+            -Vector2::<f64>::unit_x(),
+            f64
         ));
     }
 
     #[test]
     fn normal_dir_of_null_vel() {
-        let origin: Vector2<FloatType> = Vector2::default();
+        let origin: Vector2<f64> = Vector2::default();
         let err = origin.normal_dir();
         assert_eq!(err, Err(CoordsError::InvalidUnitDir));
     }

--- a/honeycomb-core/src/spatial_repr/vector.rs
+++ b/honeycomb-core/src/spatial_repr/vector.rs
@@ -291,95 +291,101 @@ impl<T: CoordsFloat> std::ops::Neg for Vector2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::FloatType;
 
+    // utils
     macro_rules! almost_equal {
         ($f1: expr, $f2: expr, $t: ty) => {
             ($f1 - $f2).abs() < <$t>::EPSILON
         };
     }
-
     macro_rules! almost_equal_vec {
         ($lhs: expr, $rhs: expr, $t: ty) => {
             almost_equal!($lhs.x(), $rhs.x(), $t) & almost_equal!($lhs.y(), $rhs.y(), $t)
         };
     }
 
-    #[test]
-    fn dot_product() {
-        // double
-        let along_x = Vector2::unit_x() * 15.0_f64;
-        let along_y = Vector2::unit_y() * 10.0_f64;
-        assert!(almost_equal!(along_x.dot(&along_y), 0.0, f64));
-        assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0, f64));
-        assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0, f64));
-
-        // simple
-        let along_x = Vector2::unit_x() * 15.0_f32;
-        let along_y = Vector2::unit_y() * 10.0_f32;
-        assert!(almost_equal!(along_x.dot(&along_y), 0.0, f32));
-        assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0, f32));
-        assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0, f32));
+    // tests
+    macro_rules! generate_dot_prod_test {
+        ($id: ident, $t: ty) => {
+            #[test]
+            fn $id() {
+                let along_x = Vector2::<$t>::unit_x() * 15.0;
+                let along_y = Vector2::<$t>::unit_y() * 10.0;
+                assert!(almost_equal!(along_x.dot(&along_y), 0.0, $t));
+                assert!(almost_equal!(along_x.dot(&Vector2::unit_x()), 15.0, $t));
+                assert!(almost_equal!(along_y.dot(&Vector2::unit_y()), 10.0, $t));
+            }
+        };
+    }
+    macro_rules! generate_unit_dir_test {
+        ($id: ident, $t: ty) => {
+            #[test]
+            fn $id() {
+                let along_x = Vector2::<$t>::unit_x() * 4.0;
+                let along_y = Vector2::<$t>::unit_y() * 3.0;
+                assert!(almost_equal_vec!(
+                    along_x.unit_dir().unwrap(),
+                    Vector2::<$t>::unit_x(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    Vector2::<$t>::unit_x().unit_dir().unwrap(),
+                    Vector2::<$t>::unit_x(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    along_y.unit_dir().unwrap(),
+                    Vector2::<$t>::unit_y(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    (along_x + along_y).unit_dir().unwrap(),
+                    Vector2::<$t>::from((4.0 / 5.0, 3.0 / 5.0)),
+                    $t
+                ));
+                let origin: Vector2<$t> = Vector2::default();
+                assert_eq!(origin.unit_dir(), Err(CoordsError::InvalidUnitDir));
+            }
+        };
+    }
+    macro_rules! generate_normal_dir_test {
+        ($id: ident, $t: ty) => {
+            #[test]
+            fn $id() {
+                let along_x = Vector2::<$t>::unit_x() * 4.0;
+                let along_y = Vector2::<$t>::unit_y() * 3.0;
+                assert!(almost_equal_vec!(
+                    along_x.normal_dir().unwrap(),
+                    Vector2::<$t>::unit_y(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    Vector2::<$t>::unit_x().normal_dir().unwrap(),
+                    Vector2::<$t>::unit_y(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    along_y.normal_dir().unwrap(),
+                    -Vector2::<$t>::unit_x(),
+                    $t
+                ));
+                assert!(almost_equal_vec!(
+                    Vector2::<$t>::unit_y().normal_dir().unwrap(),
+                    -Vector2::<$t>::unit_x(),
+                    $t
+                ));
+                let origin: Vector2<$t> = Vector2::default();
+                assert_eq!(origin.normal_dir(), Err(CoordsError::InvalidUnitDir));
+            }
+        };
     }
 
-    #[test]
-    fn unit_dir() {
-        let along_x = Vector2::unit_x() * 4.0_f64;
-        let along_y = Vector2::unit_y() * 3.0_f64;
-        assert!(almost_equal_vec!(
-            along_x.unit_dir().unwrap(),
-            Vector2::<f64>::unit_x(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            Vector2::<f64>::unit_x().unit_dir().unwrap(),
-            Vector2::<f64>::unit_x(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            along_y.unit_dir().unwrap(),
-            Vector2::<f64>::unit_y(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            (along_x + along_y).unit_dir().unwrap(),
-            Vector2::<f64>::from((4.0 / 5.0, 3.0 / 5.0)),
-            f64
-        ));
-        let origin: Vector2<FloatType> = Vector2::default();
-        assert!(origin.unit_dir().is_err());
-    }
+    generate_dot_prod_test!(dot_product_simple, f32);
+    generate_dot_prod_test!(dot_product_double, f64);
 
-    #[test]
-    fn normal_dir() {
-        let along_x = Vector2::unit_x() * 4.0;
-        let along_y = Vector2::unit_y() * 3.0;
-        assert!(almost_equal_vec!(
-            along_x.normal_dir().unwrap(),
-            Vector2::<f64>::unit_y(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            Vector2::<f64>::unit_x().normal_dir().unwrap(),
-            Vector2::<f64>::unit_y(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            along_y.normal_dir().unwrap(),
-            -Vector2::<f64>::unit_x(),
-            f64
-        ));
-        assert!(almost_equal_vec!(
-            Vector2::<f64>::unit_y().normal_dir().unwrap(),
-            -Vector2::<f64>::unit_x(),
-            f64
-        ));
-    }
+    generate_unit_dir_test!(unit_dir_simple, f32);
+    generate_unit_dir_test!(unit_dir_double, f64);
 
-    #[test]
-    fn normal_dir_of_null_vel() {
-        let origin: Vector2<f64> = Vector2::default();
-        let err = origin.normal_dir();
-        assert_eq!(err, Err(CoordsError::InvalidUnitDir));
-    }
+    generate_normal_dir_test!(normal_dir_simple, f32);
+    generate_normal_dir_test!(normal_dir_double, f64);
 }

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -255,37 +255,68 @@ impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::FloatType;
 
     #[test]
     fn add_vertex_vector() {
-        let mut a: Vertex2<FloatType> = Vertex2::from((1.0, 1.0));
-        let b: Vector2<FloatType> = Vector2::from((1.0, 0.0));
-        let a_moved = a + b;
-        assert_eq!(a_moved, Vertex2::from((2.0, 1.0)));
-        a += &b;
-        assert_eq!(a, a_moved);
-        a += b;
-        assert_eq!(a, Vertex2::from((3.0, 1.0)));
+        {
+            let mut a: Vertex2<f64> = Vertex2::from((1.0, 1.0));
+            let b: Vector2<f64> = Vector2::from((1.0, 0.0));
+            let a_moved = a + b;
+            assert_eq!(a_moved, Vertex2::from((2.0, 1.0)));
+            a += &b;
+            assert_eq!(a, a_moved);
+            a += b;
+            assert_eq!(a, Vertex2::from((3.0, 1.0)));
+        }
+        {
+            let mut a: Vertex2<f32> = Vertex2::from((1.0, 1.0));
+            let b: Vector2<f32> = Vector2::from((1.0, 0.0));
+            let a_moved = a + b;
+            assert_eq!(a_moved, Vertex2::from((2.0, 1.0)));
+            a += &b;
+            assert_eq!(a, a_moved);
+            a += b;
+            assert_eq!(a, Vertex2::from((3.0, 1.0)));
+        }
     }
 
     #[test]
     fn sub_vertex_vector() {
-        let mut a: Vertex2<FloatType> = Vertex2::from((1.0, 1.0));
-        let b: Vector2<FloatType> = Vector2::from((1.0, 0.0));
-        let a_moved = a - b;
-        assert_eq!(a_moved, Vertex2::from((0.0, 1.0)));
-        a -= &b;
-        assert_eq!(a, a_moved);
-        a -= b;
-        assert_eq!(a, Vertex2::from((-1.0, 1.0)));
+        {
+            let mut a: Vertex2<f64> = Vertex2::from((1.0, 1.0));
+            let b: Vector2<f64> = Vector2::from((1.0, 0.0));
+            let a_moved = a - b;
+            assert_eq!(a_moved, Vertex2::from((0.0, 1.0)));
+            a -= &b;
+            assert_eq!(a, a_moved);
+            a -= b;
+            assert_eq!(a, Vertex2::from((-1.0, 1.0)));
+        }
+        {
+            let mut a: Vertex2<f32> = Vertex2::from((1.0, 1.0));
+            let b: Vector2<f32> = Vector2::from((1.0, 0.0));
+            let a_moved = a - b;
+            assert_eq!(a_moved, Vertex2::from((0.0, 1.0)));
+            a -= &b;
+            assert_eq!(a, a_moved);
+            a -= b;
+            assert_eq!(a, Vertex2::from((-1.0, 1.0)));
+        }
     }
 
     #[test]
     fn sub_vertex_vertex() {
-        let a: Vertex2<FloatType> = Vertex2::from((1.0, 1.0));
-        let b: Vertex2<FloatType> = Vertex2::from((1.0, 0.0));
-        let ab = b - a;
-        assert_eq!(ab, Vector2::from((0.0, -1.0)));
+        {
+            let a: Vertex2<f64> = Vertex2::from((1.0, 1.0));
+            let b: Vertex2<f64> = Vertex2::from((1.0, 0.0));
+            let ab = b - a;
+            assert_eq!(ab, Vector2::from((0.0, -1.0)));
+        }
+        {
+            let a: Vertex2<f32> = Vertex2::from((1.0, 1.0));
+            let b: Vertex2<f32> = Vertex2::from((1.0, 0.0));
+            let ab = b - a;
+            assert_eq!(ab, Vector2::from((0.0, -1.0)));
+        }
     }
 }

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -512,7 +512,6 @@ impl<T: CoordsFloat> GridBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::FloatType;
 
     #[test]
     fn build_nc_lpc_l() {
@@ -604,7 +603,7 @@ mod tests {
 
     #[test]
     fn square_cmap2_correctness() {
-        let cmap: CMap2<FloatType> = GridBuilder::unit_squares(2).build2().unwrap();
+        let cmap: CMap2<f64> = GridBuilder::unit_squares(2).build2().unwrap();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction
@@ -705,7 +704,7 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     #[test]
     fn splitsquare_cmap2_correctness() {
-        let cmap: CMap2<FloatType> = GridBuilder::split_unit_squares(2).build2().unwrap();
+        let cmap: CMap2<f64> = GridBuilder::split_unit_squares(2).build2().unwrap();
 
         // hardcoded because using a generic loop & dim would just mean
         // reusing the same pattern as the one used during construction


### PR DESCRIPTION
remove all `FloatType` usages in order to prepare for feature removal; also rewrote some tests using macros to still use both f32/f64 types.

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] Testing
- [x] Refactor

## Necessary follow-up

- [x] Other: remove the `_single_precision` feature and update CIs