### PR TITLE
feat(core): add `splitn_edge` method to `CMap2`

### DIFF
--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -154,7 +154,11 @@ impl<T: CoordsFloat> CMap2<T> {
             .vertex(self.vertex_id(base_dart1))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
         let v2 = self // (*)
-            .vertex(self.vertex_id(b1d1_old))
+            .vertex(self.vertex_id(if base_dart2 == NULL_DART_ID {
+                b1d1_old
+            } else {
+                base_dart2
+            }))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
         let seg = v2 - v1;
 

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -135,14 +135,11 @@ impl<T: CoordsFloat> CMap2<T> {
     /// # Example
     ///
     /// TODO: complete
-    pub fn splitn_edge<I>(
+    pub fn splitn_edge(
         &mut self,
         edge_id: EdgeIdentifier,
-        midpoint_vertices: I,
-    ) -> Vec<DartIdentifier>
-    where
-        I: Iterator<Item = T>,
-    {
+        midpoint_vertices: impl IntoIterator<Item = T>,
+    ) -> Vec<DartIdentifier> {
         // base darts making up the edge
         let base_dart1 = edge_id as DartIdentifier;
         let base_dart2 = self.beta::<2>(base_dart1);
@@ -170,6 +167,7 @@ impl<T: CoordsFloat> CMap2<T> {
         // insert new vertices / darts on base_dart1's side
         let mut prev_d = base_dart1;
         let darts: Vec<DartIdentifier> = midpoint_vertices
+            .into_iter()
             .map(|t| {
                 if (t >= T::one()) | (t <= T::zero()) {
                     println!(

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -135,11 +135,15 @@ impl<T: CoordsFloat> CMap2<T> {
     /// # Example
     ///
     /// ```
+    /// # use honeycomb_core::{CMap2, CMapBuilder, NULL_DART_ID, Vertex2};
     /// // before
     /// //    <--2---
     /// //  1         2
     /// //    ---1-->
-    /// let mut map: CMap2<f64> = CMap2::new(2);
+    /// let mut map: CMap2<f64> = CMapBuilder::default()
+    ///                             .n_darts(2)
+    ///                             .build()
+    ///                             .unwrap();
     /// map.two_link(1, 2);
     /// map.insert_vertex(1, (0.0, 0.0));
     /// map.insert_vertex(2, (1.0, 0.0));

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -10,7 +10,7 @@ use crate::{CMap2, CoordsFloat, DartIdentifier, EdgeIdentifier, Vertex2, NULL_DA
 // ------ CONTENT
 
 impl<T: CoordsFloat> CMap2<T> {
-    /// Split an edge into to segments.
+    /// Split an edge into two segments.
     ///
     /// <div class="warning">
     /// This implementation is 2D specific.
@@ -112,6 +112,29 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
+    /// Split an edge into `n` segments.
+    ///
+    /// <div class="warning">
+    /// This implementation is 2D specific.
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
+    /// - `midpoint_vertices: I` -- Relative positions of new vertices, starting from the
+    ///   vertex of the dart sharing `edge_id` as its identifier.
+    ///
+    /// ## Generics
+    ///
+    /// - `I: Iterator<Item = T>` -- Iterator over `T` values. These should be in the `]0; 1[` open range.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the edge upon which the operation is performed does not have two defined vertices.
+    ///
+    /// # Example
+    ///
+    /// TODO: complete
     pub fn splitn_edge<I>(
         &mut self,
         edge_id: EdgeIdentifier,
@@ -144,6 +167,11 @@ impl<T: CoordsFloat> CMap2<T> {
         let mut prev_d = base_dart1;
         let darts: Vec<DartIdentifier> = midpoint_vertices
             .map(|t| {
+                if (t >= T::one()) | (t <= T::zero()) {
+                    println!(
+                        "W: vertex placement for split is not in ]0;1[ -- result may be incoherent"
+                    );
+                }
                 let new_v = v1 + seg * t;
                 let new_d = self.add_free_dart();
                 self.one_link(prev_d, new_d);

--- a/honeycomb-core/src/cmap2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap2/advanced_ops.rs
@@ -134,7 +134,41 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Example
     ///
-    /// TODO: complete
+    /// ```
+    /// // before
+    /// //    <--2---
+    /// //  1         2
+    /// //    ---1-->
+    /// let mut map: CMap2<f64> = CMap2::new(2);
+    /// map.two_link(1, 2);
+    /// map.insert_vertex(1, (0.0, 0.0));
+    /// map.insert_vertex(2, (1.0, 0.0));
+    /// // split
+    /// let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    /// // after
+    /// //    <-<-<-<
+    /// //  1 -3-4-5- 2
+    /// //    >->->->
+    /// assert_eq!(&new_darts, &[3, 4, 5]);
+    /// assert_eq!(map.vertex(3), Ok(Vertex2(0.25, 0.0)));
+    /// assert_eq!(map.vertex(4), Ok(Vertex2(0.50, 0.0)));
+    /// assert_eq!(map.vertex(5), Ok(Vertex2(0.75, 0.0)));
+    ///
+    /// assert_eq!(map.beta::<1>(1), 3);
+    /// assert_eq!(map.beta::<1>(3), 4);
+    /// assert_eq!(map.beta::<1>(4), 5);
+    /// assert_eq!(map.beta::<1>(5), NULL_DART_ID);
+    ///
+    /// assert_eq!(map.beta::<1>(2), 6);
+    /// assert_eq!(map.beta::<1>(6), 7);
+    /// assert_eq!(map.beta::<1>(7), 8);
+    /// assert_eq!(map.beta::<1>(8), NULL_DART_ID);
+    ///
+    /// assert_eq!(map.beta::<2>(1), 8);
+    /// assert_eq!(map.beta::<2>(3), 7);
+    /// assert_eq!(map.beta::<2>(4), 6);
+    /// assert_eq!(map.beta::<2>(5), 2);
+    /// ```
     pub fn splitn_edge(
         &mut self,
         edge_id: EdgeIdentifier,

--- a/honeycomb-core/src/cmap2/tests.rs
+++ b/honeycomb-core/src/cmap2/tests.rs
@@ -376,7 +376,7 @@ fn splitn_edge_complete() {
     map.insert_vertex(3, (2.0, 0.0));
     map.insert_vertex(4, (3.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(2, [0.25, 0.50, 0.75].into_iter());
+    let new_darts = map.splitn_edge(2, [0.25, 0.50, 0.75]);
     // after
     //    <--6---             <--4---
     //  1         2 -7-8-9- 3         4
@@ -413,7 +413,7 @@ fn splitn_edge_isolated() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75].into_iter());
+    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
     // after
     //    <-<-<-<
     //  1 -3-4-5- 2
@@ -448,7 +448,7 @@ fn splitn_single_dart() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75].into_iter());
+    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
     // after
     //  1 -> 3 -> 4 -> 5 -> 2 ->
     assert_eq!(&new_darts, &[3, 4, 5]);
@@ -478,7 +478,7 @@ fn splitn_edge_missing_vertex() {
     map.insert_vertex(1, (0.0, 0.0));
     // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
     // split
-    map.splitn_edge(1, [0.25, 0.50, 0.75].into_iter());
+    map.splitn_edge(1, [0.25, 0.50, 0.75]);
 }
 
 // --- IO


### PR DESCRIPTION
Add a new method to `CMap2` to split a single edge into multiple segments, the number & poisiton of new vertices being given by an iterator over relative positions passed as arguments.

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] New feature(s)
