### PR TITLE
fix(render): update aspect ratio to prevent deformation of the rendered map

### DIFF
--- a/honeycomb-render/src/state/camera.rs
+++ b/honeycomb-render/src/state/camera.rs
@@ -35,7 +35,7 @@ impl Camera {
     fn build_view_projection_matrix(&self) -> cgmath::Matrix4<f32> {
         let view = cgmath::Matrix4::look_at_rh(self.eye, self.target, self.up);
         let proj = cgmath::perspective(cgmath::Deg(self.fovy), self.aspect, self.znear, self.zfar);
-        OPENGL_TO_WGPU_MATRIX * proj * view
+        proj * view
     }
 }
 
@@ -56,7 +56,7 @@ impl Default for CameraUniform {
 
 impl CameraUniform {
     pub fn update_view_proj(&mut self, camera: &Camera) {
-        self.view_proj = camera.build_view_projection_matrix().into();
+        self.view_proj = (OPENGL_TO_WGPU_MATRIX * camera.build_view_projection_matrix()).into();
     }
 }
 

--- a/honeycomb-render/src/state/gfx.rs
+++ b/honeycomb-render/src/state/gfx.rs
@@ -105,6 +105,8 @@ impl GfxState {
         self.config.width = new_size.width.max(1);
         self.config.height = new_size.height.max(1);
         self.surface.configure(&self.device, &self.config);
+        self.camera.aspect = self.config.width as f32 / self.config.height as f32;
+        self.camera_uniform.update_view_proj(&self.camera);
     }
 
     pub fn input(&mut self, event: &WindowEvent, target: &ActiveEventLoop) -> bool {


### PR DESCRIPTION
update the camera uniform buffer to take into account the aspect ratio in the matrix view/projection transform. This solves the issue of deformation, but does not handle resolution upscaling when the window size grows.

Before:

![image](https://github.com/LIHPC-Computational-Geometry/honeycomb/assets/95699343/39b9f856-a24f-4c7c-8666-21a5dde8c391)

After:

![image](https://github.com/LIHPC-Computational-Geometry/honeycomb/assets/95699343/ef1b53db-3cae-4b14-83f3-0df5cdee2ddf)

## Scope



- [x] Code: `honeycomb-render`

## Type of change

- [x] Fix: related to #53 
