### PR TITLE
feat: add a main crate to provide a clean user API

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,12 +32,22 @@ jobs:
       # generate raw coverage data
       # excluding the benchmark / example crates to remove some bias
       - name: Build code
-        run: cargo build --all-features --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
+        run: |
+          cargo build --all-features --workspace \
+            --exclude honeycomb \
+            --exclude honeycomb-benches \
+            --exclude honeycomb-examples \
+            --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
       - name: Run tests
-        run: cargo test --all-features --workspace --exclude honeycomb-benches --exclude honeycomb-examples --exclude honeycomb-render
+        run: |
+          cargo build --all-features --workspace \
+            --exclude honeycomb \
+            --exclude honeycomb-benches \
+            --exclude honeycomb-examples \
+            --exclude honeycomb-render
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
       - name: Run tests
         run: |
-          cargo build --all-features --workspace \
+          cargo test --all-features --workspace \
             --exclude honeycomb \
             --exclude honeycomb-benches \
             --exclude honeycomb-examples \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = "2"
 members = [
     "benches",
+    "honeycomb",
     "honeycomb-core",
     "honeycomb-kernels",
     "honeycomb-render",
@@ -26,6 +27,7 @@ authors = [
 
 [workspace.dependencies]
 # members
+honeycomb = { version = "0.5.0", path = "./honeycomb" }
 honeycomb-benches = { version = "0.5.0", path = "./benches" }
 honeycomb-core = { version = "0.5.0", path = "./honeycomb-core" }
 honeycomb-kernels = { version = "0.5.0", path = "./honeycomb-kernels" }

--- a/honeycomb/Cargo.toml
+++ b/honeycomb/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "honeycomb"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+description.workspace = true
+categories.workspace = true
+keywords.workspace = true
+authors.workspace = true
+publish = true
+
+[features]
+default = ["kernels"]
+kernels = ["dep:honeycomb-kernels"]
+render = ["dep:honeycomb-render"]
+
+[dependencies]
+honeycomb-core = { workspace = true, features = ["io", "utils"] }
+honeycomb-kernels = { workspace = true, optional = true }
+honeycomb-render = { workspace = true, optional = true }

--- a/honeycomb/src/build.rs
+++ b/honeycomb/src/build.rs
@@ -1,0 +1,18 @@
+#[rustversion::nightly]
+fn set_rustc_channel_cfg() -> &'static str {
+    "nightly"
+}
+
+#[rustversion::beta]
+fn set_rustc_channel_cfg() -> &'static str {
+    "beta"
+}
+
+#[rustversion::stable]
+fn set_rustc_channel_cfg() -> &'static str {
+    "stable"
+}
+
+fn main() {
+    println!("cargo:rustc-cfg={}", set_rustc_channel_cfg());
+}

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -1,0 +1,19 @@
+//!
+
+pub use honeycomb_core as core;
+
+#[cfg(feature = "kernels")]
+pub use honeycomb_kernels as kernels;
+
+#[cfg(feature = "render")]
+pub use honeycomb_render as render;
+
+pub mod prelude {
+    pub use honeycomb_core::prelude::*;
+
+    #[cfg(feature = "kernels")]
+    pub use honeycomb_kernels::grisubal;
+
+    #[cfg(feature = "render")]
+    pub use honeycomb_render::App;
+}

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -9,10 +9,22 @@ pub use honeycomb_kernels as kernels;
 pub use honeycomb_render as render;
 
 pub mod prelude {
-    pub use honeycomb_core::prelude::*;
+    // ------ CORE RE-EXPORTS
+
+    pub use honeycomb_core::attributes::{AttributeBind, AttributeUpdate};
+    pub use honeycomb_core::cmap::{
+        BuilderError, CMap2, CMapBuilder, CMapError, DartIdentifier, EdgeIdentifier,
+        FaceIdentifier, GridDescriptor, Orbit2, OrbitPolicy, VertexIdentifier, VolumeIdentifier,
+        NULL_DART_ID, NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
+    };
+    pub use honeycomb_core::geometry::{CoordsError, CoordsFloat, Vector2, Vertex2};
+
+    // ------ KERNELS RE-EXPORTS
 
     #[cfg(feature = "kernels")]
     pub use honeycomb_kernels::grisubal;
+
+    // ------ RENDER RE-EXPORTS
 
     #[cfg(feature = "render")]
     pub use honeycomb_render::App;

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -26,6 +26,10 @@
 //! - the `render` feature is disabled by default; enabling it significantly lengthen the
 //!   dependency tree as well as the compilation time.
 
+// --- enable doc_auto_cfg feature if compiling in nightly
+#![allow(unexpected_cfgs)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
+
 pub use honeycomb_core as core;
 
 #[cfg(feature = "kernels")]

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -25,6 +25,15 @@
 //!   than the core crate.
 //! - the `render` feature is disabled by default; enabling it significantly lengthen the
 //!   dependency tree as well as the compilation time.
+//!
+//! ## Quickstart
+//!
+//! For usage examples, refer to examples hosted in the repository; there also are documentation
+//! examples for important items:
+//!
+//! - [`CMap2`][honeycomb_core::cmap::CMap2]
+//! - [`CMapBuilder`][honeycomb_core::cmap::CMapBuilder]
+//! - [`grisubal`][`honeycomb_kernels::grisubal`]
 
 // --- enable doc_auto_cfg feature if compiling in nightly
 #![allow(unexpected_cfgs)]

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -1,4 +1,30 @@
+//! # honeycomb
 //!
+//! Honeycomb aims to provide a safe, efficient and scalable implementation of combinatorial maps
+//! for meshing applications. More specifically, the goal is to converge towards a (or multiple)
+//! structure(s) adapted to algorithms exploiting GPU and many-core architectures.
+//!
+//! ## Structure
+//!
+//! This crate acts as the user-facing API, re-exporting components and items implemented in the
+//! following sub-crates:
+//!
+//! - `honeycomb_core` -- core structures implementations
+//! - `honeycomb_kernels` -- algorithm implementations
+//! - `honeycomb_render` -- visual debugging tool
+//!
+//! ## Features
+//!
+//! Two features can be enabled to control which implementations are exposed:
+//!
+//! - `kernels` -- content from the `honeycomb_kernels` crate
+//! - `render` -- content from the `honeycomb_render` crate
+//!
+//! Note that:
+//! - the `kernels` feature is enabled by default since it does not require any more dependencies
+//!   than the core crate.
+//! - the `render` feature is disabled by default; enabling it significantly lengthen the
+//!   dependency tree as well as the compilation time.
 
 pub use honeycomb_core as core;
 
@@ -8,6 +34,11 @@ pub use honeycomb_kernels as kernels;
 #[cfg(feature = "render")]
 pub use honeycomb_render as render;
 
+/// commonly used items
+///
+/// This module contains all items commonly used to write a program using combinatorial maps.
+/// These items are re-exported from their original crates for ease of use and should cover
+/// all basic use cases.
 pub mod prelude {
     // ------ CORE RE-EXPORTS
 


### PR DESCRIPTION
This PR adds a new crate: `honeycomb`. It is only made up of re-exports from the core, kernels and render crates. The goal is to provide a single dependency for users in order to (a) simplify usage, (b) avoid dependency issues where the user disable features of a crate only for another crate to enable those back.

All items of the respective core, kernels & render crate are accessible through re-exports; Additionally, a `prelude` module is defined with commonly used items.

Ideally, this crate can be published with `1.0.0`; I just need to try and get the `honeycomb` package name from crates.io since the current project using it looks dead.

## Scope

- [x] Repository

## Type of change

- [x] New feature(s)
