### PR TITLE
fix: indent lists in doc correctly to comply with clippy

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -130,8 +130,8 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrSparseVec<T> {
 /// # Generics
 ///
 /// - `A: AttributeBind + AttributeUpdate + Clone` -- Type of the stored attributes. The
-/// `Clone` implementation is required in order to return copied values & invalidate internal
-/// storage slot.
+///   `Clone` implementation is required in order to return copied values & invalidate internal
+///   storage slot.
 ///
 /// # Example
 ///

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -138,8 +138,8 @@ macro_rules! unknown_attribute_storage {
         /// # Arguments
         ///
         /// - `length: usize` -- Initial length/capacity of the storage. It should correspond to
-        /// the upper bound of IDs used to index the attribute's values, i.e. the number of darts
-        /// including the null dart.
+        ///   the upper bound of IDs used to index the attribute's values, i.e. the number of darts
+        ///   including the null dart.
         ///
         /// # Return
         ///

--- a/honeycomb-core/src/cells/orbits.rs
+++ b/honeycomb-core/src/cells/orbits.rs
@@ -48,9 +48,9 @@ pub enum OrbitPolicy<'a> {
 /// [Breadth-first search algorithm][WIKIBFS]. This means that:
 ///
 /// - we look at the images of the current dart through all beta functions,
-/// adding those to a queue, before moving on to the next dart.
+///   adding those to a queue, before moving on to the next dart.
 /// - we apply the beta functions in their specified order (in the case of a
-/// custom [`OrbitPolicy`]); This guarantees a consistent and predictable result.
+///   custom [`OrbitPolicy`]); This guarantees a consistent and predictable result.
 ///
 /// Both of these points allow the structure to be used for sewing operations at the cost of some
 /// performance (non-trivial parallelization & sequential consistency requirements).
@@ -78,7 +78,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     /// # Arguments
     ///
     /// - `map_handle: &'a CMap2<T>` -- Reference to the map containing the beta
-    /// functions used in the BFS.
+    ///   functions used in the BFS.
     /// - `orbit_policy: OrbitPolicy<'a>` -- Policy used by the orbit for the BFS.
     /// - `dart: DartIdentifier` -- Dart of which the structure will compute the orbit.
     ///

--- a/honeycomb-core/src/cmap2/basic_ops.rs
+++ b/honeycomb-core/src/cmap2/basic_ops.rs
@@ -247,10 +247,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// cell. This definition has three interesting properties:
     ///
     /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
-    /// associated cell ID.
+    ///   associated cell ID.
     /// - Cell IDs are not affected by the order of traversal of the map.
     /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
-    /// that the storage is consistent / up to date.
+    ///   that the storage is consistent / up to date.
     ///
     /// These properties come at the literal cost of the computation routine, which is:
     /// 1. a BFS to compute a given orbit
@@ -281,10 +281,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// cell. This definition has three interesting properties:
     ///
     /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
-    /// associated cell ID.
+    ///   associated cell ID.
     /// - Cell IDs are not affected by the order of traversal of the map.
     /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
-    /// that the storage is consistent / up to date.
+    ///   that the storage is consistent / up to date.
     ///
     /// These properties come at the literal cost of the computation routine, which is:
     /// 1. a BFS to compute a given orbit
@@ -315,10 +315,10 @@ impl<T: CoordsFloat> CMap2<T> {
     /// cell. This definition has three interesting properties:
     ///
     /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
-    /// associated cell ID.
+    ///   associated cell ID.
     /// - Cell IDs are not affected by the order of traversal of the map.
     /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
-    /// that the storage is consistent / up to date.
+    ///   that the storage is consistent / up to date.
     ///
     /// These properties come at the literal cost of the computation routine, which is:
     /// 1. a BFS to compute a given orbit
@@ -341,7 +341,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ## Generics
     ///
     /// - `const I: u8` -- Dimension of the cell of interest. *I* should be 0 (vertex), 1 (edge) or
-    /// 2 (face) for a 2D map.
+    ///   2 (face) for a 2D map.
     ///
     /// # Return
     ///

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -101,7 +101,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This method return a `Result` taking the following values:
     /// - `Ok(v: Vertex2)` -- The vertex was successfully overwritten & its previous value was
-    /// returned
+    ///   returned
     /// - `Err(CMapError::UnknownVertexID)` -- The vertex was not found in the internal storage
     ///
     pub fn replace_vertex(

--- a/honeycomb-core/src/cmap2/structure.rs
+++ b/honeycomb-core/src/cmap2/structure.rs
@@ -66,8 +66,8 @@ use std::collections::BTreeSet;
 /// Note that:
 /// - we create the map using its builder structure: [`CMapBuilder`].
 /// - the map we operate on has no boundaries. In addition to the different
-/// operations realized at each step, we insert a few assertions to demonstrate the
-/// progressive changes applied to the structure.
+///   operations realized at each step, we insert a few assertions to demonstrate the
+///   progressive changes applied to the structure.
 ///
 /// ```
 /// # use honeycomb_core::CMapError;

--- a/honeycomb-core/src/cmapbuilder/io/mod.rs
+++ b/honeycomb-core/src/cmapbuilder/io/mod.rs
@@ -91,13 +91,13 @@ macro_rules! build_vertices {
 ///
 /// - `Ok(CMap2)` -- The file was successfully parsed and its content made into a 2-map.
 /// - `Err(BuilderError)` -- The function failed for one of the following reasons (sorted
-/// by [`BuilderError`] variants):
+///   by [`BuilderError`] variants):
 ///     - `UnsupportedVtkData`: The file contains unsupported data, i.e.:
 ///         - file format isn't Legacy,
 ///         - data set is something other than `UnstructuredGrid`,
 ///         - coordinate representation type isn't `float` or `double`
 ///         - mesh contains unsupported cell types (`PolyVertex`, `PolyLine`, `TriangleStrip`,
-///         `Pixel` or anything 3D)
+///           `Pixel` or anything 3D)
 ///     - `InvalidVtkFile`: The file contains inconsistencies, i.e.:
 ///         - the number of coordinates cannot be divided by `3`, meaning a tuple is incomplete
 ///         - the number of `Cells` and `CellTypes` isn't equal

--- a/honeycomb-core/src/spatial_repr/vertex.rs
+++ b/honeycomb-core/src/spatial_repr/vertex.rs
@@ -200,7 +200,7 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 /// - **MERGING POLICY** - The new vertex is placed at the midpoint between the two existing ones.
 /// - **SPLITTING POLICY** - The current vertex is duplicated.
 /// - **UNDEFINED ATTRIBUTES MERGING** - The new vertex takes the value of the one provided if it
-/// exists, otherwise the function panics.
+///   exists, otherwise the function panics.
 impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
     fn merge(attr1: Self, attr2: Self) -> Self {
         Self::average(&attr1, &attr2)


### PR DESCRIPTION
fixes related to this new lint: https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation