### PR TITLE
refactor!(core): change internal Vtk building routine to return a `Result`

### DIFF
--- a/honeycomb-core/src/cmapbuilder/grid/descriptor.rs
+++ b/honeycomb-core/src/cmapbuilder/grid/descriptor.rs
@@ -101,7 +101,7 @@ impl<T: CoordsFloat> GridDescriptor<T> {
 macro_rules! check_parameters {
     ($id: ident, $msg: expr) => {
         if $id.is_sign_negative() | $id.is_zero() {
-            return Err(BuilderError::InvalidParameters($msg));
+            return Err(BuilderError::InvalidGridParameters($msg));
         }
     };
 }
@@ -150,7 +150,7 @@ impl<T: CoordsFloat> GridDescriptor<T> {
                     [lpx, lpy],
                 ))
             }
-            (_, _, _) => Err(BuilderError::MissingParameters(
+            (_, _, _) => Err(BuilderError::MissingGridParameters(
                 "GridBuilder: insufficient building parameters",
             )),
         }

--- a/honeycomb-core/src/cmapbuilder/io/mod.rs
+++ b/honeycomb-core/src/cmapbuilder/io/mod.rs
@@ -6,7 +6,9 @@
 //! are supported, because of orientation and dimension restriction.
 
 // ------ IMPORTS
-use crate::{CMap2, CMapBuilder, CoordsFloat, DartIdentifier, Vertex2, VertexIdentifier};
+use crate::{
+    BuilderError, CMap2, CMapBuilder, CoordsFloat, DartIdentifier, Vertex2, VertexIdentifier,
+};
 use num::Zero;
 use std::collections::BTreeMap;
 use vtkio::model::{CellType, DataSet, VertexNumbers};
@@ -71,8 +73,10 @@ macro_rules! build_vertices {
 #[allow(clippy::too_many_lines)]
 /// Internal building routine for [`CMap2::from_vtk_file`].
 ///
-/// TODO: change return type to `Result` & propagate return up to the map builder methods.
-pub fn build_2d_from_vtk<T: CoordsFloat>(value: Vtk) -> CMap2<T> {
+/// # Result / Errors
+///
+/// todo: explain failure conditions
+pub fn build_2d_from_vtk<T: CoordsFloat>(value: Vtk) -> Result<CMap2<T>, BuilderError> {
     let mut cmap: CMap2<T> = CMap2::new(0);
     let mut sew_buffer: BTreeMap<(usize, usize), DartIdentifier> = BTreeMap::new();
     match value.data {
@@ -214,7 +218,7 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(value: Vtk) -> CMap2<T> {
         }
     }
 
-    cmap
+    Ok(cmap)
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/cmapbuilder/io/mod.rs
+++ b/honeycomb-core/src/cmapbuilder/io/mod.rs
@@ -56,10 +56,11 @@ impl<T: CoordsFloat> CMapBuilder<T> {
 
 macro_rules! build_vertices {
     ($v: ident) => {{
-        assert!(
-            ($v.len() % 3).is_zero(),
-            "failed to build vertices list - the point list contains an incomplete tuple"
-        );
+        if !($v.len() % 3).is_zero() {
+            return Err(BuilderError::InvalidVtkFile(
+                "failed to build vertices list - the point list contains an incomplete tuple",
+            ));
+        }
         $v.chunks_exact(3)
             .map(|slice| {
                 // WE IGNORE Z values
@@ -84,133 +85,140 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(value: Vtk) -> Result<CMap2<T>, Builder
         | DataSet::StructuredGrid { .. }
         | DataSet::RectilinearGrid { .. }
         | DataSet::PolyData { .. }
-        | DataSet::Field { .. } => {}
-        DataSet::UnstructuredGrid { pieces, .. } => pieces.iter().for_each(|piece| {
-            // assume inline data
-            let tmp = piece
-                .load_piece_data(None)
-                .expect("failed to load piece data");
+        | DataSet::Field { .. } => {
+            return Err(BuilderError::UnsupportedVtkData(
+                "dataset not supported - only UnstructuredGrid is currently supported",
+            ))
+        }
+        DataSet::UnstructuredGrid { pieces, .. } => {
+            let mut tmp = pieces.iter().map(|piece| {
+                // assume inline data
+                let tmp = piece
+                    .load_piece_data(None)
+                    .expect("failed to load piece data - is it not inlined?");
 
-            // build vertex list
-            // since we're expecting coordinates, we'll assume floating type
-            // we're also converting directly to our vertex type since we're building a 2-map
-            let vertices: Vec<Vertex2<T>> = match tmp.points {
-                IOBuffer::F64(v) => build_vertices!(v),
-                IOBuffer::F32(v) => build_vertices!(v),
-                _ => unimplemented!(),
-            };
+                // build vertex list
+                // since we're expecting coordinates, we'll assume floating type
+                // we're also converting directly to our vertex type since we're building a 2-map
+                let vertices: Vec<Vertex2<T>> = match tmp.points {
+                    IOBuffer::F64(v) => build_vertices!(v),
+                    IOBuffer::F32(v) => build_vertices!(v),
+                    _ => return Err(BuilderError::UnsupportedVtkData("unsupported coordinate representation type - please use float or double")),
+                };
 
-            let vtkio::model::Cells { cell_verts, types } = tmp.cells;
-            match cell_verts {
-                VertexNumbers::Legacy {
-                    num_cells,
-                    vertices: verts,
-                } => {
-                    // check basic stuff
-                    assert_eq!(
-                        num_cells as usize,
-                        types.len(),
-                        "failed to build cells - inconsistent number of cell between CELLS and CELL_TYPES"
-                    );
+                let vtkio::model::Cells { cell_verts, types } = tmp.cells;
+                match cell_verts {
+                    VertexNumbers::Legacy {
+                        num_cells,
+                        vertices: verts,
+                    } => {
+                        // check basic stuff
+                        if num_cells as usize != types.len() {
+                            return Err(BuilderError::InvalidVtkFile("failed to build cells - inconsistent number of cell between CELLS and CELL_TYPES"));
+                        }
 
-                    // build a collection of vertex lists corresponding of each cell
-                    let mut cell_components: Vec<Vec<usize>> = Vec::new();
-                    let mut take_next = 0;
-                    verts.iter().for_each(|vertex_id| if take_next.is_zero() {
-                        // making it usize since it's a counter
-                        take_next = *vertex_id as usize;
-                        cell_components.push(Vec::with_capacity(take_next));
-                    } else {
-                        cell_components.last_mut().unwrap().push(*vertex_id as usize);
-                        take_next -= 1;
-                    });
-                    assert_eq!(num_cells as usize, cell_components.len());
+                        // build a collection of vertex lists corresponding of each cell
+                        let mut cell_components: Vec<Vec<usize>> = Vec::new();
+                        let mut take_next = 0;
+                        verts.iter().for_each(|vertex_id| if take_next.is_zero() {
+                            // making it usize since it's a counter
+                            take_next = *vertex_id as usize;
+                            cell_components.push(Vec::with_capacity(take_next));
+                        } else {
+                            cell_components.last_mut().unwrap().push(*vertex_id as usize);
+                            take_next -= 1;
+                        });
+                        assert_eq!(num_cells as usize, cell_components.len());
 
-                    types.iter().zip(cell_components.iter()).for_each(|(cell_type, vids)| match cell_type {
-                        CellType::Vertex => {
-                            assert_eq!(vids.len(), 1, "failed to build cell - `Vertex` has {} instead of 1 vertex", vids.len());
-                            // silent ignore
+                        let mut errs = types.iter().zip(cell_components.iter()).map(|(cell_type, vids)| match cell_type {
+                            CellType::Vertex => {
+                                assert_eq!(vids.len(), 1, "failed to build cell - `Vertex` has {} instead of 1 vertex", vids.len());
+                                // silent ignore
+                                Ok(())
+                            }
+                            CellType::PolyVertex => Err(BuilderError::UnsupportedVtkData("failed to build cell - `PolyVertex` cell type is not supported because for consistency")),
+                            CellType::Line => {
+                                assert_eq!(vids.len(), 2, "failed to build cell - `Line` has {} instead of 2 vertices", vids.len());
+                                // silent ignore
+                                Ok(())
+                            }
+                            CellType::PolyLine => Err(BuilderError::UnsupportedVtkData("failed to build cell - `PolyLine` cell type is not supported because for consistency")),
+                            CellType::Triangle => {
+                                // check validity
+                                assert_eq!(vids.len(), 3, "failed to build cell - `Triangle` has {} instead of 3 vertices", vids.len());
+                                // build the triangle
+                                let d0 = cmap.add_free_darts(3);
+                                let (d1, d2) = (d0 + 1, d0 + 2);
+                                cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
+                                cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
+                                cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
+                                cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
+                                cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
+                                cmap.one_link(d2, d0); // edge d2 links vertices vids[2] & vids[0]
+                                // record a trace of the built cell for future 2-sew
+                                sew_buffer.insert((vids[0], vids[1]), d0);
+                                sew_buffer.insert((vids[1], vids[2]), d1);
+                                sew_buffer.insert((vids[2], vids[0]), d2);
+                                Ok(())
+                            }
+                            CellType::TriangleStrip => Err(BuilderError::UnsupportedVtkData("failed to build cell - `TriangleStrip` cell type is not supported because of orientation requirements")),
+                            CellType::Polygon => {
+                                // FIXME: NOT TESTED
+                                // operation order should still work, but it would be nice to have
+                                // an heterogeneous mesh to test on
+                                let n_vertices = vids.len();
+                                let d0 = cmap.add_free_darts(n_vertices);
+                                (0..n_vertices).for_each(|i| {
+                                    let di = d0 + i as DartIdentifier;
+                                    let dip1 = if i == n_vertices - 1 {
+                                        d0
+                                    } else {
+                                        di + 1
+                                    };
+                                    cmap.insert_vertex(di as VertexIdentifier, vertices[vids[i]]);
+                                    cmap.one_link(di, dip1);
+                                    sew_buffer.insert((vids[i], vids[(i + 1) % n_vertices]), di);
+                                });
+                                Ok(())
+                            }
+                            CellType::Pixel => Err(BuilderError::UnsupportedVtkData("failed to build cell - `Pixel` cell type is not supported because of orientation requirements")),
+                            CellType::Quad => {
+                                assert_eq!(vids.len(), 4, "failed to build cell - `Quad` has {} instead of 4 vertices", vids.len());
+                                // build the quad
+                                let d0 = cmap.add_free_darts(4);
+                                let (d1, d2, d3) = (d0 + 1, d0 + 2, d0 + 3);
+                                cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
+                                cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
+                                cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
+                                cmap.insert_vertex(d3 as VertexIdentifier, vertices[vids[3]]);
+                                cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
+                                cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
+                                cmap.one_link(d2, d3); // edge d2 links vertices vids[2] & vids[3]
+                                cmap.one_link(d3, d0); // edge d3 links vertices vids[3] & vids[0]
+                                // record a trace of the built cell for future 2-sew
+                                sew_buffer.insert((vids[0], vids[1]), d0);
+                                sew_buffer.insert((vids[1], vids[2]), d1);
+                                sew_buffer.insert((vids[2], vids[3]), d2);
+                                sew_buffer.insert((vids[3], vids[0]), d3);
+                                Ok(())
+                            }
+                            _ => Err(BuilderError::UnsupportedVtkData("failed to build cell - found a CellType that is not supported in 2-maps")),
+                        });
+                        if let Some(is_err) = errs.find(std::result::Result::is_err) {
+                            return Err(is_err.unwrap_err()); // unwrap & wrap because type inference is clunky
                         }
-                        CellType::PolyVertex => unimplemented!(
-                            "failed to build cell - `PolyVertex` cell type is not supported because for consistency"
-                        ),
-                        CellType::Line => {
-                            assert_eq!(vids.len(), 2, "failed to build cell - `Line` has {} instead of 2 vertices", vids.len());
-                            // silent ignore
-                        }
-                        CellType::PolyLine => unimplemented!(
-                            "failed to build cell - `PolyLine` cell type is not supported because for consistency"
-                        ),
-                        CellType::Triangle => {
-                            // check validity
-                            assert_eq!(vids.len(), 3, "failed to build cell - `Triangle` has {} instead of 3 vertices", vids.len());
-                            // build the triangle
-                            let d0 = cmap.add_free_darts(3);
-                            let (d1, d2) = (d0+1, d0+2);
-                            cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
-                            cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
-                            cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
-                            cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                            cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                            cmap.one_link(d2, d0); // edge d2 links vertices vids[2] & vids[0]
-                            // record a trace of the built cell for future 2-sew
-                            sew_buffer.insert((vids[0], vids[1]), d0);
-                            sew_buffer.insert((vids[1], vids[2]), d1);
-                            sew_buffer.insert((vids[2], vids[0]), d2);
-                        }
-                        CellType::TriangleStrip => unimplemented!(
-                            "failed to build cell - `TriangleStrip` cell type is not supported because of orientation requirements"
-                        ),
-                        CellType::Polygon => {
-                            // FIXME: NOT TESTED
-                            // operation order should still work, but it would be nice to have
-                            // an heterogeneous mesh to test on
-                            let n_vertices = vids.len();
-                            let d0 = cmap.add_free_darts(n_vertices);
-                            (0..n_vertices ).for_each(|i| {
-                                let di = d0 + i as DartIdentifier;
-                                let dip1 = if i==n_vertices-1 {
-                                    d0
-                                } else {
-                                    di +1
-                                };
-                                cmap.insert_vertex(di as VertexIdentifier, vertices[vids[i]]);
-                                cmap.one_link(di, dip1);
-                                sew_buffer.insert((vids[i], vids[(i + 1) % n_vertices]), di);
-                            });
-                        }
-                        CellType::Pixel => unimplemented!(
-                            "failed to build cell - `Pixel` cell type is not supported because of orientation requirements"
-                        ),
-                        CellType::Quad => {
-                            assert_eq!(vids.len(), 4,  "failed to build cell - `Quad` has {} instead of 4 vertices", vids.len());
-                            // build the quad
-                            let d0 = cmap.add_free_darts(4);
-                            let (d1, d2, d3) = (d0+1, d0+2, d0+3);
-                            cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
-                            cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
-                            cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
-                            cmap.insert_vertex(d3 as VertexIdentifier, vertices[vids[3]]);
-                            cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                            cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                            cmap.one_link(d2, d3); // edge d2 links vertices vids[2] & vids[3]
-                            cmap.one_link(d3, d0); // edge d3 links vertices vids[3] & vids[0]
-                            // record a trace of the built cell for future 2-sew
-                            sew_buffer.insert((vids[0], vids[1]), d0);
-                            sew_buffer.insert((vids[1], vids[2]), d1);
-                            sew_buffer.insert((vids[2], vids[3]), d2);
-                            sew_buffer.insert((vids[3], vids[0]), d3);
-                        }
-                        c => unimplemented!(
-                            "failed to build cell - {c:#?} is not supported in 2-maps"
-                        ),
-                    });
+                    }
+                    VertexNumbers::XML { .. } => {
+                        return Err(BuilderError::UnsupportedVtkData("XML Vtk files are not supported"));
+                    }
                 }
-                VertexNumbers::XML { .. } => {
-                    unimplemented!("XML file format is not currently supported")
-                }
+                Ok(())
+            });
+            // return the first error if there is one
+            if let Some(is_err) = tmp.find(std::result::Result::is_err) {
+                return Err(is_err.unwrap_err()); // unwrap & wrap because type inference is clunky
             }
-        }),
+        }
     }
     while let Some(((id0, id1), dart_id0)) = sew_buffer.pop_first() {
         if let Some(dart_id1) = sew_buffer.remove(&(id1, id0)) {

--- a/honeycomb-core/src/cmapbuilder/structure.rs
+++ b/honeycomb-core/src/cmapbuilder/structure.rs
@@ -22,11 +22,18 @@ use vtkio::Vtk;
 /// structure.
 #[derive(Debug)]
 pub enum BuilderError {
-    /// The builder is missing one or multiple parameters in order to proceed with the requested
-    /// operation.
-    MissingParameters(&'static str),
-    /// One or multiple of the builder's fields are invalid.
-    InvalidParameters(&'static str),
+    // grid-related variants
+    /// One or multiple of the specified grid characteristics are invalid.
+    InvalidGridParameters(&'static str),
+    /// The builder is missing one or multiple parameters to generate the grid.
+    MissingGridParameters(&'static str),
+    // vtk-related variants
+    /// Specified VTK file contains inconsistent data.
+    InvalidVtkFile(&'static str),
+    /// Specified VTK file could not be found.
+    MissingVtkFile(&'static str),
+    /// Specified VTK file contains unsupported data.
+    UnsupportedVtkData(&'static str),
 }
 
 // --- main struct

--- a/honeycomb-core/src/cmapbuilder/structure.rs
+++ b/honeycomb-core/src/cmapbuilder/structure.rs
@@ -102,7 +102,7 @@ impl<T: CoordsFloat> CMapBuilder<T> {
         if let Some(vfile) = self.vtk_file {
             // build from vtk
             // this routine should return a Result instead of the map directly
-            return Ok(super::io::build_2d_from_vtk(vfile));
+            return super::io::build_2d_from_vtk(vfile);
         }
         #[cfg(feature = "utils")]
         if let Some(gridb) = self.grid_descriptor {


### PR DESCRIPTION
- `build_2d_from_vtk` now return a `Result<CMap2, BuilderError>`
- a number the function's assertions are replaced with early `Err` returns
- `BuilderError` has been expanded with more (specialized) variants

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] Refactor

## Other

- [x] Breaking change: because of new `BuilderError` variants (& renamed old ones)
