### PR TITLE
refactor(core): deprecate old constructors

### DIFF
--- a/honeycomb-core/src/cmap2/structure.rs
+++ b/honeycomb-core/src/cmap2/structure.rs
@@ -175,6 +175,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// See [`CMap2`] example.
     ///
+    #[deprecated(note = "please use `CMapBuilder::n_darts` instead")]
     #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn new(n_darts: usize) -> Self {
         Self {

--- a/honeycomb-core/src/cmapbuilder/grid/building_routines.rs
+++ b/honeycomb-core/src/cmapbuilder/grid/building_routines.rs
@@ -11,6 +11,7 @@ pub fn build_2d_grid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
 ) -> CMap2<T> {
+    #[allow(deprecated)] // allow because CMap2::new() will still be available inside the crate
     let mut map: CMap2<T> = CMap2::new(4 * n_square_x * n_square_y);
 
     // first, topology
@@ -100,6 +101,7 @@ pub fn build_2d_splitgrid<T: CoordsFloat>(
     [n_square_x, n_square_y]: [usize; 2],
     [len_per_x, len_per_y]: [T; 2],
 ) -> CMap2<T> {
+    #[allow(deprecated)] // allow because CMap2::new() will still be available inside the crate
     let mut map: CMap2<T> = CMap2::new(6 * n_square_x * n_square_y);
 
     // first, topology

--- a/honeycomb-core/src/cmapbuilder/grid/descriptor.rs
+++ b/honeycomb-core/src/cmapbuilder/grid/descriptor.rs
@@ -2,11 +2,13 @@
 
 // ------ IMPORTS
 
+#[allow(deprecated)]
 use crate::utils::GridBuilder;
 use crate::{BuilderError, CoordsFloat};
 
 // ------ CONTENT
 
+#[allow(deprecated)]
 /// Temporary type alias before [`GridBuilder`] is renamed to this.
 pub type GridDescriptor<T> = GridBuilder<T>;
 
@@ -20,6 +22,7 @@ macro_rules! check_parameters {
     };
 }
 
+#[allow(deprecated)]
 impl<T: CoordsFloat> GridDescriptor<T> {
     /// Parse provided grid parameters to provide what's used to actually generate the grid.
     pub(crate) fn parse(self) -> Result<([usize; 2], [T; 2]), BuilderError> {

--- a/honeycomb-core/src/cmapbuilder/io/mod.rs
+++ b/honeycomb-core/src/cmapbuilder/io/mod.rs
@@ -27,6 +27,7 @@ impl<T: CoordsFloat + 'static> CMap2<T> {
     ///     - the mesh contains one type of cell that is not supported (either because of
     ///     dimension or orientation incompatibilities)
     ///     - the file has major inconsistencies / errors
+    #[deprecated(note = "please use `CMapBuilder::from_vtk_file` instead")]
     #[must_use = "constructed object is not used, consider removing this function call"]
     pub fn from_vtk_file(file_path: impl AsRef<std::path::Path> + std::fmt::Debug) -> Self {
         CMapBuilder::from_vtk_file(file_path).build().unwrap()

--- a/honeycomb-core/src/cmapbuilder/io/mod.rs
+++ b/honeycomb-core/src/cmapbuilder/io/mod.rs
@@ -93,6 +93,7 @@ macro_rules! build_vertices {
 ///
 /// TODO: change return type to `Result` & propagate return up to the map builder methods.
 pub fn build_2d_from_vtk<T: CoordsFloat>(value: Vtk) -> CMap2<T> {
+    #[allow(deprecated)] // allow because CMap2::new() will still be available inside the crate
     let mut cmap: CMap2<T> = CMap2::new(0);
     let mut sew_buffer: BTreeMap<(usize, usize), DartIdentifier> = BTreeMap::new();
     match value.data {

--- a/honeycomb-core/src/cmapbuilder/structure.rs
+++ b/honeycomb-core/src/cmapbuilder/structure.rs
@@ -104,6 +104,7 @@ impl<T: CoordsFloat> CMapBuilder<T> {
             // this routine should return a Result instead of the map directly
             return Ok(super::io::build_2d_from_vtk(vfile));
         }
+        #[allow(deprecated)]
         #[cfg(feature = "utils")]
         if let Some(gridb) = self.grid_descriptor {
             // build from grid descriptor
@@ -117,6 +118,7 @@ impl<T: CoordsFloat> CMapBuilder<T> {
                     .map(|(ns, lens)| super::grid::build_2d_grid(ns, lens))
             };
         }
+        #[allow(deprecated)] // allow because CMap2::new() will still be available inside the crate
         Ok(CMap2::new(self.n_darts))
     }
 }

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -86,6 +86,7 @@ macro_rules! setters {
 }
 
 // editing methods
+#[allow(deprecated)]
 impl<T: CoordsFloat> GridBuilder<T> {
     // n_cells
     setters!(n_cells, n_cells_x, n_cells_y, n_cells_z, 0, usize);
@@ -112,6 +113,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
 }
 
 // building methods
+#[allow(deprecated)]
 impl<T: CoordsFloat> GridBuilder<T> {
     #[allow(clippy::missing_errors_doc)]
     /// Consumes the builder and produce a [`CMap2`] object.
@@ -139,6 +141,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
 }
 
 // predefinite constructs
+#[allow(deprecated)]
 impl<T: CoordsFloat> GridBuilder<T> {
     /// Generate a predefined [`GridBuilder`] object.
     ///

--- a/honeycomb-core/src/utils/generation.rs
+++ b/honeycomb-core/src/utils/generation.rs
@@ -14,6 +14,12 @@ use crate::{BuilderError, CMap2, CMapBuilder, CoordsFloat};
 
 /// Builder structure for specialized [`CMap2`].
 ///
+/// <div class="warning">
+///
+/// This structure will be reneamed to [`GridDescriptor`] & have its `build2` removed.
+///
+/// </div>
+///
 /// The user must specify two out of these three characteristics:
 ///
 /// - `n_cells: [usize; 3]` - The number of cells per axis
@@ -26,24 +32,7 @@ use crate::{BuilderError, CMap2, CMapBuilder, CoordsFloat};
 /// # Generics
 ///
 /// - `T: CoordsFloat` -- Generic type of the future [`CMap2`] instance.
-///
-/// # Example
-///
-/// The following code generates a map that can be visualized by running the example
-/// `render_squaremap_parameterized`:
-///
-/// ```rust
-/// # fn main() {
-/// use honeycomb_core::{CMap2, utils::GridBuilder};
-///
-/// let map = GridBuilder::default()
-///     .n_cells([15, 5, 0])
-///     .len_per_cell_x(1.0_f64)
-///     .len_per_cell_y(3.0_f64)
-///     .build2();
-/// # }
-/// ```
-///
+#[deprecated(note = "please use `GridDescriptor` with `CMapBuilder::build` instead")]
 #[derive(Default, Clone)]
 pub struct GridBuilder<T: CoordsFloat> {
     pub(crate) n_cells: Option<[usize; 3]>,
@@ -143,7 +132,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
     /// # Example
     ///
     /// See [`GridBuilder`] example.
-    ///
+    #[deprecated]
     pub fn build2(self) -> Result<CMap2<T>, BuilderError> {
         CMapBuilder::from_grid_descriptor(self).build()
     }
@@ -191,6 +180,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
     /// - cells are ordered from left to right, from the bottom up. The same rule
     ///   applies for face IDs.
     ///
+    #[deprecated(note = "please use `CMapBuilder::unit_grid` instead")]
     #[must_use = "unused builder object, consider removing this function call"]
     pub fn unit_squares(n_square: usize) -> Self {
         Self {
@@ -227,6 +217,7 @@ impl<T: CoordsFloat> GridBuilder<T> {
     /// let cmap: CMap2<f64> = GridBuilder::split_unit_squares(2).build2().unwrap();
     /// ```
     ///
+    #[deprecated(note = "please use `CMapBuilder::unit_split_grid` instead")]
     #[must_use = "unused builder object, consider removing this function call"]
     pub fn split_unit_squares(n_square: usize) -> Self {
         Self {

--- a/honeycomb-core/src/utils/mod.rs
+++ b/honeycomb-core/src/utils/mod.rs
@@ -9,4 +9,5 @@ mod generation;
 
 // ------ PUBLIC RE-EXPORTS
 
+#[allow(deprecated)]
 pub use generation::GridBuilder;


### PR DESCRIPTION
Mark previous constructors as deprecated since `CMapBuilder` covers all of their features.

## Scope

- [x] Code: if relevant, add affected target

## Type of change

- [x] Refactor
