### PR TITLE
refactor(kernels): ignore points of interest landing exactly on the grid

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -125,6 +125,17 @@ pub fn build_mesh<T: CoordsFloat>(geometry: &Geometry2<T>, grid_cell_sizes: (T, 
 
 // --- main kernels steps
 
+fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, (cx, cy): (T, T)) {
+    // PoI that land on the grid create a number of issues; removing them is ok since we're intersecting the grid
+    // at their coordinates, so the shape will be captured via intersection anyway
+    geometry.poi.retain(|idx| {
+        let v = geometry.vertices[*idx];
+        let on_x_axis = (v.x() % cx).is_zero();
+        let on_y_axis = (v.y() % cy).is_zero();
+        !(on_x_axis | on_y_axis)
+    });
+}
+
 #[allow(
     clippy::too_many_lines,
     clippy::cast_possible_truncation,

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -137,6 +137,7 @@ fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, (cx, cy): (
     // at their coordinates, so the shape will be captured via intersection anyway
     geometry.poi.retain(|idx| {
         let v = geometry.vertices[*idx];
+        // origin is assumed to be (0.0, 0.0)
         let on_x_axis = (v.x() % cx).is_zero();
         let on_y_axis = (v.y() % cy).is_zero();
         !(on_x_axis | on_y_axis)

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -71,7 +71,10 @@ macro_rules! up_intersec {
 /// ## Generics
 ///
 /// - `T: CoordsFloat` -- Floating point type used for coordinate representation.
-pub fn build_mesh<T: CoordsFloat>(geometry: &Geometry2<T>, grid_cell_sizes: (T, T)) -> CMap2<T> {
+pub fn build_mesh<T: CoordsFloat>(
+    geometry: &mut Geometry2<T>,
+    grid_cell_sizes: (T, T),
+) -> CMap2<T> {
     // build the overlapping grid we'll modify
     let bbox = geometry.bbox();
     let (cx, cy) = grid_cell_sizes; // will need later
@@ -87,6 +90,10 @@ pub fn build_mesh<T: CoordsFloat>(geometry: &Geometry2<T>, grid_cell_sizes: (T, 
         .expect("E: could not build overlapping grid map");
 
     // process the geometry
+
+    // preparations
+
+    remove_redundant_poi(geometry, (cx, cy));
 
     // FIXME: WHAT'S THE BEHAVIOR WHEN INTERSECTING CORNERS? WHEN SEGMENTS ARE TANGENTS?
 

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -12,7 +12,7 @@ use std::{
     process::id,
 };
 
-use crate::{Geometry2, GeometryVertex, GridCellId, IsBoundary, MapEdge};
+use crate::{remove_redundant_poi, Geometry2, GeometryVertex, GridCellId, IsBoundary, MapEdge};
 use honeycomb_core::{
     CMap2, CMapBuilder, CoordsFloat, DartIdentifier, EdgeIdentifier, Vertex2, VertexIdentifier,
     NULL_DART_ID,
@@ -131,18 +131,6 @@ pub fn build_mesh<T: CoordsFloat>(
 }
 
 // --- main kernels steps
-
-fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, (cx, cy): (T, T)) {
-    // PoI that land on the grid create a number of issues; removing them is ok since we're intersecting the grid
-    // at their coordinates, so the shape will be captured via intersection anyway
-    geometry.poi.retain(|idx| {
-        let v = geometry.vertices[*idx];
-        // origin is assumed to be (0.0, 0.0)
-        let on_x_axis = (v.x() % cx).is_zero();
-        let on_y_axis = (v.y() % cy).is_zero();
-        !(on_x_axis | on_y_axis)
-    });
-}
 
 #[allow(
     clippy::too_many_lines,

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -117,9 +117,9 @@ pub fn grisubal<T: CoordsFloat>(
         Err(e) => panic!("E: could not open specified vtk file - {e}"),
     };
     // pre-processing
-    let geometry = Geometry2::from(geometry_vtk);
+    let mut geometry = Geometry2::from(geometry_vtk);
     // build the map
-    let mut cmap = kernel::build_mesh(&geometry, grid_cell_sizes);
+    let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes);
     // optional post-processing
     match clip.unwrap_or_default() {
         Clip::All => {

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -201,6 +201,18 @@ impl<T: CoordsFloat> From<Vtk> for Geometry2<T> {
     }
 }
 
+pub fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, (cx, cy): (T, T)) {
+    // PoI that land on the grid create a number of issues; removing them is ok since we're intersecting the grid
+    // at their coordinates, so the shape will be captured via intersection anyway
+    geometry.poi.retain(|idx| {
+        let v = geometry.vertices[*idx];
+        // origin is assumed to be (0.0, 0.0)
+        let on_x_axis = (v.x() % cx).is_zero();
+        let on_y_axis = (v.y() % cy).is_zero();
+        !(on_x_axis | on_y_axis)
+    });
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum GeometryVertex {
     /// Regular vertex. Inner `usize` indicates the vertex ID in-geometry.

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -201,6 +201,9 @@ impl<T: CoordsFloat> From<Vtk> for Geometry2<T> {
     }
 }
 
+/// Remove from their geometry points of interest that intersect with a grid of specified dimension.
+///
+/// This function works under the assumption that the grid is Cartesian & has its origin on `(0.0, 0.0)`.
 pub fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, (cx, cy): (T, T)) {
     // PoI that land on the grid create a number of issues; removing them is ok since we're intersecting the grid
     // at their coordinates, so the shape will be captured via intersection anyway

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -35,4 +35,6 @@ pub use grisubal::{grisubal, model::Clip};
 #[allow(unused)]
 pub(crate) use grisubal::grid::{BBox2, GridCellId};
 #[allow(unused)]
-pub(crate) use grisubal::model::{Geometry2, GeometryVertex, IsBoundary, MapEdge};
+pub(crate) use grisubal::model::{
+    remove_redundant_poi, Geometry2, GeometryVertex, IsBoundary, MapEdge,
+};


### PR DESCRIPTION
If a PoI is located exactly on the grid, it should be captured by intersection. To prevent duplicating vertices, we can remove the vertex's PoI status & capture the vertex using the regular intersection case.

## Scope

- [x] Code: `honeycomb-kernels`

## Type of change

- [x] Refactor