### PR TITLE
fix(core): correct face computation in serializing code

### DIFF
--- a/honeycomb-core/src/cmap/dim2/io.rs
+++ b/honeycomb-core/src/cmap/dim2/io.rs
@@ -101,7 +101,7 @@ where
     let face_data = face_ids.into_iter().map(|id| {
         let mut count: u32 = 0;
         // VecDeque will be useful later
-        let orbit: Vec<u32> = Orbit2::new(map, OrbitPolicy::Face, id as DartIdentifier)
+        let orbit: Vec<u32> = Orbit2::new(map, OrbitPolicy::Custom(&[1]), id as DartIdentifier)
             .map(|dart_id| {
                 count += 1;
                 id_map[&map.vertex_id(dart_id)] as u32


### PR DESCRIPTION
vertex list of each face was computed using `Orbit2::Face`; This was incorrect since this orbit is defined by a BFS using both beta 0 and beta 1.

Points should be ordered sequentially for the VTK cells used to serialize maps, so I replaced the predefined orbit with a custom one which uses a single beta function to cycle through the vertices.