### PR TITLE
feat(kernel::grisubal): implement post-processing clip operation

### DIFF
--- a/examples/examples/kernels/grisubal.rs
+++ b/examples/examples/kernels/grisubal.rs
@@ -1,4 +1,4 @@
-use honeycomb_kernels::grisubal;
+use honeycomb_kernels::{grisubal, Clip};
 use honeycomb_render::{RenderParameters, SmaaMode};
 
 use std::env;
@@ -7,7 +7,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if let Some(path) = args.get(1) {
-        let map = grisubal::<f64>(path, [1., 1.], None).unwrap();
+        let map = grisubal::<f64>(path, [1., 1.], Some(Clip::Left)).unwrap();
 
         let render_params = RenderParameters {
             smaa_mode: SmaaMode::Smaa1X,

--- a/examples/examples/kernels/grisubal.rs
+++ b/examples/examples/kernels/grisubal.rs
@@ -7,7 +7,20 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if let Some(path) = args.get(1) {
-        let map = grisubal::<f64>(path, [1., 1.], Some(Clip::Left)).unwrap();
+        let clip = if let Some(val) = args.get(2) {
+            match val.as_ref() {
+                "left" => Clip::Left,
+                "right" => Clip::Right,
+                _ => {
+                    println!("W: unrecognised clip argument - running kernel without clipping");
+                    Clip::None
+                }
+            }
+        } else {
+            Clip::None
+        };
+
+        let map = grisubal::<f64>(path, [1., 1.], clip).unwrap();
 
         let render_params = RenderParameters {
             smaa_mode: SmaaMode::Smaa1X,

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -16,28 +16,38 @@ use std::collections::{HashSet, VecDeque};
 
 pub fn clip_left<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, GrisubalError> {
     // color faces using a bfs starting on multiple nodes
-    let left_bound: Vec<DartIdentifier> = (1..cmap.n_darts() as DartIdentifier)
+    let marked = mark_faces(&cmap, Boundary::Left, Boundary::Right)?;
+
+    // save vertices & split boundary
+    delete_darts(&mut cmap, marked, Boundary::Right);
+
+    Ok(cmap)
+}
+
+// --- internals
+
+#[allow(clippy::cast_possible_truncation)]
+fn mark_faces<T: CoordsFloat>(
+    cmap: &CMap2<T>,
+    mark: Boundary,
+    other: Boundary,
+) -> Result<HashSet<FaceIdentifier>, GrisubalError> {
+    let mut marked: HashSet<FaceIdentifier> = HashSet::from([0]);
+    let mut queue: VecDeque<FaceIdentifier> = (1..cmap.n_darts() as DartIdentifier)
         .filter_map(|dart_id| {
             // use darts on the left side of the boundary as starting points to walk through faces
-            if matches!(
-                cmap.get_attribute::<Boundary>(dart_id),
-                Some(Boundary::Left),
-            ) && !cmap.is_free(dart_id)
-            {
+            if cmap.get_attribute::<Boundary>(dart_id) == Some(mark) && !cmap.is_free(dart_id) {
                 return Some(cmap.face_id(dart_id));
             }
             None
         })
         .collect();
-    let mut marked: HashSet<FaceIdentifier> = HashSet::from([0]);
-    let mut queue: VecDeque<FaceIdentifier> = VecDeque::from(left_bound.clone());
     while let Some(face_id) = queue.pop_front() {
         // mark faces
         if marked.insert(face_id) {
             // detect orientation issues / open geometries
-            let mut darts = Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier);
-            if let Some(rid) = darts
-                .find(|did| matches!(cmap.get_attribute::<Boundary>(*did), Some(Boundary::Right)))
+            let mut darts = Orbit2::new(cmap, OrbitPolicy::Face, face_id as DartIdentifier);
+            if let Some(rid) = darts.find(|did| cmap.get_attribute::<Boundary>(*did) == Some(other))
             {
                 // TODO: explain why it is an inconsistency
                 return Err(GrisubalError::InconsistentOrientation(
@@ -45,7 +55,7 @@ pub fn clip_left<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, Grisuba
                 ));
             }
             // find neighbor faces where entry darts aren't tagged
-            let darts = Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier);
+            let darts = Orbit2::new(cmap, OrbitPolicy::Face, face_id as DartIdentifier);
             queue.extend(darts.filter_map(|dart_id| {
                 if matches!(
                     cmap.get_attribute::<Boundary>(cmap.beta::<2>(dart_id)),
@@ -58,42 +68,39 @@ pub fn clip_left<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, Grisuba
         }
     }
     marked.remove(&0);
+    Ok(marked)
+}
 
-    // save vertices & split boundary
-    let right_boundary: Vec<(DartIdentifier, Vertex2<T>)> = (1..cmap.n_darts() as DartIdentifier)
+#[allow(clippy::cast_possible_truncation)]
+fn delete_darts<T: CoordsFloat>(
+    cmap: &mut CMap2<T>,
+    marked: HashSet<FaceIdentifier>,
+    kept_boundary: Boundary,
+) {
+    let kept_boundary_components: Vec<(DartIdentifier, Vertex2<T>)> = (1..cmap.n_darts()
+        as DartIdentifier)
         .filter_map(|dart_id| {
-            if matches!(
-                cmap.get_attribute::<Boundary>(dart_id),
-                Some(Boundary::Right),
-            ) {
+            if cmap.get_attribute::<Boundary>(dart_id) == Some(kept_boundary) {
                 return Some((dart_id, cmap.vertex(cmap.vertex_id(dart_id)).unwrap()));
             }
             None
         })
         .collect();
 
-    for &face_id in &marked {
+    for face_id in marked {
         let darts: Vec<DartIdentifier> =
-            Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier).collect();
+            Orbit2::new(cmap, OrbitPolicy::Face, face_id as DartIdentifier).collect();
         for &dart in &darts {
             let _ = cmap.remove_vertex(cmap.vertex_id(dart));
-        }
-    }
-
-    for &face_id in &marked {
-        let darts: Vec<DartIdentifier> =
-            Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier).collect();
-        for &dart in &darts {
             cmap.set_betas(dart, [NULL_DART_ID; 3]);
             cmap.remove_free_dart(dart);
         }
     }
-    for (dart, vertex) in right_boundary {
+
+    for (dart, vertex) in kept_boundary_components {
         let b1 = cmap.beta::<1>(dart);
         let b0 = cmap.beta::<0>(dart);
         cmap.set_betas(dart, [b0, b1, NULL_DART_ID]); // set beta2(dart) to 0
         cmap.insert_vertex(cmap.vertex_id(dart), vertex);
     }
-
-    Ok(cmap)
 }

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -24,6 +24,16 @@ pub fn clip_left<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, Grisuba
     Ok(cmap)
 }
 
+pub fn clip_right<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, GrisubalError> {
+    // color faces using a bfs starting on multiple nodes
+    let marked = mark_faces(&cmap, Boundary::Right, Boundary::Left)?;
+
+    // save vertices & split boundary
+    delete_darts(&mut cmap, marked, Boundary::Left);
+
+    Ok(cmap)
+}
+
 // --- internals
 
 #[allow(clippy::cast_possible_truncation)]

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -1,0 +1,91 @@
+//! Module short description
+//!
+//! Should you interact with this module directly?
+//!
+//! Content description if needed
+
+// ------ IMPORTS
+
+use crate::grisubal::model::Boundary;
+use crate::GrisubalError;
+use crate::GrisubalError::InconsistentOrientation;
+use honeycomb_core::{
+    CMap2, CoordsFloat, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy, NULL_DART_ID,
+};
+use std::collections::{HashSet, VecDeque};
+// ------ CONTENT
+
+pub fn clip_left<T: CoordsFloat>(mut cmap: CMap2<T>) -> Result<CMap2<T>, GrisubalError> {
+    // color faces using a bfs starting on multiple nodes
+    let left_bound: Vec<DartIdentifier> = (1..cmap.n_darts() as DartIdentifier)
+        .filter_map(|dart_id| {
+            // use darts on the left side of the boundary as starting points to walk through faces
+            if matches!(
+                cmap.get_attribute::<Boundary>(dart_id),
+                Some(Boundary::Left),
+            ) && !cmap.is_free(dart_id)
+            {
+                return Some(cmap.face_id(dart_id));
+            }
+            None
+        })
+        .collect();
+    let mut marked: HashSet<FaceIdentifier> = HashSet::from([0]);
+    let mut queue: VecDeque<FaceIdentifier> = VecDeque::from(left_bound.clone());
+    while let Some(face_id) = queue.pop_front() {
+        // mark faces
+        if marked.insert(face_id) {
+            // detect orientation issues / open geometries
+            let mut darts = Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier);
+            if let Some(rid) = darts
+                .find(|did| matches!(cmap.get_attribute::<Boundary>(*did), Some(Boundary::Right)))
+            {
+                // TODO: explain why it is an inconsistency
+                return Err(InconsistentOrientation(
+                    format!("reached right side (dart #{rid}, face #{face_id}) without crossing the boundary")
+                ));
+            }
+            // find neighbor faces where darts aren't tagged
+            queue.extend(darts.filter_map(|dart_id| {
+                if matches!(
+                    cmap.get_attribute::<Boundary>(cmap.beta::<2>(dart_id)),
+                    Some(Boundary::None)
+                ) {
+                    return Some(cmap.face_id(cmap.beta::<2>(dart_id)));
+                }
+                None
+            }));
+        }
+    }
+
+    // split the boundary & nuke all darts of marked faces
+    for &face_id in &marked {
+        let darts: Vec<DartIdentifier> =
+            Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier).collect();
+        for &dart in &darts {
+            if cmap.beta::<2>(dart) != NULL_DART_ID {
+                cmap.two_unsew(dart);
+            }
+        }
+    }
+
+    for &face_id in &marked {
+        let darts: Vec<DartIdentifier> =
+            Orbit2::new(&cmap, OrbitPolicy::Face, face_id as DartIdentifier).collect();
+        for &dart in &darts {
+            cmap.set_betas(dart, [NULL_DART_ID; 3]);
+            cmap.remove_free_dart(dart);
+        }
+    }
+    (1..cmap.n_darts() as DartIdentifier).for_each(|dart_id| {
+        // use darts on the left side of the boundary as starting points to walk through faces
+        if matches!(
+            cmap.get_attribute::<Boundary>(dart_id),
+            Some(Boundary::Right),
+        ) {
+            println!("vertex: {:#?}", cmap.vertex(cmap.vertex_id(dart_id)))
+        }
+    });
+
+    Ok(cmap)
+}

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -14,7 +14,7 @@ use std::collections::{HashSet, VecDeque};
 /// Clip content on the left side of the boundary.
 pub fn clip_left<T: CoordsFloat>(cmap: &mut CMap2<T>) -> Result<(), GrisubalError> {
     // color faces using a bfs starting on multiple nodes
-    let marked = mark_faces(&cmap, Boundary::Left, Boundary::Right)?;
+    let marked = mark_faces(cmap, Boundary::Left, Boundary::Right)?;
 
     // save vertices & split boundary
     delete_darts(cmap, marked, Boundary::Right);
@@ -25,7 +25,7 @@ pub fn clip_left<T: CoordsFloat>(cmap: &mut CMap2<T>) -> Result<(), GrisubalErro
 /// Clip content on the right side of the boundary.
 pub fn clip_right<T: CoordsFloat>(cmap: &mut CMap2<T>) -> Result<(), GrisubalError> {
     // color faces using a bfs starting on multiple nodes
-    let marked = mark_faces(&cmap, Boundary::Right, Boundary::Left)?;
+    let marked = mark_faces(cmap, Boundary::Right, Boundary::Left)?;
 
     // save vertices & split boundary
     delete_darts(cmap, marked, Boundary::Left);
@@ -56,7 +56,7 @@ fn mark_faces<T: CoordsFloat>(
         if marked.insert(face_id) {
             // detect orientation issues / open geometries
             let mut darts = Orbit2::new(cmap, OrbitPolicy::Face, face_id as DartIdentifier);
-            if let Some(_) = darts.find(|did| cmap.get_attribute::<Boundary>(*did) == Some(other)) {
+            if darts.any(|did| cmap.get_attribute::<Boundary>(did) == Some(other)) {
                 return Err(GrisubalError::InconsistentOrientation(
                     "reached other side of the boundary without crossing it".to_string(),
                 ));

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod model;
 
 // ------ IMPORTS
 
-use crate::grisubal::clip::clip_left;
+use crate::grisubal::clip::{clip_left, clip_right};
 use crate::{detect_orientation_issue, remove_redundant_poi, Clip, Geometry2};
 use honeycomb_core::{CMap2, CoordsFloat};
 use vtkio::Vtk;
@@ -124,13 +124,8 @@ pub fn grisubal<T: CoordsFloat>(
     let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes)?;
     // optional post-processing
     match clip.unwrap_or_default() {
-        Clip::All => {
-            todo!()
-        }
         Clip::Left => clip_left(cmap),
-        Clip::Right => {
-            todo!()
-        }
+        Clip::Right => clip_right(cmap),
         Clip::None => Ok(cmap),
     }
 }

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -38,10 +38,10 @@ pub(crate) mod model;
 
 // ------ IMPORTS
 
+use crate::grisubal::clip::clip_left;
 use crate::{detect_orientation_issue, remove_redundant_poi, Clip, Geometry2};
 use honeycomb_core::{CMap2, CoordsFloat};
 use vtkio::Vtk;
-
 // ------ CONTENT
 
 #[derive(Debug)]
@@ -127,18 +127,15 @@ pub fn grisubal<T: CoordsFloat>(
         Clip::All => {
             todo!()
         }
-        Clip::Left => {
-            todo!()
-        }
+        Clip::Left => clip_left(cmap),
         Clip::Right => {
             todo!()
         }
-        Clip::None => {}
+        Clip::None => Ok(cmap),
     }
-    // return result
-    Ok(cmap)
 }
 
 // ------ TESTS
+mod clip;
 #[cfg(test)]
 mod tests;

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -32,6 +32,7 @@
 
 // ------ MODULE DECLARATIONS
 
+pub(crate) mod clip;
 pub(crate) mod grid;
 pub(crate) mod kernel;
 pub(crate) mod model;
@@ -39,6 +40,7 @@ pub(crate) mod model;
 // ------ IMPORTS
 
 use crate::grisubal::clip::{clip_left, clip_right};
+use crate::grisubal::model::Boundary;
 use crate::{detect_orientation_issue, remove_redundant_poi, Clip, Geometry2};
 use honeycomb_core::{CMap2, CoordsFloat};
 use vtkio::Vtk;
@@ -125,13 +127,17 @@ pub fn grisubal<T: CoordsFloat>(
     let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes)?;
     // optional post-processing
     match clip {
-        Clip::Left => clip_left(cmap),
-        Clip::Right => clip_right(cmap),
-        Clip::None => Ok(cmap),
+        Clip::Left => clip_left(&mut cmap)?,
+        Clip::Right => clip_right(&mut cmap)?,
+        Clip::None => {}
     }
+    // remove attribute used for clipping
+    cmap.remove_attribute_storage::<Boundary>();
+
+    Ok(cmap)
 }
 
 // ------ TESTS
-mod clip;
+
 #[cfg(test)]
 mod tests;

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -99,14 +99,15 @@ pub enum GrisubalError {
 /// # use honeycomb_core::CMap2;
 /// # use honeycomb_kernels::{grisubal, Clip, GrisubalError};
 /// # fn main() -> Result<(), GrisubalError>{
-/// let cmap: CMap2<f64> = grisubal("some/path/to/geometry.vtk", [1., 1.], Some(Clip::Left))?;
+/// let cmap: CMap2<f64> = grisubal("some/path/to/geometry.vtk", [1., 1.], Clip::default())?;
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::needless_pass_by_value)]
 pub fn grisubal<T: CoordsFloat>(
     file_path: impl AsRef<std::path::Path>,
     grid_cell_sizes: [T; 2],
-    clip: Option<Clip>,
+    clip: Clip,
 ) -> Result<CMap2<T>, GrisubalError> {
     // load geometry from file
     let geometry_vtk = match Vtk::import(file_path) {
@@ -123,7 +124,7 @@ pub fn grisubal<T: CoordsFloat>(
     #[allow(unused)]
     let mut cmap = kernel::build_mesh(&mut geometry, grid_cell_sizes)?;
     // optional post-processing
-    match clip.unwrap_or_default() {
+    match clip {
         Clip::Left => clip_left(cmap),
         Clip::Right => clip_right(cmap),
         Clip::None => Ok(cmap),

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -31,8 +31,6 @@ use honeycomb_core::CMap2;
 /// input.
 #[derive(Default)]
 pub enum Clip {
-    /// Clip all elements beside the captured boundary.
-    All,
     /// Clip elements located on the left side of the oriented boundary.
     Left,
     /// Clip elements located on the right side of the oriented boundary.
@@ -152,7 +150,7 @@ impl<T: CoordsFloat> TryFrom<Vtk> for Geometry2<T> {
                                     if vids.len() != 2 {
                                         return Some(GrisubalError::BadVtkData("`Line` cell has incorrect # of vertices (!=2)"));
                                     }
-                                    segments.push((vids[0],vids[1]));
+                                    segments.push((vids[0], vids[1]));
                                     None
                                 }
                                 CellType::PolyLine =>


### PR DESCRIPTION
changes can be tested using the `grisubal` example; `<CLIP>` should be `left` or `right`, no args or anything else will default to no clipping.

```
cargo run --example grisubal <VTKFILE> <CLIP>
```

- implement the clipping step, for both side of the captured geometry
- remove the `Clip::All` (follow up of a discussion with @franck-ledoux)

The clipping step can catch orientation inconsistency for geometries with "holes" & open geometries: if requirements are verified, it should not be possible to reach the other side of the boundary without crossing it in a search algorithm. Since the first substep of clipping is a coloring algorithm, we can verify the requirements at the same time.

## Scope

- [x] Code: if relevant, add affected target

## Type of change

- [x] New feature(s)

## Necessary follow-up

- [x] Needs documentation