### PR TITLE
chore!: remove sp feature & update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
-        run: cargo build --features utils,io --all
+        run: cargo build --all --all-features
   build_examples:
     name: Build examples for ${{ matrix.os }}
     strategy:
@@ -37,7 +37,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
-        run: cargo build --features utils,io --examples
+        run: cargo build --examples --all-features
   build_benchmarks:
     name: Build benchmarks for ${{ matrix.os }}
     strategy:
@@ -51,4 +51,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks
-        run: cargo build --features utils,io --benches
+        run: cargo build --benches --all-features

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,12 +31,12 @@ jobs:
       # generate raw coverage data
       # excluding the benchmark / example crates to remove some bias
       - name: Build code
-        run: cargo build --features utils,io --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
+        run: cargo build --all-features --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
       - name: Run tests
-        run: cargo test --features utils,io --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
+        run: cargo test --all-features --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate User Guide
         run: mdbook build -d ../target/doc/ honeycomb-guide/
       - name: Generate Rust Docs
-        run: cargo +nightly doc --all --no-deps --features utils,io
+        run: cargo +nightly doc --all --no-deps --all-features
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -19,14 +19,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check Format
-        run: cargo fmt -- --check
+        run: cargo fmt --all --check
   clippy:
-    strategy:
-      matrix:
-        features:
-          - _single_precision
-          - utils
-          - io
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Clippy
-        run: cargo clippy --features ${{ matrix.features }} -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
   tests:
     strategy:
       matrix:
@@ -51,4 +45,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run Tests
-        run: cargo test --features ${{ matrix.features }} --all
+        run: cargo test --all --all-features

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -15,7 +15,6 @@ publish = true
 [features]
 io = ["dep:vtkio"]
 utils = []
-_single_precision = []
 
 # deps
 


### PR DESCRIPTION
remove the `_single_precision` feature from the core crate & update the CI to automatically enable all features.

## Scope

- [x] Code: `honeycomb-core`
- [x] CI

## Type of change

- [x] Refactor

## Other

- [x] Breaking change

## Necessary follow-up

- [x] Other: the benchmark crate still uses a similar feature, but I will edit it later since benches should probably be re-written anyway
