### PR TITLE
refactor(kernels): insert PoIs using `splitn_edge` in final step of grisubal

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -401,7 +401,7 @@ fn generate_edge_data<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     geometry: &Geometry2<T>,
     new_segments: &HashMap<GeometryVertex, GeometryVertex>,
-) -> Vec<MapEdge> {
+) -> Vec<MapEdge<T>> {
     new_segments
         .iter()
         .filter(|(k, _)| matches!(k, GeometryVertex::Intersec(_)))
@@ -412,13 +412,8 @@ fn generate_edge_data<T: CoordsFloat>(
             while !matches!(end, GeometryVertex::Intersec(_)) {
                 match end {
                     GeometryVertex::PoI(vid) => {
-                        // insert the PoI in the map; create some darts to go with it
-                        let v = geometry.vertices[*vid];
-                        let d = cmap.add_free_darts(2);
-                        cmap.two_link(d, d + 1);
-                        cmap.insert_vertex(d as VertexIdentifier, v);
-                        // save intermediate & update end point
-                        intermediates.push(d);
+                        // save the PoI as an intermediate & update end point
+                        intermediates.push(geometry.vertices[*vid]);
                         end = &new_segments[end];
                     }
                     GeometryVertex::Regular(_) => {
@@ -448,7 +443,7 @@ fn generate_edge_data<T: CoordsFloat>(
         .collect()
 }
 
-fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[MapEdge]) {
+fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[MapEdge<T>]) {
     for MapEdge {
         start,
         intermediates,

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -205,9 +205,9 @@ pub enum GeometryVertex {
     Intersec(DartIdentifier),
 }
 
-pub struct MapEdge {
+pub struct MapEdge<T: CoordsFloat> {
     pub start: DartIdentifier,
-    pub intermediates: Vec<DartIdentifier>,
+    pub intermediates: Vec<Vertex2<T>>,
     pub end: DartIdentifier,
 }
 


### PR DESCRIPTION
Using a suggestion from @franck-ledoux; by waiting until the final step & using the `splitn_edge` method, we can avoid having random disconnected darts as PoIs in-between steps of the algorithm.

## Scope

- [x] Code

## Type of change

- [x] Refactor