### PR TITLE
fix(kernel::grisubal): correct range & macro calls for `man_dist > 1` intersection case

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -336,8 +336,8 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                         // the pair at respective relative positions 1 and 0 (or 0 and 1)
                         let i_base = c1.0 as isize;
                         let j_base = c1.1 as isize;
-                        let i_cell_range = min(i_base, i_base + 1 + i)..max(i_base + i, i_base + 1);
-                        let j_cell_range = min(j_base, j_base + 1 + j)..max(j_base + j, j_base + 1);
+                        let i_cell_range = min(i_base, i_base + i)..=max(i_base + i, i_base);
+                        let j_cell_range = min(j_base, j_base + j)..=max(j_base + j, j_base);
                         let subgrid_cells =
                             i_cell_range.flat_map(|x| j_cell_range.clone().map(move |y| (x, y)));
 

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -362,9 +362,9 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                     left_intersec!(v1, v2, v_vdart, cy)
                                 };
                                 let h_coeffs = if j.is_positive() {
-                                    right_intersec!(v1, v2, v_hdart, cx)
+                                    up_intersec!(v1, v2, v_hdart, cx)
                                 } else {
-                                    left_intersec!(v1, v2, v_hdart, cx)
+                                    down_intersec!(v1, v2, v_hdart, cx)
                                 };
 
                                 (hdart_id, vdart_id, v_coeffs, h_coeffs)

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     clip_left, clip_right, compute_overlapping_grid, detect_orientation_issue,
     remove_redundant_poi, Boundary, Clip, Geometry2,
 };
-use honeycomb_core::{CMap2, CoordsFloat};
+use honeycomb_core::{CMap2, CoordsFloat, Vertex2};
 use vtkio::Vtk;
 // ------ CONTENT
 
@@ -121,7 +121,29 @@ pub fn grisubal<T: CoordsFloat>(
     };
 
     // pre-processing
-    let mut geometry = Geometry2::try_from(geometry_vtk)?;
+    let mut geometry = Geometry2 {
+        vertices: vec![
+            Vertex2(T::from(1.33).unwrap(), T::from(0.5).unwrap()),
+            Vertex2(T::from(1.66).unwrap(), T::from(0.5).unwrap()),
+            Vertex2(T::from(2.5).unwrap(), T::from(1.33).unwrap()),
+            Vertex2(T::from(2.5).unwrap(), T::from(1.66).unwrap()),
+            Vertex2(T::from(1.66).unwrap(), T::from(2.5).unwrap()),
+            Vertex2(T::from(1.33).unwrap(), T::from(2.5).unwrap()),
+            Vertex2(T::from(0.5).unwrap(), T::from(1.66).unwrap()),
+            Vertex2(T::from(0.5).unwrap(), T::from(1.33).unwrap()),
+        ],
+        segments: vec![
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (7, 0),
+        ],
+        poi: vec![0, 1, 2, 3, 4, 5, 6, 7],
+    };
     detect_orientation_issue(&geometry)?;
 
     // compute an overlapping grid & remove redundant PoIs

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     clip_left, clip_right, compute_overlapping_grid, detect_orientation_issue,
     remove_redundant_poi, Boundary, Clip, Geometry2,
 };
-use honeycomb_core::{CMap2, CoordsFloat, Vertex2};
+use honeycomb_core::{CMap2, CoordsFloat};
 use vtkio::Vtk;
 // ------ CONTENT
 
@@ -121,29 +121,7 @@ pub fn grisubal<T: CoordsFloat>(
     };
 
     // pre-processing
