### PR TITLE
feat(core): add `remove_storage` method to `AttrStorageManager`

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -428,6 +428,24 @@ impl AttrStorageManager {
             .expect("E: could not downcast generic storage to specified attribute type")
     }
 
+    /// Remove an entire attribute storage from the manager.
+    ///
+    /// This method is useful when implementing routines that uses attributes to run; Those can then be removed
+    /// before the final result is returned.
+    ///
+    /// # Generic
+    ///
+    /// - `A: AttributeBind` -- Attribute stored by the fetched storage.
+    pub fn remove_storage<A: AttributeBind>(&mut self) {
+        // we could return it ?
+        let _ = match A::binds_to() {
+            OrbitPolicy::Vertex => &self.vertices.remove(&TypeId::of::<A>()),
+            OrbitPolicy::Edge => &self.edges.remove(&TypeId::of::<A>()),
+            OrbitPolicy::Face => &self.faces.remove(&TypeId::of::<A>()),
+            OrbitPolicy::Custom(_) => &self.others.remove(&TypeId::of::<A>()),
+        };
+    }
+
     /// Set the value of an attribute.
     ///
     /// # Arguments

--- a/honeycomb-core/src/cmap2/embed.rs
+++ b/honeycomb-core/src/cmap2/embed.rs
@@ -13,6 +13,22 @@ use crate::{
 
 // ------ CONTENT
 
+// --- big guns
+
+impl<T: CoordsFloat> CMap2<T> {
+    /// Remove an entire attribute storage from the map.
+    ///
+    /// This method is useful when implementing routines that uses attributes to run; Those can then be removed
+    /// before the final result is returned.
+    ///
+    /// # Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute stored by the fetched storage.
+    pub fn remove_attribute_storage<A: AttributeBind + AttributeUpdate>(&mut self) {
+        self.attributes.remove_storage::<A>();
+    }
+}
+
 // --- vertex attributes
 impl<T: CoordsFloat> CMap2<T> {
     /// Return the current number of vertices.


### PR DESCRIPTION
Add a method that allows removing a given storage from the manager entirely. This will be useful for the `grisubal` implementation (see #110), more specifically to remove the attribute used to model clipping regions.

## Scope

- [x] Code: `honeycomb-core`

## Type of change

- [x] New feature(s)
