### PR TITLE
fix(kernels::grisubal): remove `#[allow(unused)]` from the module

### DIFF
--- a/honeycomb-kernels/src/grisubal/grid.rs
+++ b/honeycomb-kernels/src/grisubal/grid.rs
@@ -4,8 +4,6 @@
 
 // ------ IMPORTS
 
-use honeycomb_core::{CoordsFloat, GridDescriptor};
-
 // ------ CONTENT
 
 /// Structure used to index the overlapping grid's cases.

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -9,7 +9,6 @@
 use std::{
     cmp::{max, min},
     collections::{HashMap, VecDeque},
-    process::id,
 };
 
 use crate::{
@@ -17,8 +16,7 @@ use crate::{
     GridCellId, MapEdge,
 };
 use honeycomb_core::{
-    CMap2, CMapBuilder, CoordsFloat, DartIdentifier, EdgeIdentifier, GridDescriptor, Vertex2,
-    VertexIdentifier, NULL_DART_ID,
+    CMap2, CMapBuilder, CoordsFloat, DartIdentifier, EdgeIdentifier, GridDescriptor, NULL_DART_ID,
 };
 
 // ------ CONTENT
@@ -142,13 +140,12 @@ pub fn build_mesh<T: CoordsFloat>(geometry: &mut Geometry2<T>, [cx, cy]: [T; 2])
 pub(super) fn generate_intersection_data<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     geometry: &Geometry2<T>,
-    [nx, ny]: [usize; 2],
+    [nx, _ny]: [usize; 2],
     [cx, cy]: [T; 2],
 ) -> (
     HashMap<GeometryVertex, GeometryVertex>,
     Vec<(DartIdentifier, T)>,
 ) {
-    let mut n_vertices = geometry.vertices.len();
     let mut intersection_metadata = Vec::new();
     let mut new_segments = HashMap::with_capacity(geometry.poi.len() * 2); // that *2 has no basis
     geometry.segments.iter().for_each(|&(v1_id, v2_id)| {
@@ -198,7 +195,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                 // compute relative position of the intersection on the interecting edges
                 // `s` is relative to the segment `v1v2`, `t` to the grid's segment (the origin being `v_dart`)
                 #[rustfmt::skip]
-                let (_s, mut t) = match diff {
+                let (_s, t) = match diff {
                     (-1,  0) => left_intersec!(v1, v2, v_dart, cy),
                     ( 1,  0) => right_intersec!(v1, v2, v_dart, cy),
                     ( 0, -1) => down_intersec!(v1, v2, v_dart, cx),
@@ -250,7 +247,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                 // vertex associated to the intersected dart
                                 let v_dart = cmap.vertex(cmap.vertex_id(dart_id)).unwrap();
                                 // compute intersection
-                                let (_s, mut t) = if i.is_positive() {
+                                let (_s, t) = if i.is_positive() {
                                     right_intersec!(v1, v2, v_dart, cy)
                                 } else {
                                     left_intersec!(v1, v2, v_dart, cy)
@@ -292,7 +289,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                 // vertex associated to the intersected dart
                                 let v_dart = cmap.vertex(cmap.vertex_id(dart_id)).unwrap();
                                 // compute intersection
-                                let (_s, mut t) = if j.is_positive() {
+                                let (_s, t) = if j.is_positive() {
                                     up_intersec!(v1, v2, v_dart, cx)
                                 } else {
                                     down_intersec!(v1, v2, v_dart, cx)
@@ -421,7 +418,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
 
 pub(super) fn insert_intersections<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
-    mut intersection_metadata: Vec<(DartIdentifier, T)>,
+    intersection_metadata: Vec<(DartIdentifier, T)>,
 ) -> Vec<DartIdentifier> {
     let mut res = vec![NULL_DART_ID; intersection_metadata.len()];
     // we need to:
@@ -573,7 +570,7 @@ pub(super) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
                 .zip(intermediates.iter())
                 .for_each(|(dart_id, v)| {
                     let vid = cmap.vertex_id(*dart_id);
-                    cmap.replace_vertex(vid, *v);
+                    let _ = cmap.replace_vertex(vid, *v);
                 });
         }
 
@@ -591,6 +588,7 @@ pub(super) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
 /// Clipping routine.
 ///
 /// This function takes a map built by [`build_mesh`] and removes cells on the *normal* side of the boundary.
+#[allow(unused)]
 pub fn remove_normal<T: CoordsFloat>(cmap2: &mut CMap2<T>, geometry: &Geometry2<T>) {
     todo!()
 }
@@ -598,6 +596,7 @@ pub fn remove_normal<T: CoordsFloat>(cmap2: &mut CMap2<T>, geometry: &Geometry2<
 /// Clipping routine
 ///
 /// This function takes a map built by [`build_mesh`] and removes cells on the *anti-normal* side of the boundary.
+#[allow(unused)]
 pub fn remove_anti_normal<T: CoordsFloat>(cmap2: &mut CMap2<T>, geometry: &Geometry2<T>) {
     todo!()
 }

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -65,10 +65,12 @@ pub(crate) mod model;
 
 use crate::{Clip, Geometry2};
 use honeycomb_core::{CMap2, CoordsFloat};
+use model::detect_orientation_issue;
 use vtkio::Vtk;
 
 // ------ CONTENT
 
+#[derive(Debug)]
 /// Enum used to model potential errors of the `grisubal` kernel.
 pub enum GrisubalError {
     /// An orientation issue has been detected in the input geometry; The associated message details more precisely
@@ -125,6 +127,7 @@ pub fn grisubal<T: CoordsFloat>(
     };
     // pre-processing
     let mut geometry = Geometry2::from(geometry_vtk);
+    detect_orientation_issue(&geometry).unwrap();
     // build the map
     #[allow(unused)]
     let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes);

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -126,6 +126,7 @@ pub fn grisubal<T: CoordsFloat>(
     // pre-processing
     let mut geometry = Geometry2::from(geometry_vtk);
     // build the map
+    #[allow(unused)]
     let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes);
     // optional post-processing
     match clip.unwrap_or_default() {

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -11,8 +11,8 @@ use std::collections::HashSet;
 use crate::GrisubalError;
 
 use honeycomb_core::{
-    AttrSparseVec, AttributeBind, AttributeUpdate, CoordsFloat, DartIdentifier, EdgeIdentifier,
-    OrbitPolicy, Vertex2, VertexIdentifier,
+    AttrSparseVec, AttributeBind, AttributeUpdate, CoordsFloat, DartIdentifier, OrbitPolicy,
+    Vertex2,
 };
 use num::Zero;
 use vtkio::{
@@ -40,13 +40,6 @@ pub enum Clip {
     /// Keep all elements. Default value.
     #[default]
     None,
-}
-
-/// Build a [Geometry2] object from a VTK file.
-pub fn load_geometry<T: CoordsFloat>(
-    file_path: impl AsRef<std::path::Path> + std::fmt::Debug,
-) -> Geometry2<T> {
-    todo!()
 }
 
 /// Geometry representation structure.
@@ -321,7 +314,7 @@ impl AttributeUpdate for Boundary {
         }
     }
 
-    fn split(attr: Self) -> (Self, Self) {
+    fn split(_attr: Self) -> (Self, Self) {
         unreachable!()
     }
 

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     grisubal::kernel::{
         generate_edge_data, generate_intersection_data, insert_edges_in_map, insert_intersections,
     },
-    Boundary, Geometry2, GeometryVertex, MapEdge,
+    Boundary, Geometry2, GeometryVertex,
 };
 
 // ------ CONTENT
@@ -128,7 +128,7 @@ fn regular_intersections() {
     .unwrap();
 
     // square with bottom left at (0.5,0.5) & top right at (1.5,1.5)
-    let mut geometry = Geometry2 {
+    let geometry = Geometry2 {
         vertices: vec![
             Vertex2(0.5, 0.5),
             Vertex2(1.5, 0.5),
@@ -270,7 +270,7 @@ fn corner_intersection() {
     .unwrap();
 
     // square with bottom left at (0.5,0.5) & top right at (1.5,1.5)
-    let mut geometry = Geometry2 {
+    let geometry = Geometry2 {
         vertices: vec![Vertex2(0.5, 0.5), Vertex2(1.5, 0.5), Vertex2(1.5, 1.5)],
         segments: vec![(0, 1), (1, 2), (2, 0)],
         poi: vec![0, 1, 2],

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -21,7 +21,6 @@
 
 // ------ MODULE DECLARATIONS
 
-#[allow(unused)]
 pub mod grisubal;
 
 // ------ RE-EXPORTS
@@ -32,9 +31,7 @@ pub use grisubal::{grisubal, model::Clip, GrisubalError};
 
 // --- INTERNALS
 
-#[allow(unused)]
 pub(crate) use grisubal::grid::GridCellId;
-#[allow(unused)]
 pub(crate) use grisubal::model::{
     compute_overlapping_grid, remove_redundant_poi, Boundary, Geometry2, GeometryVertex, MapEdge,
 };


### PR DESCRIPTION
- remove the lint exception
- fix warnings accordingly
- call `detect_orientation_issue` after generating the `Geometry2`, in the main kernel function

## Scope

- [x] Code

## Type of change

- [x] Fix