### PR TITLE
feat!(core): add `UnknownAttributeStorage` trait for attribute-agnostic methods

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -6,7 +6,7 @@
 // ------ IMPORTS
 
 use crate::attributes::traits::AttributeStorage;
-use crate::{AttributeBind, AttributeUpdate, UnknownAttributeStorage};
+use crate::{AttributeBind, AttributeUpdate, DartIdentifier, UnknownAttributeStorage};
 use num::ToPrimitive;
 
 // ------ CONTENT
@@ -51,6 +51,24 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
 
     fn n_attributes(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count()
+    }
+
+    fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier) {
+        let new_val = match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
+            (Some(v1), Some(v2)) => AttributeUpdate::merge(v1, v2),
+            (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_undefined(Some(v)),
+            (None, None) => AttributeUpdate::merge_undefined(None),
+        };
+        self.set(out.into(), new_val);
+    }
+
+    fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
+        let new_val = self
+            .remove(inp.into())
+            .expect("E: cannot split attribute value - value not found in storage");
+        let (lhs_val, rhs_val) = AttributeUpdate::split(new_val);
+        self.set(lhs_out.into(), lhs_val);
+        self.set(rhs_out.into(), rhs_val);
     }
 }
 
@@ -151,6 +169,24 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
 
     fn n_attributes(&self) -> usize {
         self.data.len() - self.unused_data_slots.len()
+    }
+
+    fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier) {
+        let new_val = match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
+            (Some(v1), Some(v2)) => AttributeUpdate::merge(v1, v2),
+            (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_undefined(Some(v)),
+            (None, None) => AttributeUpdate::merge_undefined(None),
+        };
+        self.set(out.into(), new_val);
+    }
+
+    fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
+        let new_val = self
+            .remove(inp.into())
+            .expect("E: cannot split attribute value - value not found in storage");
+        let (lhs_val, rhs_val) = AttributeUpdate::split(new_val);
+        self.set(lhs_out.into(), lhs_val);
+        self.set(rhs_out.into(), rhs_val);
     }
 }
 

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -6,7 +6,7 @@
 // ------ IMPORTS
 
 use crate::attributes::traits::AttributeStorage;
-use crate::{AttributeBind, AttributeUpdate};
+use crate::{AttributeBind, AttributeUpdate, UnknownAttributeStorage};
 use num::ToPrimitive;
 
 // ------ CONTENT
@@ -35,7 +35,7 @@ pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
     data: Vec<Option<T>>,
 }
 
-impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrSparseVec<A> {
+impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for AttrSparseVec<A> {
     fn new(length: usize) -> Self
     where
         Self: Sized,
@@ -52,7 +52,9 @@ impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrSpar
     fn n_attributes(&self) -> usize {
         self.data.iter().filter(|val| val.is_some()).count()
     }
+}
 
+impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrSparseVec<A> {
     fn set(&mut self, id: A::IdentifierType, val: A) {
         self.data[id.to_usize().unwrap()] = Some(val);
     }
@@ -131,7 +133,7 @@ pub struct AttrCompactVec<A: AttributeBind + AttributeUpdate + Clone> {
     data: Vec<A>,
 }
 
-impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrCompactVec<A> {
+impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for AttrCompactVec<A> {
     fn new(length: usize) -> Self
     where
         Self: Sized,
@@ -150,7 +152,9 @@ impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrComp
     fn n_attributes(&self) -> usize {
         self.data.len() - self.unused_data_slots.len()
     }
+}
 
+impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrCompactVec<A> {
     fn set(&mut self, id: A::IdentifierType, val: A) {
         if let Some(idx) = self.index_map[id.to_usize().unwrap()] {
             // internal index is defined => there should be associated data

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -46,7 +46,7 @@ pub enum ManagerError {
 /// ```
 /// # use std::any::{Any, TypeId};
 /// # use std::collections::HashMap;
-/// # use honeycomb_core::{AttributeBind, AttributeStorage};
+/// # use honeycomb_core::{AttributeBind, AttributeStorage, UnknownAttributeStorage};
 /// pub struct Manager {
 ///     inner: HashMap<TypeId, Box<dyn Any>>,
 /// }

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORTS
 
-use crate::{AttributeBind, AttributeStorage, OrbitPolicy};
+use crate::{AttributeBind, AttributeStorage, OrbitPolicy, UnknownAttributeStorage};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -1,6 +1,9 @@
 // ------ IMPORTS
 
-use crate::{AttrCompactVec, AttrSparseVec, AttributeBind, AttributeStorage, AttributeUpdate};
+use crate::{
+    AttrCompactVec, AttrSparseVec, AttributeBind, AttributeStorage, AttributeUpdate,
+    UnknownAttributeStorage,
+};
 use std::any::Any;
 
 // ------ CONTENT

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -128,6 +128,15 @@ pub trait AttributeBind: Debug + Sized + Any {
 
 /// Common trait implemented by generic attribute storages.
 ///
+/// This trait contain attribute-agnostic function & methods.
+///
+/// The documentation of this trait describe the behavior each function & method should have.
+pub trait UnknownAttributeStorage: Debug + Any {}
+
+/// Common trait implemented by generic attribute storages.
+///
+/// This trait contain attribute-specific methods.
+///
 /// The documentation of this trait describe the behavior each function & method should have.
 pub trait AttributeStorage<A: AttributeBind>: Debug + Any {
     /// Constructor

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -5,7 +5,7 @@
 
 // ------ IMPORTS
 
-use crate::OrbitPolicy;
+use crate::{DartIdentifier, OrbitPolicy};
 use std::any::Any;
 use std::fmt::Debug;
 
@@ -159,6 +159,56 @@ pub trait UnknownAttributeStorage: Debug + Any {
     /// its length.
     #[must_use = "returned value is not used, consider removing this method call"]
     fn n_attributes(&self) -> usize;
+
+    /// Merge attributes at specified index
+    ///
+    /// This method should serve as a wire to `AttributeUpdate::merge`, essentially doing
+    /// the following:
+    ///
+    /// ```text
+    /// attributes[out] = AttributeUpdate::merge(attributes[lhs_inp], attributes[rhs_inp]);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `out: DartIdentifier` -- Identifier to associate the result with.
+    /// - `lhs_inp: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `rhs_inp: DartIdentifier` -- Identifier of the other attribute value to merge.
+    fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier);
+
+    /// Merge attributes at specified index
+    ///
+    /// This method should serve as a wire to `AttributeUpdate::merge_undefined`, essentially doing
+    /// the following:
+    ///
+    /// ```text
+    /// attr_in = attributes.get(id);
+    /// attributes[out] = AttributeUpdate::merge_undefined(attr_in);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `out: DartIdentifier` -- Identifier to associate the result with.
+    /// - `inp: DartIdentifier` -- Identifier of one (potential) attribute value to merge from.
+    fn merge_undefined(&mut self, out: DartIdentifier, inp: DartIdentifier);
+
+    /// Split attribute to specified indices
+    ///
+    /// This method should serve as a wire to `AttributeUpdate::split`, essentially doing
+    /// the following:
+    ///
+    /// ```text
+    /// (val_lhs, val_rhs) = AttributeUpdate::split(attributes[inp]);
+    /// attributes[lhs_out] = val_lhs;
+    /// attributes[rhs_out] = val_rhs;
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_out: DartIdentifier` -- Identifier to associate the result with.
+    /// - `rhs_out: DartIdentifier` -- Identifier to associate the result with.
+    /// - `inp: DartIdentifier` -- Identifier of the attribute value to split.
+    fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier);
 }
 
 /// Common trait implemented by generic attribute storages.

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -119,7 +119,7 @@ pub trait AttributeBind: Debug + Sized + Any {
     type StorageType: AttributeStorage<Self>;
 
     /// Identifier type of the entity the attribute is bound to.
-    type IdentifierType: num::ToPrimitive + Clone;
+    type IdentifierType: From<DartIdentifier> + num::ToPrimitive + Clone;
 
     /// Return an [`OrbitPolicy`] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -162,52 +162,46 @@ pub trait UnknownAttributeStorage: Debug + Any {
 
     /// Merge attributes at specified index
     ///
-    /// This method should serve as a wire to `AttributeUpdate::merge`, essentially doing
-    /// the following:
-    ///
-    /// ```text
-    /// attributes[out] = AttributeUpdate::merge(attributes[lhs_inp], attributes[rhs_inp]);
-    /// ```
+    /// This method should serve as a wire to either `AttributeUpdate::merge`
+    /// or `AttributeUpdate::merge_undefined` after removing the values we wish to merge from
+    /// the storage.
     ///
     /// # Arguments
     ///
     /// - `out: DartIdentifier` -- Identifier to associate the result with.
     /// - `lhs_inp: DartIdentifier` -- Identifier of one attribute value to merge.
     /// - `rhs_inp: DartIdentifier` -- Identifier of the other attribute value to merge.
-    fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier);
-
-    /// Merge attributes at specified index
     ///
-    /// This method should serve as a wire to `AttributeUpdate::merge_undefined`, essentially doing
-    /// the following:
+    /// # Behavior pseudo-code
     ///
     /// ```text
-    /// attr_in = attributes.get(id);
-    /// attributes[out] = AttributeUpdate::merge_undefined(attr_in);
+    /// let new_val = match (attributes.remove(lhs_inp), attributes.remove(rhs_inp)) {
+    ///     (Some(v1), Some(v2)) => AttributeUpdate::merge(v1, v2),
+    ///     (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_undefined(Some(v)),
+    ///     None, None => AttributeUpdate::merge_undefined(None),
+    /// }
+    /// attributes.set(out, new_val);
     /// ```
-    ///
-    /// # Arguments
-    ///
-    /// - `out: DartIdentifier` -- Identifier to associate the result with.
-    /// - `inp: DartIdentifier` -- Identifier of one (potential) attribute value to merge from.
-    fn merge_undefined(&mut self, out: DartIdentifier, inp: DartIdentifier);
+    fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier);
 
     /// Split attribute to specified indices
     ///
-    /// This method should serve as a wire to `AttributeUpdate::split`, essentially doing
-    /// the following:
-    ///
-    /// ```text
-    /// (val_lhs, val_rhs) = AttributeUpdate::split(attributes[inp]);
-    /// attributes[lhs_out] = val_lhs;
-    /// attributes[rhs_out] = val_rhs;
-    /// ```
+    /// This method should serve as a wire to `AttributeUpdate::split` after removing the value
+    /// we want to split from the storage.
     ///
     /// # Arguments
     ///
     /// - `lhs_out: DartIdentifier` -- Identifier to associate the result with.
     /// - `rhs_out: DartIdentifier` -- Identifier to associate the result with.
     /// - `inp: DartIdentifier` -- Identifier of the attribute value to split.
+    ///
+    /// # Behavior pseudo-code
+    ///
+    /// ```text
+    /// (val_lhs, val_rhs) = AttributeUpdate::split(attributes.remove(inp).unwrap());
+    /// attributes[lhs_out] = val_lhs;
+    /// attributes[rhs_out] = val_rhs;
+    /// ```
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier);
 }
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -131,14 +131,7 @@ pub trait AttributeBind: Debug + Sized + Any {
 /// This trait contain attribute-agnostic function & methods.
 ///
 /// The documentation of this trait describe the behavior each function & method should have.
-pub trait UnknownAttributeStorage: Debug + Any {}
-
-/// Common trait implemented by generic attribute storages.
-///
-/// This trait contain attribute-specific methods.
-///
-/// The documentation of this trait describe the behavior each function & method should have.
-pub trait AttributeStorage<A: AttributeBind>: Debug + Any {
+pub trait UnknownAttributeStorage: Debug + Any {
     /// Constructor
     ///
     /// # Arguments
@@ -166,7 +159,14 @@ pub trait AttributeStorage<A: AttributeBind>: Debug + Any {
     /// its length.
     #[must_use = "returned value is not used, consider removing this method call"]
     fn n_attributes(&self) -> usize;
+}
 
+/// Common trait implemented by generic attribute storages.
+///
+/// This trait contain attribute-specific methods.
+///
+/// The documentation of this trait describe the behavior each function & method should have.
+pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// Setter
     ///
     /// Set the value of an element at a given index. This operation is not affected by the initial

--- a/honeycomb-core/src/cmap2/basic_ops.rs
+++ b/honeycomb-core/src/cmap2/basic_ops.rs
@@ -11,9 +11,9 @@
 
 use super::CMAP2_BETA;
 use crate::{
-    AttributeStorage, CMap2, CoordsFloat, DartIdentifier, EdgeCollection, EdgeIdentifier,
-    FaceCollection, FaceIdentifier, Orbit2, OrbitPolicy, VertexCollection, VertexIdentifier,
-    NULL_DART_ID,
+    CMap2, CoordsFloat, DartIdentifier, EdgeCollection, EdgeIdentifier, FaceCollection,
+    FaceIdentifier, Orbit2, OrbitPolicy, UnknownAttributeStorage, VertexCollection,
+    VertexIdentifier, NULL_DART_ID,
 };
 use std::collections::BTreeSet;
 

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -6,7 +6,10 @@
 
 // ------ IMPORT
 
-use crate::{AttributeStorage, CMap2, CMapError, CoordsFloat, Vertex2, VertexIdentifier};
+use crate::{
+    AttributeStorage, CMap2, CMapError, CoordsFloat, UnknownAttributeStorage, Vertex2,
+    VertexIdentifier,
+};
 
 // ------ CONTENT
 

--- a/honeycomb-core/src/cmap2/structure.rs
+++ b/honeycomb-core/src/cmap2/structure.rs
@@ -9,7 +9,7 @@
 use crate::{CMapBuilder, NULL_DART_ID};
 
 use super::CMAP2_BETA;
-use crate::{AttrSparseVec, AttributeStorage, CoordsFloat, DartIdentifier, Vertex2};
+use crate::{AttrSparseVec, CoordsFloat, DartIdentifier, UnknownAttributeStorage, Vertex2};
 use std::collections::BTreeSet;
 
 // ------ CONTENT

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -46,7 +46,7 @@ mod spatial_repr;
 pub use attributes::{
     collections::{AttrCompactVec, AttrSparseVec},
     manager::{AttrStorageManager, ManagerError},
-    traits::{AttributeBind, AttributeStorage, AttributeUpdate},
+    traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage},
 };
 pub use cells::{
     collections::{


### PR DESCRIPTION
- new trait `UnknownAttributeStorage` which is attribute-agnostic, i.e. isn't defined using `A: AttributeBind`
- move some members of `AttributeStorage` to the new trait
- add index-based `merge` and `split` routines to the new trait in order to process those operations without downcasting the entire storage object

## Scope

- [x] Code

## Type of change

- [x] New feature(s)

## Other

- [x] Breaking change: moved some methods from `AttributeStorage`, add a `From<DartIdentifier>` bound to `AttributeBind::IdentifierType`

## Necessary follow-up

- [x] Needs testing
