### PR TITLE
feat(kernels): add a dedicated intersection insertion step

### DIFF
--- a/examples/examples/kernels/grisubal.rs
+++ b/examples/examples/kernels/grisubal.rs
@@ -1,16 +1,24 @@
 use honeycomb_kernels::grisubal;
 use honeycomb_render::{RenderParameters, SmaaMode};
 
+use std::env;
+
 fn main() {
-    let map = grisubal::<f64>("../../meshing-samples/vtk/2D/rectangle.vtk", (1., 1.), None);
+    let args: Vec<String> = env::args().collect();
 
-    let render_params = RenderParameters {
-        smaa_mode: SmaaMode::Smaa1X,
-        relative_resize: false,
-        shrink_factor: 0.05,
-        arrow_headsize: 0.01,
-        arrow_thickness: 0.005,
-    };
+    if let Some(path) = args.get(1) {
+        let map = grisubal::<f64>(path, (1., 1.), None);
 
-    honeycomb_render::launch(render_params, Some(&map));
+        let render_params = RenderParameters {
+            smaa_mode: SmaaMode::Smaa1X,
+            relative_resize: false,
+            shrink_factor: 0.05,
+            arrow_headsize: 0.01,
+            arrow_thickness: 0.005,
+        };
+
+        honeycomb_render::launch(render_params, Some(&map));
+    } else {
+        println!("No input geometry specified - you can pass a path to a vtk input as command line argument")
+    }
 }

--- a/examples/examples/kernels/grisubal.rs
+++ b/examples/examples/kernels/grisubal.rs
@@ -2,7 +2,7 @@ use honeycomb_kernels::grisubal;
 use honeycomb_render::{RenderParameters, SmaaMode};
 
 fn main() {
-    let map = grisubal::<f64>("assets/rectangle.vtk", (1., 1.), None);
+    let map = grisubal::<f64>("../../meshing-samples/vtk/2D/rectangle.vtk", (1., 1.), None);
 
     let render_params = RenderParameters {
         smaa_mode: SmaaMode::Smaa1X,

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -198,7 +198,7 @@ fn generate_intersected_segments<T: CoordsFloat>(
                     _ => unreachable!(),
                 };
 
-                // WARNING: these two lines should be atomic
+                // FIXME: these two lines should be atomic
                 let id = intersection_metadata.len();
                 intersection_metadata.push((dart_id, t));
 
@@ -251,7 +251,7 @@ fn generate_intersected_segments<T: CoordsFloat>(
                                     left_intersec!(v1, v2, v_dart, cy)
                                 };
 
-                                // WARNING: these two lines should be atomic
+                                // FIXME: these two lines should be atomic
                                 let id = intersection_metadata.len();
                                 intersection_metadata.push((dart_id, t));
 
@@ -293,7 +293,7 @@ fn generate_intersected_segments<T: CoordsFloat>(
                                     down_intersec!(v1, v2, v_dart, cx)
                                 };
 
-                                // WARNING: these two lines should be atomic
+                                // FIXME: these two lines should be atomic
                                 let id = intersection_metadata.len();
                                 intersection_metadata.push((dart_id, t));
 
@@ -374,7 +374,7 @@ fn generate_intersected_segments<T: CoordsFloat>(
                         // collect geometry vertices
                         let mut vs = vec![make_geometry_vertex!(geometry, v1_id)];
                         vs.extend(intersec_data.iter_mut().map(|(_, t, dart_id)| {
-                            // WARNING: these two lines should be atomic
+                            // FIXME: these two lines should be atomic
                             let id = intersection_metadata.len();
                             intersection_metadata.push((*dart_id, *t));
 

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -448,6 +448,7 @@ fn insert_intersections<T: CoordsFloat>(
     // b. proceed with insertion
     // c. map back inserted darts / vertices to the initial vector layout in order for usage with segment data
 
+    /*
     // a.
     let mut edge_intersec: HashMap<EdgeIdentifier, Vec<(usize, T)>> = HashMap::new();
     intersection_metadata
@@ -483,6 +484,21 @@ fn insert_intersections<T: CoordsFloat>(
                 res[*id] = *dart_id;
             });
     }
+    */
+
+    intersection_metadata
+        .iter_mut()
+        .enumerate()
+        .for_each(|(idx, (dart_id, t))| {
+            let edge_id = cmap.edge_id(*dart_id);
+            // works in 2D because edges are 2 darts at most
+            if edge_id != *dart_id {
+                *t = T::one() - *t;
+            }
+            cmap.split_edge(edge_id, Some(*t));
+            let new_vid = cmap.beta::<1>(*dart_id);
+            res[idx] = new_vid;
+        });
 
     res
 }

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -202,15 +202,13 @@ impl<T: CoordsFloat> From<Vtk> for Geometry2<T> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum GeometryVertex<T: CoordsFloat> {
+pub enum GeometryVertex {
     /// Regular vertex. Inner `usize` indicates the vertex ID in-geometry.
     Regular(usize),
     /// Characteristic vertex, i.e. Point of Interest. Inner `usize` indicates the vertex ID in-geometry.
     PoI(usize),
-    /// Interection vertex. Inner `DartIdentifier, T` values give the interesected dart & the relative position of the
-    /// intersection along its edge. Note that the `T` value should be adjusted for direction since
-    /// [`CMap2::split_edge`] uses the direction of the edge, not necessarily of the dart.
-    Intersec(DartIdentifier, T),
+    /// Interection vertex. Inner `usize` indices the associated metadata ID in the dedicated collection.
+    Intersec(usize),
 }
 
 pub struct MapEdge {

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -17,6 +17,9 @@ use vtkio::{
     IOBuffer, Vtk,
 };
 
+#[cfg(doc)]
+use honeycomb_core::CMap2;
+
 // ------ CONTENT
 
 /// Post-processing clip operation.
@@ -199,10 +202,15 @@ impl<T: CoordsFloat> From<Vtk> for Geometry2<T> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum GeometryVertex {
+pub enum GeometryVertex<T: CoordsFloat> {
+    /// Regular vertex. Inner `usize` indicates the vertex ID in-geometry.
     Regular(usize),
+    /// Characteristic vertex, i.e. Point of Interest. Inner `usize` indicates the vertex ID in-geometry.
     PoI(usize),
-    Intersec(DartIdentifier),
+    /// Interection vertex. Inner `DartIdentifier, T` values give the interesected dart & the relative position of the
+    /// intersection along its edge. Note that the `T` value should be adjusted for direction since
+    /// [`CMap2::split_edge`] uses the direction of the edge, not necessarily of the dart.
+    Intersec(DartIdentifier, T),
 }
 
 pub struct MapEdge {


### PR DESCRIPTION
This PR modify step 1 and step 2 of the algorithm to insert a new step in between. This step ensures correct vertex insertion even if a single edge is intersected multiple times on both of its sides.

As a side note, the `grisubal` example is now executed on the input file passed as argument: 

```
cargo run  --example grisubal -- path/to/file.vtk
```

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Necessary follow-up

- [x] Needs documentation
- [x] Other: This step can be used to process specifically tangents & corner intersections
