### PR TITLE
replace `Any` by `UnknownAttributeStorage` to handle collections in attribute manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ cfg-if = "1"
 rustversion = "1.0.15"
 
 # core
+downcast-rs = "1.2.1"
 num = "0.4.2"
 vtkio = { version = "0.6.3" }
 

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -20,6 +20,7 @@ utils = []
 
 [dependencies]
 cfg-if.workspace = true
+downcast-rs.workspace = true
 num.workspace = true
 vtkio = { workspace = true, optional = true }
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -106,6 +106,8 @@ impl AttrStorageManager {
         }
     }
 
+    // merges
+
     pub fn merge_attributes(
         &mut self,
         orbit_policy: OrbitPolicy,
@@ -152,11 +154,64 @@ impl AttrStorageManager {
 
     pub fn merge_other_attributes(
         &mut self,
+        orbit_policy: OrbitPolicy,
         id_out: DartIdentifier,
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
     ) {
         todo!()
+    }
+
+    // splits
+
+    pub fn split_attributes(
+        &mut self,
+        orbit_policy: OrbitPolicy,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    pub fn split_vertex_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    pub fn split_edge_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    pub fn split_face_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    pub fn split_other_attributes(
+        &mut self,
+        orbit_policy: OrbitPolicy,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+        match orbit_policy {
+            OrbitPolicy::Vertex => self.split_vertex_attributes(id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Edge => self.split_edge_attributes(id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Face => self.split_face_attributes(id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Custom(_) => {
+                todo!("custom orbit binding is a special case that will be treated later")
+            }
+        }
     }
 }
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -108,6 +108,15 @@ impl AttrStorageManager {
 
     // merges
 
+    /// Execute a merging operation on all attributes associated with a given orbit
+    /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_attributes(
         &mut self,
         orbit_policy: OrbitPolicy,
@@ -120,11 +129,18 @@ impl AttrStorageManager {
             OrbitPolicy::Edge => self.merge_edge_attributes(id_out, id_in_lhs, id_in_rhs),
             OrbitPolicy::Face => self.merge_face_attributes(id_out, id_in_lhs, id_in_rhs),
             OrbitPolicy::Custom(_) => {
-                todo!("custom orbit binding is a special case that will be treated later")
+                self.merge_other_attributes(orbit_policy, id_out, id_in_lhs, id_in_rhs);
             }
         }
     }
 
+    /// Execute a merging operation on all attributes associated with vertices for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_vertex_attributes(
         &mut self,
         id_out: DartIdentifier,
@@ -134,6 +150,13 @@ impl AttrStorageManager {
         todo!()
     }
 
+    /// Execute a merging operation on all attributes associated with edges for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_edge_attributes(
         &mut self,
         id_out: DartIdentifier,
@@ -143,6 +166,13 @@ impl AttrStorageManager {
         todo!()
     }
 
+    /// Execute a merging operation on all attributes associated with faces for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_face_attributes(
         &mut self,
         id_out: DartIdentifier,
@@ -152,6 +182,15 @@ impl AttrStorageManager {
         todo!()
     }
 
+    /// Execute a merging operation on all attributes associated with a given orbit
+    /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_other_attributes(
         &mut self,
         orbit_policy: OrbitPolicy,
@@ -159,45 +198,21 @@ impl AttrStorageManager {
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
     ) {
-        todo!()
+        todo!("custom orbit binding is a special case that will be treated later")
     }
 
     // splits
 
+    /// Execute a splitting operation on all attributes associated with a given orbit
+    /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     pub fn split_attributes(
-        &mut self,
-        orbit_policy: OrbitPolicy,
-        id_out_lhs: DartIdentifier,
-        id_out_rhs: DartIdentifier,
-        id_in: DartIdentifier,
-    ) {
-    }
-
-    pub fn split_vertex_attributes(
-        &mut self,
-        id_out_lhs: DartIdentifier,
-        id_out_rhs: DartIdentifier,
-        id_in: DartIdentifier,
-    ) {
-    }
-
-    pub fn split_edge_attributes(
-        &mut self,
-        id_out_lhs: DartIdentifier,
-        id_out_rhs: DartIdentifier,
-        id_in: DartIdentifier,
-    ) {
-    }
-
-    pub fn split_face_attributes(
-        &mut self,
-        id_out_lhs: DartIdentifier,
-        id_out_rhs: DartIdentifier,
-        id_in: DartIdentifier,
-    ) {
-    }
-
-    pub fn split_other_attributes(
         &mut self,
         orbit_policy: OrbitPolicy,
         id_out_lhs: DartIdentifier,
@@ -209,9 +224,77 @@ impl AttrStorageManager {
             OrbitPolicy::Edge => self.split_edge_attributes(id_out_lhs, id_out_rhs, id_in),
             OrbitPolicy::Face => self.split_face_attributes(id_out_lhs, id_out_rhs, id_in),
             OrbitPolicy::Custom(_) => {
-                todo!("custom orbit binding is a special case that will be treated later")
+                self.split_other_attributes(orbit_policy, id_out_lhs, id_out_rhs, id_in);
             }
         }
+    }
+
+    /// Execute a splitting operation on all attributes associated with vertices
+    /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    pub fn split_vertex_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    /// Execute a splitting operation on all attributes associated with edges for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    pub fn split_edge_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    /// Execute a splitting operation on all attributes associated with faces for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    pub fn split_face_attributes(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+    }
+
+    /// Execute a splitting operation on all attributes associated with a given orbit
+    /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    pub fn split_other_attributes(
+        &mut self,
+        orbit_policy: OrbitPolicy,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+        todo!("custom orbit binding is a special case that will be treated later")
     }
 }
 
@@ -457,6 +540,13 @@ impl AttrStorageManager {
         storage.remove(id)
     }
 
+    /// Merge given attribute values.
+    ///
+    /// # Arguments
+    ///
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_attribute<A: AttributeBind>(
         &mut self,
         id_out: DartIdentifier,
@@ -467,6 +557,13 @@ impl AttrStorageManager {
         storage.merge(id_out, id_in_lhs, id_in_rhs);
     }
 
+    /// Split given attribute value.
+    ///
+    /// # Arguments
+    ///
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     pub fn split_attribute<A: AttributeBind>(
         &mut self,
         id_out_lhs: DartIdentifier,

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -1,8 +1,7 @@
-//! Module short description
+//! attribute super structure code
 //!
-//! Should you interact with this module directly?
-//!
-//! Content description if needed
+//! this module contains all code used to implement a manager struct, used to handle generic
+//! attributes embedded in a given combinatorial map.
 
 // ------ IMPORTS
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -7,7 +7,7 @@
 // ------ IMPORTS
 
 use crate::{AttributeBind, AttributeStorage, OrbitPolicy, UnknownAttributeStorage};
-use std::any::{Any, TypeId};
+use std::any::TypeId;
 use std::collections::HashMap;
 
 // ------ CONTENT
@@ -72,13 +72,13 @@ pub enum ManagerError {
 #[derive(Default)]
 pub struct AttrStorageManager {
     /// Vertex attributes' storages.
-    vertices: HashMap<TypeId, Box<dyn Any>>,
+    vertices: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>,
     /// Edge attributes' storages.
-    edges: HashMap<TypeId, Box<dyn Any>>,
+    edges: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>,
     /// Face attributes' storages.
-    faces: HashMap<TypeId, Box<dyn Any>>,
+    faces: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>,
     /// Other storages.
-    others: HashMap<TypeId, Box<dyn Any>>, // Orbit::Custom
+    others: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>, // Orbit::Custom
 }
 
 macro_rules! get_storage {

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -95,6 +95,15 @@ impl AttrStorageManager {
         for storage in self.vertices.values_mut() {
             storage.extend(length);
         }
+        for storage in self.edges.values_mut() {
+            storage.extend(length);
+        }
+        for storage in self.faces.values_mut() {
+            storage.extend(length);
+        }
+        for storage in self.others.values_mut() {
+            storage.extend(length);
+        }
     }
 
     pub fn merge_attributes(

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -96,6 +96,59 @@ impl AttrStorageManager {
             storage.extend(length);
         }
     }
+
+    pub fn merge_attributes(
+        &mut self,
+        orbit_policy: OrbitPolicy,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        match orbit_policy {
+            OrbitPolicy::Vertex => self.merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Edge => self.merge_edge_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Face => self.merge_face_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Custom(_) => {
+                todo!("custom orbit binding is a special case that will be treated later")
+            }
+        }
+    }
+
+    pub fn merge_vertex_attributes(
+        &mut self,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        todo!()
+    }
+
+    pub fn merge_edge_attributes(
+        &mut self,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        todo!()
+    }
+
+    pub fn merge_face_attributes(
+        &mut self,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        todo!()
+    }
+
+    pub fn merge_other_attributes(
+        &mut self,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        todo!()
+    }
 }
 
 // --- attribute-specific methods

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -119,7 +119,7 @@ impl AttrStorageManager {
     /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_attributes(
         &mut self,
-        orbit_policy: OrbitPolicy,
+        orbit_policy: &OrbitPolicy,
         id_out: DartIdentifier,
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
@@ -147,7 +147,9 @@ impl AttrStorageManager {
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
     ) {
-        todo!()
+        for storage in self.vertices.values_mut() {
+            storage.merge(id_out, id_in_lhs, id_in_rhs);
+        }
     }
 
     /// Execute a merging operation on all attributes associated with edges for specified cells.
@@ -163,7 +165,9 @@ impl AttrStorageManager {
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
     ) {
-        todo!()
+        for storage in self.edges.values_mut() {
+            storage.merge(id_out, id_in_lhs, id_in_rhs);
+        }
     }
 
     /// Execute a merging operation on all attributes associated with faces for specified cells.
@@ -179,7 +183,9 @@ impl AttrStorageManager {
         id_in_lhs: DartIdentifier,
         id_in_rhs: DartIdentifier,
     ) {
-        todo!()
+        for storage in self.faces.values_mut() {
+            storage.merge(id_out, id_in_lhs, id_in_rhs);
+        }
     }
 
     /// Execute a merging operation on all attributes associated with a given orbit
@@ -193,10 +199,10 @@ impl AttrStorageManager {
     /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     pub fn merge_other_attributes(
         &mut self,
-        orbit_policy: OrbitPolicy,
-        id_out: DartIdentifier,
-        id_in_lhs: DartIdentifier,
-        id_in_rhs: DartIdentifier,
+        _orbit_policy: &OrbitPolicy,
+        _id_out: DartIdentifier,
+        _id_in_lhs: DartIdentifier,
+        _id_in_rhs: DartIdentifier,
     ) {
         todo!("custom orbit binding is a special case that will be treated later")
     }
@@ -214,7 +220,7 @@ impl AttrStorageManager {
     /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     pub fn split_attributes(
         &mut self,
-        orbit_policy: OrbitPolicy,
+        orbit_policy: &OrbitPolicy,
         id_out_lhs: DartIdentifier,
         id_out_rhs: DartIdentifier,
         id_in: DartIdentifier,
@@ -244,6 +250,9 @@ impl AttrStorageManager {
         id_out_rhs: DartIdentifier,
         id_in: DartIdentifier,
     ) {
+        for storage in self.vertices.values_mut() {
+            storage.split(id_out_lhs, id_out_rhs, id_in);
+        }
     }
 
     /// Execute a splitting operation on all attributes associated with edges for specified cells.
@@ -260,6 +269,9 @@ impl AttrStorageManager {
         id_out_rhs: DartIdentifier,
         id_in: DartIdentifier,
     ) {
+        for storage in self.edges.values_mut() {
+            storage.split(id_out_lhs, id_out_rhs, id_in);
+        }
     }
 
     /// Execute a splitting operation on all attributes associated with faces for specified cells.
@@ -276,6 +288,9 @@ impl AttrStorageManager {
         id_out_rhs: DartIdentifier,
         id_in: DartIdentifier,
     ) {
+        for storage in self.faces.values_mut() {
+            storage.split(id_out_lhs, id_out_rhs, id_in);
+        }
     }
 
     /// Execute a splitting operation on all attributes associated with a given orbit
@@ -289,10 +304,10 @@ impl AttrStorageManager {
     /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     pub fn split_other_attributes(
         &mut self,
-        orbit_policy: OrbitPolicy,
-        id_out_lhs: DartIdentifier,
-        id_out_rhs: DartIdentifier,
-        id_in: DartIdentifier,
+        _orbit_policy: &OrbitPolicy,
+        _id_out_lhs: DartIdentifier,
+        _id_out_rhs: DartIdentifier,
+        _id_in: DartIdentifier,
     ) {
         todo!("custom orbit binding is a special case that will be treated later")
     }

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -6,7 +6,9 @@
 
 // ------ IMPORTS
 
-use crate::{AttributeBind, AttributeStorage, OrbitPolicy, UnknownAttributeStorage};
+use crate::{
+    AttributeBind, AttributeStorage, DartIdentifier, OrbitPolicy, UnknownAttributeStorage,
+};
 use std::any::TypeId;
 use std::collections::HashMap;
 
@@ -111,6 +113,23 @@ macro_rules! get_storage_mut {
     };
 }
 
+// --- manager-wide methods
+
+impl AttrStorageManager {
+    /// Extend the size of all storages in the manager.
+    ///
+    /// # Arguments
+    ///
+    /// - `length: usize` -- Length by which storages should be extended.
+    pub fn extend_storages(&mut self, length: usize) {
+        for storage in self.vertices.values_mut() {
+            storage.extend(length);
+        }
+    }
+}
+
+// --- attribute-specific methods
+
 impl AttrStorageManager {
     #[allow(clippy::missing_errors_doc)]
     /// Add a new storage to the manager.
@@ -149,15 +168,6 @@ impl AttrStorageManager {
             Err(ManagerError::DuplicateStorage)
         } else {
             Ok(())
-        }
-    }
-
-    /// UNIMPLEMENTED
-    pub fn extend_storages(&mut self, _length: usize) {
-        // not sure if this is actually possible since we need to fetch the attribute from storages,
-        // which cannot be interpreted as such without the attribute in the first place
-        for _storage in self.vertices.values_mut() {
-            todo!()
         }
     }
 
@@ -328,5 +338,25 @@ impl AttrStorageManager {
     pub fn remove_attribute<A: AttributeBind>(&mut self, id: A::IdentifierType) -> Option<A> {
         get_storage_mut!(self, storage);
         storage.remove(id)
+    }
+
+    pub fn merge_attribute<A: AttributeBind>(
+        &mut self,
+        id_out: DartIdentifier,
+        id_in_lhs: DartIdentifier,
+        id_in_rhs: DartIdentifier,
+    ) {
+        get_storage_mut!(self, storage);
+        storage.merge(id_out, id_in_lhs, id_in_rhs);
+    }
+
+    pub fn split_attribute<A: AttributeBind>(
+        &mut self,
+        id_out_lhs: DartIdentifier,
+        id_out_rhs: DartIdentifier,
+        id_in: DartIdentifier,
+    ) {
+        get_storage_mut!(self, storage);
+        storage.split(id_out_lhs, id_out_rhs, id_in);
     }
 }

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -83,6 +83,23 @@ pub struct AttrStorageManager {
     others: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>, // Orbit::Custom
 }
 
+// --- manager-wide methods
+
+impl AttrStorageManager {
+    /// Extend the size of all storages in the manager.
+    ///
+    /// # Arguments
+    ///
+    /// - `length: usize` -- Length by which storages should be extended.
+    pub fn extend_storages(&mut self, length: usize) {
+        for storage in self.vertices.values_mut() {
+            storage.extend(length);
+        }
+    }
+}
+
+// --- attribute-specific methods
+
 macro_rules! get_storage {
     ($slf: ident, $id: ident) => {
         let probably_storage = match A::binds_to() {
@@ -112,23 +129,6 @@ macro_rules! get_storage_mut {
             .expect("E: could not downcast generic storage to specified attribute type");
     };
 }
-
-// --- manager-wide methods
-
-impl AttrStorageManager {
-    /// Extend the size of all storages in the manager.
-    ///
-    /// # Arguments
-    ///
-    /// - `length: usize` -- Length by which storages should be extended.
-    pub fn extend_storages(&mut self, length: usize) {
-        for storage in self.vertices.values_mut() {
-            storage.extend(length);
-        }
-    }
-}
-
-// --- attribute-specific methods
 
 impl AttrStorageManager {
     #[allow(clippy::missing_errors_doc)]

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -6,6 +6,7 @@
 // ------ IMPORTS
 
 use crate::{DartIdentifier, OrbitPolicy};
+use downcast_rs::{impl_downcast, Downcast};
 use std::any::Any;
 use std::fmt::Debug;
 
@@ -131,7 +132,7 @@ pub trait AttributeBind: Debug + Sized + Any {
 /// This trait contain attribute-agnostic function & methods.
 ///
 /// The documentation of this trait describe the behavior each function & method should have.
-pub trait UnknownAttributeStorage: Debug + Any {
+pub trait UnknownAttributeStorage: Any + Debug + Downcast {
     /// Constructor
     ///
     /// # Arguments
@@ -204,6 +205,8 @@ pub trait UnknownAttributeStorage: Debug + Any {
     /// ```
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier);
 }
+
+impl_downcast!(UnknownAttributeStorage);
 
 /// Common trait implemented by generic attribute storages.
 ///


### PR DESCRIPTION
- title
- implement new methods to handle manager-wide updates of attribute collections
- closes #93 

Note: It looks like `downcast-rs` isn't used, but if you remove the `Downcast` trait from `UnknownAttributeStorage`, the code won't compile.

## Scope

- [x] Code

## Type of change

- [x] New feature(s)
- [x] Refactor

## Other

- [x] New dependency: `downcast-rs`; Necessary until `trait_upcasting` is stabilized https://github.com/rust-lang/rust/issues/65991

## Necessary follow-up

- [x] Needs testing
- [x] Other: with these new methods, it should be possible to add the manager to `CMap2` & wire everything up to handle attributes automatically
