### PR TITLE
fix(kernels): correct grisubal algorithm logic

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -476,10 +476,12 @@ fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[MapEdge]) {
             // start to first intermediate; expect should not happen due to if statement
             let di_first = intermediates.first().expect("E: unreachable");
             cmap.one_sew(d_new, *di_first);
+            cmap.one_link(cmap.beta::<2>(*di_first), cmap.beta::<2>(d_new));
             // intermediate to intermediate
             intermediates.windows(2).for_each(|ds| {
                 let &[di1, di2] = ds else { unreachable!() };
                 cmap.one_sew(di1, di2);
+                cmap.one_link(cmap.beta::<2>(di2), cmap.beta::<2>(di1));
             });
             // last intermediate to end; last may be the same as first
             let di_last = intermediates.last().expect("E: unreachable");

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -270,7 +270,7 @@ fn generate_intersected_segments<T: CoordsFloat>(
                     (0, j) => {
                         // we can solve the intersection equation
                         // for each horizontal edge of the grid we cross (j times)
-                        let j_base = c1.0 as isize;
+                        let j_base = c1.1 as isize;
                         let tmp =
                             // the range is either
                             // j > 0: j_base..j_base + j


### PR DESCRIPTION
there are two fixes in this PR:
- a copy-paste typo where a coordinate along X was read instead of along Y - 84ffa9dd3381b0eab19cbbee080b31e2b9ac34bd
- missing topology operations in the last step of the algorithm - 44493b986ffcd79611473b626adb26ae2d09a9aa

this fixes issues mentioned in #120 