### PR TITLE
feat(kernels): add new intersection type dedicated to corners

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -386,13 +386,9 @@ fn generate_intersected_segments<T: CoordsFloat>(
                             if t.is_zero() {
                                 // we assume that the segment fully goes through the corner and does not land exactly
                                 // on it, this allows us to compute directly the dart from which the next segment
-                                // should start: the one incident to the vertex in the opposite quadrant (*)
+                                // should start: the one incident to the vertex in the opposite quadrant
                                 let dart_in = *dart_id;
-                                // (*): this is accessible using a combination of beta functions
-                                // out = b2(b1(b2(in)))
-                                let dart_out =
-                                    cmap.beta::<2>(cmap.beta::<1>(cmap.beta::<2>(dart_in)));
-                                GeometryVertex::IntersecCorner(dart_in, dart_out)
+                                GeometryVertex::IntersecCorner(dart_in)
                             } else {
                                 // FIXME: these two lines should be atomic
                                 let id = intersection_metadata.len();
@@ -490,7 +486,7 @@ fn generate_edge_data<T: CoordsFloat>(
             // while we land on regular vertices, go to the next
             while !matches!(
                 end,
-                GeometryVertex::Intersec(_) | GeometryVertex::IntersecCorner(..)
+                GeometryVertex::Intersec(_) | GeometryVertex::IntersecCorner(_)
             ) {
                 match end {
                     GeometryVertex::PoI(vid) => {
@@ -512,14 +508,14 @@ fn generate_edge_data<T: CoordsFloat>(
                 GeometryVertex::Intersec(d_start_idx) => {
                     cmap.beta::<2>(intersection_darts[*d_start_idx])
                 }
-                GeometryVertex::IntersecCorner(d_in, _) => {
+                GeometryVertex::IntersecCorner(d_in) => {
                     cmap.beta::<2>(cmap.beta::<1>(cmap.beta::<2>(*d_in)))
                 }
                 _ => unreachable!(), // unreachable due to filter
             };
             let d_end = match end {
                 GeometryVertex::Intersec(d_end_idx) => intersection_darts[*d_end_idx],
-                GeometryVertex::IntersecCorner(d_in, _) => *d_in,
+                GeometryVertex::IntersecCorner(d_in) => *d_in,
                 _ => unreachable!(), // unreachable due to filter
             };
 

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -386,8 +386,13 @@ fn generate_intersected_segments<T: CoordsFloat>(
                             if t.is_zero() {
                                 // we assume that the segment fully goes through the corner and does not land exactly
                                 // on it, this allows us to compute directly the dart from which the next segment
-                                // should start
-                                todo!()
+                                // should start: the one incident to the vertex in the opposite quadrant (*)
+                                let dart_in = *dart_id;
+                                // (*): this is accessible using a combination of beta functions
+                                // out = b2(b1(b2(in)))
+                                let dart_out =
+                                    cmap.beta::<2>(cmap.beta::<1>(cmap.beta::<2>(dart_id)));
+                                GeometryVertex::IntersecCorner(dart_in, dart_out)
                             } else {
                                 // FIXME: these two lines should be atomic
                                 let id = intersection_metadata.len();

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -366,11 +366,11 @@ fn generate_intersected_segments<T: CoordsFloat>(
                                 // in that case, we keep the data of the intersection at relative position 0;
                                 // this corresponds to the dart that should be linked to by the previous point
                                 // of the segment
-                                if vt.is_zero() & ht.is_one() {
+                                if (vt.abs() < T::epsilon()) & ((ht - one).abs() < T::epsilon()) {
                                     return Some((vs, vt, vdart_id));
                                 }
-                                if vt.is_one() & ht.is_zero() {
-                                    return Some((hs, ht, hdart_id));
+                                if ((vt - one).abs() < T::epsilon()) & (ht.abs() < T::epsilon()) {
+                                    return Some((hs, zero, hdart_id));
                                 }
 
                                 // intersect none; this is possible since we're looking at cells of a subgrid,
@@ -512,7 +512,9 @@ fn generate_edge_data<T: CoordsFloat>(
                 GeometryVertex::Intersec(d_start_idx) => {
                     cmap.beta::<2>(intersection_darts[*d_start_idx])
                 }
-                GeometryVertex::IntersecCorner(_, d_out) => *d_out,
+                GeometryVertex::IntersecCorner(d_in, _) => {
+                    cmap.beta::<2>(cmap.beta::<1>(cmap.beta::<2>(*d_in)))
+                }
                 _ => unreachable!(), // unreachable due to filter
             };
             let d_end = match end {

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -207,8 +207,11 @@ pub enum GeometryVertex {
     Regular(usize),
     /// Characteristic vertex, i.e. Point of Interest. Inner `usize` indicates the vertex ID in-geometry.
     PoI(usize),
-    /// Interection vertex. Inner `usize` indices the associated metadata ID in the dedicated collection.
+    /// Intersection vertex. Inner `usize` indices the associated metadata ID in the dedicated collection.
     Intersec(usize),
+    /// Intersection corner. This variant is dedicated to corner intersection and contain data that is directly
+    /// used to instantiate [`MapEdge`] objects.
+    IntersecCorner(DartIdentifier, DartIdentifier),
 }
 
 pub struct MapEdge<T: CoordsFloat> {

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -210,8 +210,10 @@ pub enum GeometryVertex {
     /// Intersection vertex. Inner `usize` indices the associated metadata ID in the dedicated collection.
     Intersec(usize),
     /// Intersection corner. This variant is dedicated to corner intersection and contain data that is directly
-    /// used to instantiate [`MapEdge`] objects.
-    IntersecCorner(DartIdentifier, DartIdentifier),
+    /// used to instantiate [`MapEdge`] objects. The contained dart correspond to the intersected dart (end dart); the
+    /// dart of the opposite quadrant (start dart of the next segment) can be retrieved by applying a combination of
+    /// beta functions
+    IntersecCorner(DartIdentifier),
 }
 
 pub struct MapEdge<T: CoordsFloat> {


### PR DESCRIPTION
Add `GeometryVertex::IntersecCorner` variant to handle segments that cross grid cells across corners (not edges). In this case, the vertex insertion logic is bypassed and we directly save a `DartIdentifier` that can be used to build `MapEdge`s at step 3.

## Scope

- [x] Code: if relevant, add affected target

## Type of change

- [x] New feature(s)