-    let mut geometry = Geometry2 {
-        vertices: vec![
-            Vertex2(T::from(1.33).unwrap(), T::from(0.5).unwrap()),
-            Vertex2(T::from(1.66).unwrap(), T::from(0.5).unwrap()),
-            Vertex2(T::from(2.5).unwrap(), T::from(1.33).unwrap()),
-            Vertex2(T::from(2.5).unwrap(), T::from(1.66).unwrap()),
-            Vertex2(T::from(1.66).unwrap(), T::from(2.5).unwrap()),
-            Vertex2(T::from(1.33).unwrap(), T::from(2.5).unwrap()),
-            Vertex2(T::from(0.5).unwrap(), T::from(1.66).unwrap()),
-            Vertex2(T::from(0.5).unwrap(), T::from(1.33).unwrap()),
-        ],
-        segments: vec![
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 4),
-            (4, 5),
-            (5, 6),
-            (6, 7),
-            (7, 0),
-        ],
-        poi: vec![0, 1, 2, 3, 4, 5, 6, 7],
-    };
+    let mut geometry = Geometry2::try_from(geometry_vtk)?;
     detect_orientation_issue(&geometry)?;
 
     // compute an overlapping grid & remove redundant PoIs

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -414,6 +414,7 @@ pub enum GeometryVertex {
     IntersecCorner(DartIdentifier),
 }
 
