### PR TITLE
refactor(kernels): add buffer cells to the overlapping grid in grisubal

### DIFF
--- a/honeycomb-kernels/src/grisubal/grid.rs
+++ b/honeycomb-kernels/src/grisubal/grid.rs
@@ -54,8 +54,8 @@ impl<T: CoordsFloat> BBox2<T> {
         let n_cells_x = (self.max_x / len_cell_x).ceil().to_usize();
         let n_cells_y = (self.max_y / len_cell_y).ceil().to_usize();
         GridDescriptor::default()
-            .n_cells_x(n_cells_x.unwrap())
-            .n_cells_y(n_cells_y.unwrap())
+            .n_cells_x(n_cells_x.unwrap() + 1)
+            .n_cells_y(n_cells_y.unwrap() + 1)
             .len_per_cell_x(len_cell_x)
             .len_per_cell_y(len_cell_y)
     }

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -73,8 +73,8 @@ pub fn build_mesh<T: CoordsFloat>(geometry: &Geometry2<T>, grid_cell_sizes: (T, 
     let bbox = geometry.bbox();
     let (cx, cy) = grid_cell_sizes; // will need later
     let (nx, ny) = (
-        (bbox.max_x / cx).ceil().to_usize().unwrap(),
-        (bbox.max_y / cy).ceil().to_usize().unwrap(),
+        (bbox.max_x / cx).ceil().to_usize().unwrap() + 1,
+        (bbox.max_y / cy).ceil().to_usize().unwrap() + 1,
     );
     let ogrid = bbox.overlapping_grid(grid_cell_sizes);
     let mut cmap = CMapBuilder::default()


### PR DESCRIPTION
not having buffer cells created issues if a single point landed on upper boundaries of the box

there still are issues for capturing such geometries, but this prevents a direct crash