### PR TITLE
feat(kernel::grisubal): add support for non-null autocomputed origin

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -11,10 +11,7 @@ use std::{
     collections::{HashMap, VecDeque},
 };
 
-use crate::{
-    compute_overlapping_grid, Boundary, Geometry2, GeometryVertex, GridCellId, GrisubalError,
-    MapEdge,
-};
+use crate::{Boundary, Geometry2, GeometryVertex, GridCellId, MapEdge};
 use honeycomb_core::{
     CMap2, CMapBuilder, CoordsFloat, DartIdentifier, EdgeIdentifier, GridDescriptor, Vector2,
     Vertex2, NULL_DART_ID,
@@ -74,11 +71,12 @@ macro_rules! up_intersec {
 ///
 /// - `T: CoordsFloat` -- Floating point type used for coordinate representation.
 pub fn build_mesh<T: CoordsFloat>(
-    geometry: &mut Geometry2<T>,
+    geometry: &Geometry2<T>,
     [cx, cy]: [T; 2],
-) -> Result<CMap2<T>, GrisubalError> {
+    [nx, ny]: [usize; 2],
+    origin: Option<Vertex2<T>>,
+) -> CMap2<T> {
     // compute grid characteristics
-    let ([nx, ny], origin) = compute_overlapping_grid(geometry, [cx, cy], true)?;
     // build grid descriptor
     let ogrid = GridDescriptor::default()
         .n_cells_x(nx)
@@ -135,7 +133,7 @@ pub fn build_mesh<T: CoordsFloat>(
     insert_edges_in_map(&mut cmap, &edges);
 
     // return result
-    Ok(cmap)
+    cmap
 }
 
 // --- main kernels steps

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -10,9 +10,11 @@
 //!
 //! # Assumptions / Hypotheses
 //!
-//! - All components of the geometry are located in positive X/Y
-//! - Edges are consistently oriented (i.e. normals of edges making up a face all point
-//!   outward / inward, no mix)
+//! Boundaries are consistently oriented, i.e.:
+//! - normals of segments making up a boundary all point outward / inward, no mix
+//! - boundaries are closed
+//! - if there are nested boundaries, their orientation are consistent one with the other; this is
+//!   an extension of the first condition
 //!
 //! # Pseudo code
 //!

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -41,9 +41,10 @@ pub(crate) mod model;
 
 // ------ IMPORTS
 
-use crate::grisubal::clip::{clip_left, clip_right};
-use crate::grisubal::model::{compute_overlapping_grid, detect_orientation_issue, Boundary};
-use crate::{remove_redundant_poi, Clip, Geometry2};
+use crate::{
+    clip_left, clip_right, compute_overlapping_grid, detect_orientation_issue,
+    remove_redundant_poi, Boundary, Clip, Geometry2,
+};
 use honeycomb_core::{CMap2, CoordsFloat};
 use vtkio::Vtk;
 // ------ CONTENT

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -125,7 +125,7 @@ pub fn grisubal<T: CoordsFloat>(
 
     // compute an overlapping grid & remove redundant PoIs
     let (grid_n_cells, origin) = compute_overlapping_grid(&geometry, grid_cell_sizes, true)?;
-    remove_redundant_poi(&mut geometry, grid_cell_sizes);
+    remove_redundant_poi(&mut geometry, grid_cell_sizes, origin.unwrap_or_default());
 
     // build the map
     #[allow(unused)]

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -246,7 +246,14 @@ pub fn compute_overlapping_grid<T: CoordsFloat>(
 
     // compute characteristics of the overlapping Cartesian grid
     if allow_origin_offset {
-        todo!()
+        // create a ~one-and-a-half cell buffer to contain the geometry
+        // this, along with the `+1` below, guarantees that
+        // dart at the boundary of the grid are not intersected by the geometry
+        let og_x = min_x - len_cell_x * T::from(1.5).unwrap();
+        let og_y = min_y - len_cell_y * T::from(1.5).unwrap();
+        let n_cells_x = ((max_x - og_x) / len_cell_x).ceil().to_usize().unwrap() + 1;
+        let n_cells_y = ((max_y - og_y) / len_cell_y).ceil().to_usize().unwrap() + 1;
+        Ok(([n_cells_x, n_cells_y], Some(Vertex2(og_x, og_y))))
     } else {
         if min_x <= T::zero() {
             return Err(GrisubalError::InvalidInput(format!(

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -285,14 +285,18 @@ pub fn compute_overlapping_grid<T: CoordsFloat>(
 /// Remove from their geometry points of interest that intersect with a grid of specified dimension.
 ///
 /// This function works under the assumption that the grid is Cartesian & has its origin on `(0.0, 0.0)`.
-pub fn remove_redundant_poi<T: CoordsFloat>(geometry: &mut Geometry2<T>, [cx, cy]: [T; 2]) {
+pub fn remove_redundant_poi<T: CoordsFloat>(
+    geometry: &mut Geometry2<T>,
+    [cx, cy]: [T; 2],
+    origin: Vertex2<T>,
+) {
     // PoI that land on the grid create a number of issues; removing them is ok since we're intersecting the grid
     // at their coordinates, so the shape will be captured via intersection anyway
     geometry.poi.retain(|idx| {
         let v = geometry.vertices[*idx];
         // origin is assumed to be (0.0, 0.0)
-        let on_x_axis = (v.x() % cx).is_zero();
-        let on_y_axis = (v.y() % cy).is_zero();
+        let on_x_axis = ((v.x() - origin.x()) % cx).is_zero();
+        let on_y_axis = ((v.y() - origin.y()) % cy).is_zero();
         !(on_x_axis | on_y_axis)
     });
 }

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -244,6 +244,17 @@ pub fn compute_overlapping_grid<T: CoordsFloat>(
         max_y = max_y.max(v.y());
     });
 
+    if max_x <= min_x {
+        return Err(GrisubalError::InvalidInput(format!(
+            "bounding values along X axis are equal - min_x == max_x == {min_x:?}"
+        )));
+    }
+    if max_y <= min_y {
+        return Err(GrisubalError::InvalidInput(format!(
+            "bounding values along Y axis are equal - min_y == max_y == {min_y:?}"
+        )));
+    }
+
     // compute characteristics of the overlapping Cartesian grid
     if allow_origin_offset {
         // create a ~one-and-a-half cell buffer to contain the geometry
@@ -263,16 +274,6 @@ pub fn compute_overlapping_grid<T: CoordsFloat>(
         if min_y <= T::zero() {
             return Err(GrisubalError::InvalidInput(format!(
                 "the geometry should be entirely defined in positive Ys - min_y = {min_y:?}"
-            )));
-        }
-        if max_x <= min_x {
-            return Err(GrisubalError::InvalidInput(format!(
-                "bounding values along X axis are equal - min_x == max_x == {min_x:?}"
-            )));
-        }
-        if max_y <= min_y {
-            return Err(GrisubalError::InvalidInput(format!(
-                "bounding values along Y axis are equal - min_y == max_y == {min_y:?}"
             )));
         }
         let n_cells_x = (max_x / len_cell_x).ceil().to_usize().unwrap() + 1;

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -140,7 +140,7 @@ fn regular_intersections() {
     };
 
     let (segments, intersection_metadata) =
-        generate_intersection_data(&mut cmap, &geometry, [2, 2], [1.0, 1.0]);
+        generate_intersection_data(&mut cmap, &geometry, [2, 2], [1.0, 1.0], None);
 
     assert_eq!(intersection_metadata.len(), 4);
     // FIXME: INDEX ACCESSES WON'T WORK IN PARALLEL
@@ -277,7 +277,7 @@ fn corner_intersection() {
     };
 
     let (segments, intersection_metadata) =
-        generate_intersection_data(&mut cmap, &geometry, [2, 2], [1.0, 1.0]);
+        generate_intersection_data(&mut cmap, &geometry, [2, 2], [1.0, 1.0], None);
 
     assert_eq!(intersection_metadata.len(), 2);
     assert_eq!(intersection_metadata[0], (2, 0.5));

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -31,6 +31,7 @@ pub use grisubal::{grisubal, model::Clip, GrisubalError};
 
 // --- INTERNALS
 
+pub(crate) use grisubal::clip::{clip_left, clip_right};
 pub(crate) use grisubal::grid::GridCellId;
 pub(crate) use grisubal::model::{
     compute_overlapping_grid, detect_orientation_issue, remove_redundant_poi, Boundary, Geometry2,


### PR DESCRIPTION
this change allows us to drop one assumption about the input geometry: it can now be defined in any range of X/Y values instead of in a strictly positive domain. A ""

## Scope

- [x] Code: if relevant, add affected target

## Type of change

- [x] New feature(s)

## Necessary follow-up

- [x] Other: vertices are manually shifted to the new origin after map init; instead, non-null origin for a grid map should be directly implemented in the `GridDescriptor` struct & the builder of the core crate