+#[derive(Debug)]
 pub struct MapEdge<T: CoordsFloat> {
     pub start: DartIdentifier,
     pub intermediates: Vec<Vertex2<T>>,

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -407,7 +407,7 @@ pub fn successive_straight_intersections() {
     // same as the one of the `regular_intersections`, so we won't repeat the assertions
     let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
 
-    let mut edges = generate_edge_data(&mut cmap, &geometry, &segments, &intersection_darts);
+    let edges = generate_edge_data(&mut cmap, &geometry, &segments, &intersection_darts);
 
     assert_eq!(edges.len(), 8);
     assert_eq!(

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -1,14 +1,13 @@
 // ------ IMPORTS
 
-use honeycomb_core::{CMapBuilder, GridDescriptor, Orbit2, OrbitPolicy, Vertex2};
-use vtkio::Vtk;
-
 use crate::{
     grisubal::kernel::{
         generate_edge_data, generate_intersection_data, insert_edges_in_map, insert_intersections,
     },
     Boundary, Geometry2, GeometryVertex,
 };
+use honeycomb_core::{CMapBuilder, GridDescriptor, Orbit2, OrbitPolicy, Vertex2};
+use vtkio::Vtk;
 
 // ------ CONTENT
 
@@ -376,4 +375,215 @@ fn corner_intersection() {
     assert!(face13_vertices.contains(&Vertex2(1.0, 1.0)));
     assert!(face13_vertices.contains(&Vertex2(1.5, 1.0)));
     assert!(face13_vertices.contains(&Vertex2(1.5, 1.5)));
+}
+
+#[allow(clippy::too_many_lines)]
+#[test]
+pub fn successive_straight_intersections() {
+    let mut cmap = CMapBuilder::from_grid_descriptor(
+        GridDescriptor::default()
+            .len_per_cell([1.0; 3])
+            .n_cells([3; 3]),
+    )
+    .add_attribute::<Boundary>()
+    .build()
+    .unwrap();
+
+    // square where each corner belong to non-neighboring cells
+    let geometry = Geometry2 {
+        vertices: vec![
+            Vertex2(0.5, 0.5),
+            Vertex2(2.5, 0.5),
+            Vertex2(2.5, 2.5),
+            Vertex2(0.5, 2.5),
+        ],
+        segments: vec![(0, 1), (1, 2), (2, 3), (3, 0)],
+        poi: vec![0, 1, 2, 3],
+    };
+
+    let (segments, intersection_metadata) =
+        generate_intersection_data(&mut cmap, &geometry, [3, 3], [1.0, 1.0], None);
+
+    // same as the one of the `regular_intersections`, so we won't repeat the assertions
+    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+
+    let mut edges = generate_edge_data(&mut cmap, &geometry, &segments, &intersection_darts);
+
+    assert_eq!(edges.len(), 8);
+    assert_eq!(
+        edges
+            .iter()
+            .filter(|edge| !edge.intermediates.is_empty())
+            .count(),
+        4
+    );
+
+    insert_edges_in_map(&mut cmap, &edges);
+
+    // bottom row
+
+    let face1_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 1)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face1_vertices.len(), 6);
+    assert!(face1_vertices.contains(&Vertex2(0.0, 0.0)));
+    assert!(face1_vertices.contains(&Vertex2(1.0, 0.0)));
+    assert!(face1_vertices.contains(&Vertex2(1.0, 0.5)));
+    assert!(face1_vertices.contains(&Vertex2(0.5, 0.5)));
+    assert!(face1_vertices.contains(&Vertex2(0.5, 1.0)));
+    assert!(face1_vertices.contains(&Vertex2(0.0, 1.0)));
+
+    let face3_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 3)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face3_vertices.len(), 4);
+    assert!(face3_vertices.contains(&Vertex2(0.5, 0.5)));
+    assert!(face3_vertices.contains(&Vertex2(1.0, 0.5)));
+    assert!(face3_vertices.contains(&Vertex2(1.0, 1.0)));
+    assert!(face3_vertices.contains(&Vertex2(0.5, 1.0)));
+
+    let face5_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 5)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face5_vertices.len(), 4);
+    assert!(face5_vertices.contains(&Vertex2(1.0, 0.0)));
+    assert!(face5_vertices.contains(&Vertex2(2.0, 0.0)));
+    assert!(face5_vertices.contains(&Vertex2(2.0, 0.5)));
+    assert!(face5_vertices.contains(&Vertex2(1.0, 0.5)));
+
+    let face7_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 7)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face7_vertices.len(), 4);
+    assert!(face7_vertices.contains(&Vertex2(1.0, 1.0)));
+    assert!(face7_vertices.contains(&Vertex2(2.0, 1.0)));
+    assert!(face7_vertices.contains(&Vertex2(2.0, 0.5)));
+    assert!(face7_vertices.contains(&Vertex2(1.0, 0.5)));
+
+    let face9_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 9)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face9_vertices.len(), 6);
+    assert!(face9_vertices.contains(&Vertex2(2.0, 0.0)));
+    assert!(face9_vertices.contains(&Vertex2(3.0, 0.0)));
+    assert!(face9_vertices.contains(&Vertex2(3.0, 1.0)));
+    assert!(face9_vertices.contains(&Vertex2(2.5, 1.0)));
+    assert!(face9_vertices.contains(&Vertex2(2.5, 0.5)));
+    assert!(face9_vertices.contains(&Vertex2(2.0, 0.5)));
+
+    let face12_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 12)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face12_vertices.len(), 4);
+    assert!(face12_vertices.contains(&Vertex2(2.0, 0.5)));
+    assert!(face12_vertices.contains(&Vertex2(2.5, 0.5)));
+    assert!(face12_vertices.contains(&Vertex2(2.5, 1.0)));
+    assert!(face12_vertices.contains(&Vertex2(2.0, 1.0)));
+
+    // middle row
+
+    let face13_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 13)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face13_vertices.len(), 4);
+    assert!(face13_vertices.contains(&Vertex2(0.0, 2.0)));
+    assert!(face13_vertices.contains(&Vertex2(0.0, 1.0)));
+    assert!(face13_vertices.contains(&Vertex2(0.5, 1.0)));
+    assert!(face13_vertices.contains(&Vertex2(0.5, 2.0)));
+
+    let face14_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 14)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face14_vertices.len(), 4);
+    assert!(face14_vertices.contains(&Vertex2(0.5, 1.0)));
+    assert!(face14_vertices.contains(&Vertex2(0.5, 2.0)));
+    assert!(face14_vertices.contains(&Vertex2(1.0, 2.0)));
+    assert!(face14_vertices.contains(&Vertex2(1.0, 1.0)));
+
+    let face17_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 17)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face17_vertices.len(), 4);
+    assert!(face17_vertices.contains(&Vertex2(1.0, 1.0)));
+    assert!(face17_vertices.contains(&Vertex2(1.0, 2.0)));
+    assert!(face17_vertices.contains(&Vertex2(2.0, 2.0)));
+    assert!(face17_vertices.contains(&Vertex2(2.0, 1.0)));
+
+    let face21_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 21)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face21_vertices.len(), 4);
+    assert!(face21_vertices.contains(&Vertex2(2.0, 1.0)));
+    assert!(face21_vertices.contains(&Vertex2(2.5, 1.0)));
+    assert!(face21_vertices.contains(&Vertex2(2.5, 2.0)));
+    assert!(face21_vertices.contains(&Vertex2(2.0, 2.0)));
+
+    let face22_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 22)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face22_vertices.len(), 4);
+    assert!(face22_vertices.contains(&Vertex2(2.5, 1.0)));
+    assert!(face22_vertices.contains(&Vertex2(2.5, 2.0)));
+    assert!(face22_vertices.contains(&Vertex2(3.0, 2.0)));
+    assert!(face22_vertices.contains(&Vertex2(3.0, 1.0)));
+
+    // top row
+
+    let face25_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 25)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face25_vertices.len(), 6);
+    assert!(face25_vertices.contains(&Vertex2(0.0, 2.0)));
+    assert!(face25_vertices.contains(&Vertex2(0.5, 2.0)));
+    assert!(face25_vertices.contains(&Vertex2(0.5, 2.5)));
+    assert!(face25_vertices.contains(&Vertex2(1.0, 2.5)));
+    assert!(face25_vertices.contains(&Vertex2(1.0, 3.0)));
+    assert!(face25_vertices.contains(&Vertex2(0.0, 3.0)));
+
+    let face26_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 26)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face26_vertices.len(), 4);
+    assert!(face26_vertices.contains(&Vertex2(0.5, 2.0)));
+    assert!(face26_vertices.contains(&Vertex2(1.0, 2.0)));
+    assert!(face26_vertices.contains(&Vertex2(1.0, 2.5)));
+    assert!(face26_vertices.contains(&Vertex2(0.5, 2.5)));
+
+    let face29_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 29)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face29_vertices.len(), 4);
+    assert!(face29_vertices.contains(&Vertex2(1.0, 2.0)));
+    assert!(face29_vertices.contains(&Vertex2(2.0, 2.0)));
+    assert!(face29_vertices.contains(&Vertex2(2.0, 2.5)));
+    assert!(face29_vertices.contains(&Vertex2(1.0, 2.5)));
+
+    let face31_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 31)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face31_vertices.len(), 4);
+    assert!(face31_vertices.contains(&Vertex2(2.0, 2.5)));
+    assert!(face31_vertices.contains(&Vertex2(1.0, 2.5)));
+    assert!(face31_vertices.contains(&Vertex2(1.0, 3.0)));
+    assert!(face31_vertices.contains(&Vertex2(2.0, 3.0)));
+
+    let face33_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 33)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face33_vertices.len(), 4);
+    assert!(face33_vertices.contains(&Vertex2(2.0, 2.0)));
+    assert!(face33_vertices.contains(&Vertex2(2.0, 2.5)));
+    assert!(face33_vertices.contains(&Vertex2(2.5, 2.5)));
+    assert!(face33_vertices.contains(&Vertex2(2.5, 2.0)));
+
+    let face34_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 34)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face34_vertices.len(), 6);
+    assert!(face34_vertices.contains(&Vertex2(2.5, 2.0)));
+    assert!(face34_vertices.contains(&Vertex2(3.0, 2.0)));
+    assert!(face34_vertices.contains(&Vertex2(3.0, 3.0)));
+    assert!(face34_vertices.contains(&Vertex2(2.0, 3.0)));
+    assert!(face34_vertices.contains(&Vertex2(2.0, 2.5)));
+    assert!(face34_vertices.contains(&Vertex2(2.5, 2.5)));
 }

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -587,3 +587,151 @@ pub fn successive_straight_intersections() {
     assert!(face34_vertices.contains(&Vertex2(2.0, 2.5)));
     assert!(face34_vertices.contains(&Vertex2(2.5, 2.5)));
 }
