### PR TITLE
feat(honeycomb-core): add `CMap2::split_edge` for future algorithm implementations

### DIFF
--- a/examples/examples/render/squaremap.rs
+++ b/examples/examples/render/squaremap.rs
@@ -6,7 +6,6 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let mut map: CMap2<f32> = GridBuilder::unit_squares(4).build2().unwrap();
-    map.split_edge(1, None);
+    let map: CMap2<f32> = GridBuilder::unit_squares(4).build2().unwrap();
     launch(render_params, Some(&map));
 }

--- a/examples/examples/render/squaremap.rs
+++ b/examples/examples/render/squaremap.rs
@@ -6,6 +6,7 @@ fn main() {
         smaa_mode: SmaaMode::Smaa1X,
         ..Default::default()
     };
-    let map: CMap2<f32> = GridBuilder::unit_squares(4).build2().unwrap();
+    let mut map: CMap2<f32> = GridBuilder::unit_squares(4).build2().unwrap();
+    map.split_edge(1, None);
     launch(render_params, Some(&map));
 }

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -10,6 +10,18 @@ use crate::{CMap2, CoordsFloat, EdgeIdentifier};
 // ------ CONTENT
 
 impl<T: CoordsFloat> CMap2<T> {
+    /// Split an edge into to segments.
+    ///
+    /// <div class="warning">
+    /// This implementation is 2D specific.
+    /// </div>
+    ///
+    /// This method takes all darts of an edge and rebuild connections in order to create a new
+    /// point on this edge. The position of the point default to the midway point, but it can
+    /// optionally be specified.
+    ///
+    /// In order to minimize editing of embedded data, the original darts are kept to their
+    /// original vertices while the new darts are used to model the new point.
     pub fn split_edge(&mut self, edge_id: EdgeIdentifier) {
         todo!()
     }

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -68,9 +68,13 @@ impl<T: CoordsFloat> CMap2<T> {
             self.two_unlink(d1);
             // rebuild the edge
             self.one_link(d1, b1d1_new);
-            self.one_link(b1d1_new, b1d1_old);
+            if b1d1_old != NULL_DART_ID {
+                self.one_link(b1d1_new, b1d1_old);
+            }
             self.one_link(d2, b1d2_new);
-            self.one_link(b1d2_new, b1d2_old);
+            if b1d2_old != NULL_DART_ID {
+                self.one_link(b1d2_new, b1d2_old);
+            }
             self.two_link(d1, b1d2_new);
             self.two_link(d2, b1d1_new);
             // insert the new vertex

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -23,6 +23,8 @@ impl<T: CoordsFloat> CMap2<T> {
     /// In order to minimize editing of embedded data, the original darts are kept to their
     /// original vertices while the new darts are used to model the new point.
     ///
+    /// For an illustration of both principles, refer to the example section.
+    ///
     /// # Arguments
     ///
     /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
@@ -33,6 +35,19 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This method may panic if the edge upon which the operation is performed does not have two
     /// defined vertices.
+    ///
+    /// # Example
+    ///
+    /// Given an edge made of darts `1` and `2`, these darts respectively encoding vertices
+    /// `(0.0, 0.0)` and `(2.0, 0.0)`, calling `map.split_edge(1, Some(0.2))` would result in the
+    /// creation of two new darts, a new vertex (ID `3`) of value `(0.4, 0.0)` and the following
+    /// topology:
+    ///
+    /// ```text
+    ///    +----1---->              +-1-> +-3->     |
+    ///  1             2    =>    1      3      2   | + denote darts that encode vertex IDs
+    ///    <----2----+              <-4-- <-2-+     |
+    /// ```
     pub fn split_edge(&mut self, edge_id: EdgeIdentifier, midpoint_vertex: Option<T>) {
         if midpoint_vertex.is_some_and(|t| (t >= T::one()) | (t <= T::zero())) {
             println!("W: vertex placement for split is not in ]0;1[ -- result may be incoherent");

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -23,11 +23,20 @@ impl<T: CoordsFloat> CMap2<T> {
     /// In order to minimize editing of embedded data, the original darts are kept to their
     /// original vertices while the new darts are used to model the new point.
     ///
+    /// # Arguments
+    ///
+    /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
+    /// - `midpoint_vertex: Option<T>` -- Relative position of the new vertex, starting from the
+    ///   vertex of the dart sharing `edge_id` as its identifier.
+    ///
     /// # Panics
     ///
     /// This method may panic if the edge upon which the operation is performed does not have two
-    /// defined vertices.a
-    pub fn split_edge(&mut self, edge_id: EdgeIdentifier, midpoint_vertex: Option<Vertex2<T>>) {
+    /// defined vertices.
+    pub fn split_edge(&mut self, edge_id: EdgeIdentifier, midpoint_vertex: Option<T>) {
+        if midpoint_vertex.is_some_and(|t| (t >= T::one()) | (t <= T::zero())) {
+            println!("W: vertex placement for split is not in ]0;1[ -- result may be incoherent");
+        }
         let d1 = edge_id as DartIdentifier;
         let d2 = self.beta::<2>(d1);
         // (*): unwrapping is ok because you probably shouldn't be using this method
@@ -47,9 +56,10 @@ impl<T: CoordsFloat> CMap2<T> {
             self.one_link(d1, b1d1_new);
             self.one_link(b1d1_new, b1d1_old);
             // insert the new vertex
+            let seg = v2 - v1;
             self.insert_vertex(
                 self.vertex_id(b1d1_new),
-                midpoint_vertex.unwrap_or(Vertex2::average(&v1, &v2)),
+                midpoint_vertex.map_or(Vertex2::average(&v1, &v2), |t| v1 + seg * t),
             );
         } else {
             let b1d1_old = self.beta::<1>(d1);
@@ -78,9 +88,10 @@ impl<T: CoordsFloat> CMap2<T> {
             self.two_link(d1, b1d2_new);
             self.two_link(d2, b1d1_new);
             // insert the new vertex
+            let seg = v2 - v1;
             self.insert_vertex(
                 self.vertex_id(b1d1_new),
-                midpoint_vertex.unwrap_or(Vertex2::average(&v1, &v2)),
+                midpoint_vertex.map_or(Vertex2::average(&v1, &v2), |t| v1 + seg * t),
             );
         }
     }

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -1,0 +1,16 @@
+//! Advanced operations implementation
+//!
+//! This module contains code used to implement advanced operations, e.g. some non-standard,
+//! higher-level abstractions that are useful in meshing algorithms.
+
+// ------ IMPORTS
+
+use crate::{CMap2, CoordsFloat, EdgeIdentifier};
+
+// ------ CONTENT
+
+impl<T: CoordsFloat> CMap2<T> {
+    pub fn split_edge(&mut self, edge_id: EdgeIdentifier) {
+        todo!()
+    }
+}

--- a/honeycomb-core/src/cmap2/basic_ops.rs
+++ b/honeycomb-core/src/cmap2/basic_ops.rs
@@ -1,6 +1,6 @@
 //! Basic operations implementation
 //!
-//! This module contains code used to implement basic opearations of combinatorial maps, such as
+//! This module contains code used to implement basic operations of combinatorial maps, such as
 //! (but not limited to):
 //!
 //! - Dart addition / insertion / removal

--- a/honeycomb-core/src/cmap2/mod.rs
+++ b/honeycomb-core/src/cmap2/mod.rs
@@ -7,6 +7,7 @@
 
 // ------ MODULE DECLARATIONS
 
+mod advanced_ops;
 mod basic_ops;
 mod embed;
 mod link_and_sew;
@@ -28,6 +29,5 @@ pub use structure::CMap2;
 const CMAP2_BETA: usize = 3;
 
 // ------ TESTS
-mod advanced_ops;
 #[cfg(test)]
 mod tests;

--- a/honeycomb-core/src/cmap2/mod.rs
+++ b/honeycomb-core/src/cmap2/mod.rs
@@ -28,5 +28,6 @@ pub use structure::CMap2;
 const CMAP2_BETA: usize = 3;
 
 // ------ TESTS
+mod advanced_ops;
 #[cfg(test)]
 mod tests;

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -258,10 +258,10 @@ fn split_edge_complete() {
     //  1         2         3         4
     //    ---1-->   ---2-->   ---3-->
     let mut map: CMap2<f64> = CMap2::new(6);
-    map.one_sew(1, 2);
-    map.one_sew(2, 3);
-    map.one_sew(4, 5);
-    map.one_sew(5, 6);
+    map.one_link(1, 2);
+    map.one_link(2, 3);
+    map.one_link(4, 5);
+    map.one_link(5, 6);
     map.two_link(1, 6);
     map.two_link(2, 5);
     map.two_link(3, 4);

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -1,9 +1,11 @@
 // ------ IMPORTS
 
-use crate::cmap2::io::build_cmap_from_vtk;
-use crate::{CMap2, DartIdentifier, Orbit2, OrbitPolicy, Vertex2, NULL_DART_ID};
-use vtkio::Vtk;
+use crate::{CMap2, Orbit2, OrbitPolicy, Vertex2, NULL_DART_ID};
 
+#[cfg(feature = "io")]
+use crate::{cmap2::io::build_cmap_from_vtk, DartIdentifier};
+#[cfg(feature = "io")]
+use vtkio::Vtk;
 // ------ CONTENT
 
 // --- GENERAL
@@ -434,6 +436,7 @@ fn io_write() {
     assert!(res.contains("2 8 3"));
 }
 
+#[cfg(feature = "io")]
 #[test]
 fn io_read() {
     let vtk = Vtk::parse_legacy_be(VTK_ASCII).unwrap();
@@ -465,7 +468,7 @@ fn io_read() {
     assert_eq!(six_count, 1);
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "io"))]
 const VTK_ASCII: &[u8] = b"
 # vtk DataFile Version 2.0
 cmap

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -249,6 +249,93 @@ fn one_sew_no_attributes_bis() {
     map.one_sew(1, 3); // panic
 }
 
+// --- ADVANCED
+
+#[test]
+fn split_edge_complete() {
+    // before
+    //    <--6---   <--5---   <--4---
+    //  1         2         3         4
+    //    ---1-->   ---2-->   ---3-->
+    let mut map: CMap2<f64> = CMap2::new(6);
+    map.one_sew(1, 2);
+    map.one_sew(2, 3);
+    map.one_sew(4, 5);
+    map.one_sew(5, 6);
+    map.two_link(1, 6);
+    map.two_link(2, 5);
+    map.two_link(3, 4);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (1.0, 0.0));
+    map.insert_vertex(3, (2.0, 0.0));
+    map.insert_vertex(4, (3.0, 0.0));
+    // split
+    map.split_edge(2, None);
+    // after
+    //    <--6---   <8- <5-   <--4---
+    //  1         2    7    3         4
+    //    ---1-->   -2> -7>   ---3-->
+    assert_eq!(map.beta::<2>(2), 8);
+    assert_eq!(map.beta::<1>(1), 2);
+    assert_eq!(map.beta::<1>(2), 7);
+    assert_eq!(map.beta::<1>(7), 3);
+
+    assert_eq!(map.beta::<2>(5), 7);
+    assert_eq!(map.beta::<1>(4), 5);
+    assert_eq!(map.beta::<1>(5), 8);
+    assert_eq!(map.beta::<1>(8), 6);
+
+    assert_eq!(map.vertex_id(8), 7);
+    assert_eq!(map.vertex_id(7), 7);
+
+    assert_eq!(map.vertex(2), Ok(Vertex2::from((1.0, 0.0))));
+    assert_eq!(map.vertex(7), Ok(Vertex2::from((1.5, 0.0))));
+    assert_eq!(map.vertex(3), Ok(Vertex2::from((2.0, 0.0))));
+}
+
+#[test]
+fn split_edge_isolated() {
+    // before
+    //    <--2---
+    //  1         2
+    //    ---1-->
+    let mut map: CMap2<f64> = CMap2::new(2);
+    map.two_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (1.0, 0.0));
+    // split
+    map.split_edge(1, Some(Vertex2::from((0.6, 0.0))));
+    // after
+    //    <-4- <2-
+    //  1     3    2
+    //    -1-> -3>
+    assert_eq!(map.beta::<2>(1), 4);
+    assert_eq!(map.beta::<1>(1), 3);
+
+    assert_eq!(map.beta::<2>(2), 3);
+    assert_eq!(map.beta::<1>(2), 4);
+
+    assert_eq!(map.vertex_id(3), 3);
+    assert_eq!(map.vertex_id(4), 3);
+
+    assert_eq!(map.vertex(1), Ok(Vertex2::from((0.0, 0.0))));
+    assert_eq!(map.vertex(3), Ok(Vertex2::from((0.6, 0.0))));
+    assert_eq!(map.vertex(2), Ok(Vertex2::from((1.0, 0.0))));
+}
+
+#[test]
+fn split_single_dart() {
+    //  1 ---1--> 2 ---2-->
+}
+
+#[test]
+#[should_panic(expected = "attempt to split an edge that is not fully defined in the first place")]
+fn split_edge_missing_vertex() {
+    //    <--2---
+    //  1         ?
+    //    ---1-->
+}
+
 // --- IO
 
 #[cfg(feature = "io")]

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -1,7 +1,7 @@
 // ------ IMPORTS
 
 use crate::cmap2::io::build_cmap_from_vtk;
-use crate::{CMap2, DartIdentifier, Orbit2, OrbitPolicy, Vertex2};
+use crate::{CMap2, DartIdentifier, Orbit2, OrbitPolicy, Vertex2, NULL_DART_ID};
 use vtkio::Vtk;
 
 // ------ CONTENT
@@ -325,7 +325,20 @@ fn split_edge_isolated() {
 
 #[test]
 fn split_single_dart() {
-    //  1 ---1--> 2 ---2-->
+    // before
+    //  1 -----> 2 ->
+    let mut map: CMap2<f64> = CMap2::new(2);
+    map.one_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (1.0, 0.0));
+    // split
+    map.split_edge(1, None);
+    // after
+    //  1 -> 3 -> 2 ->
+    assert_eq!(map.beta::<1>(1), 3);
+    assert_eq!(map.beta::<1>(3), 2);
+    assert_eq!(map.beta::<2>(3), NULL_DART_ID);
+    assert_eq!(map.vertex(3), Ok(Vertex2::from((0.5, 0.0))));
 }
 
 #[test]
@@ -334,6 +347,12 @@ fn split_edge_missing_vertex() {
     //    <--2---
     //  1         ?
     //    ---1-->
+    let mut map: CMap2<f64> = CMap2::new(2);
+    map.two_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
+    // split
+    map.split_edge(1, None);
 }
 
 // --- IO

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -306,7 +306,7 @@ fn split_edge_isolated() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    map.split_edge(1, Some(Vertex2::from((0.6, 0.0))));
+    map.split_edge(1, Some(0.6));
     // after
     //    <-4- <2-
     //  1     3    2


### PR DESCRIPTION
Implement a new method, `CMap2::split_edge`, that split an existing edges into two, giving optional control over where the new intermediary vertex is placed.

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] New feature(s)
