### PR TITLE
chore: add new profile dedicated to profiling (e.g. `perf`, flamegraphes, ...)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,7 @@ egui_dock = "0.13.0"
 
 [profile.bench]
 debug = true
+
+[profile.profiling]
+inherits = "release"
+debug = true


### PR DESCRIPTION
this prevents packing debug info in release builds (which has a great cost when using the render tool)