+
+#[allow(clippy::too_many_lines)]
+#[test]
+pub fn successive_diag_intersections() {
+    let mut cmap = CMapBuilder::from_grid_descriptor(
+        GridDescriptor::default()
+            .len_per_cell([1.0; 3])
+            .n_cells([3; 3]),
+    )
+    .add_attribute::<Boundary>()
+    .build()
+    .unwrap();
+
+    // square where each corner belong to non-neighboring cells
+    let geometry = Geometry2 {
+        vertices: vec![
+            Vertex2(1.33, 0.5),
+            Vertex2(1.66, 0.5),
+            Vertex2(2.5, 1.33),
+            Vertex2(2.5, 1.66),
+            Vertex2(1.66, 2.5),
+            Vertex2(1.33, 2.5),
+            Vertex2(0.5, 1.66),
+            Vertex2(0.5, 1.33),
+        ],
+        segments: vec![
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (7, 0),
+        ],
+        poi: vec![0, 1, 2, 3, 4, 5, 6, 7],
+    };
+
+    let (segments, intersection_metadata) =
+        generate_intersection_data(&mut cmap, &geometry, [3, 3], [1.0, 1.0], None);
+
+    // same as the one of the `regular_intersections`, so we won't repeat the assertions
+    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+
+    let mut edges = generate_edge_data(&mut cmap, &geometry, &segments, &intersection_darts);
+
+    assert_eq!(edges.len(), 8);
+    assert_eq!(
+        edges
+            .iter()
+            .filter(|edge| !edge.intermediates.is_empty())
+            .count(),
+        4
+    );
+
+    insert_edges_in_map(&mut cmap, &edges);
+
+    // bottom row
+
+    let face1_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 1)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face1_vertices.len(), 5);
+
+    let face3_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 3)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face3_vertices.len(), 3);
+
+    let face5_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 5)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face5_vertices.len(), 6);
+
+    let face7_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 7)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face7_vertices.len(), 6);
+
+    let face9_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 9)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face9_vertices.len(), 5);
+
+    let face12_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 12)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face12_vertices.len(), 3);
+
+    // middle row
+
+    let face13_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 13)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face13_vertices.len(), 6);
+
+    let face14_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 14)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face14_vertices.len(), 6);
+
+    let face17_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 17)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face17_vertices.len(), 4);
+
+    let face21_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 21)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face21_vertices.len(), 6);
+
+    let face22_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 22)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face22_vertices.len(), 6);
+
+    // top row
+
+    let face25_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 25)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face25_vertices.len(), 5);
+
+    let face26_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 26)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face26_vertices.len(), 3);
+
+    let face29_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 29)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face29_vertices.len(), 6);
+
+    let face31_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 31)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face31_vertices.len(), 6);
+
+    let face33_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 33)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face33_vertices.len(), 3);
+
+    let face34_vertices: Vec<Vertex2<f64>> = Orbit2::new(&cmap, OrbitPolicy::Face, 34)
+        .map(|d| cmap.vertex(cmap.vertex_id(d)).expect("E: unreachable"))
+        .collect();
+    assert_eq!(face34_vertices.len(), 5);
+}


### PR DESCRIPTION
There were two mistakes in the `man_dist > 1` branch:
- ranges used to build the subgrid cell list were both one element short
-  top/down intersections were computed using the left/right macros instead of the correct ones

with this PR, all correctly oriented 2D shapes hosted [here](https://github.com/claireroche/Geometries) and [here](https://github.com/imrn99/meshing-samples) yield a correct result through `grisubal`

## Scope

- [x] Code

## Type of change

- [x] Fix; closes #110 