### PR TITLE
refactor(core): improve some error enums

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -11,13 +11,6 @@ use std::{any::TypeId, collections::HashMap};
 
 // ------ CONTENT
 
-/// Attribute manager error enum.
-#[derive(Debug)]
-pub enum ManagerError {
-    /// Storage of a given type already exists in the structure.
-    DuplicateStorage,
-}
-
 /// Main attribute storage structure.
 ///
 /// This structure is used to store all generic attributes that the user may add to the
@@ -367,10 +360,7 @@ impl AttrStorageManager {
     /// - `Ok(())` if the storage was successfully added,
     /// - `Err(ManagerError::DuplicateStorage)` if there was already a storage for the specified
     ///   attribute.
-    pub fn add_storage<A: AttributeBind + 'static>(
-        &mut self,
-        size: usize,
-    ) -> Result<(), ManagerError> {
+    pub fn add_storage<A: AttributeBind + 'static>(&mut self, size: usize) {
         let typeid = TypeId::of::<A>();
         let new_storage = <A as AttributeBind>::StorageType::new(size);
         if match A::binds_to() {
@@ -381,9 +371,10 @@ impl AttrStorageManager {
         }
         .is_some()
         {
-            Err(ManagerError::DuplicateStorage)
-        } else {
-            Ok(())
+            panic!(
+                "E: Storage of attribute `{}` already exists in the attribute storage manager",
+                std::any::type_name::<A>()
+            );
         }
     }
 

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -9,7 +9,7 @@ mod manager;
 mod traits;
 
 pub use collections::{AttrCompactVec, AttrSparseVec};
-pub use manager::{AttrStorageManager, ManagerError};
+pub use manager::AttrStorageManager;
 pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
 
 // ------ TESTS

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -447,7 +447,7 @@ fn compact_vec_replace_already_removed() {
 macro_rules! generate_manager {
     ($name: ident) => {
         let mut $name = AttrStorageManager::default();
-        assert!($name.add_storage::<Temperature>(10).is_ok());
+        $name.add_storage::<Temperature>(10);
         $name.insert_attribute(0, Temperature::from(273.0));
         $name.insert_attribute(1, Temperature::from(275.0));
         $name.insert_attribute(2, Temperature::from(277.0));

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -92,9 +92,7 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     /// and [here](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)
     #[must_use = "unused builder object, consider removing this method call"]
     pub fn add_attribute<A: AttributeBind + 'static>(mut self) -> Self {
-        if self.attributes.add_storage::<A>(0).is_err() {
-            println!("W: attribute already added to the builder - continuing...");
-        }
+        self.attributes.add_storage::<A>(self.n_darts);
         self
     }
 }

--- a/honeycomb-core/src/geometry/mod.rs
+++ b/honeycomb-core/src/geometry/mod.rs
@@ -25,10 +25,14 @@ pub use vertex::Vertex2;
 /// Coordinates-level error enum
 #[derive(Debug, PartialEq)]
 pub enum CoordsError {
-    /// Error during the computation of the unit directional vector.
+    /// Error during the computation of the unit direction vector.
     ///
     /// This is returned when trying to compute the unit vector of a null [`Vector2`].
     InvalidUnitDir,
+    /// Error during the computation of the normal direction vector.
+    ///
+    /// This is returned when trying to compute the normal to a null [`Vector2`].
+    InvalidNormDir,
 }
 
 // --- generic fp repersentation trait

--- a/honeycomb-core/src/geometry/tests.rs
+++ b/honeycomb-core/src/geometry/tests.rs
@@ -104,7 +104,7 @@ mod vector {
                     -Vector2::<$t>::unit_x()
                 )));
                 let origin: Vector2<$t> = Vector2::default();
-                assert_eq!(origin.normal_dir(), Err(CoordsError::InvalidUnitDir));
+                assert_eq!(origin.normal_dir(), Err(CoordsError::InvalidNormDir));
             }
         };
     }

--- a/honeycomb-core/src/geometry/vector.rs
+++ b/honeycomb-core/src/geometry/vector.rs
@@ -25,7 +25,7 @@ use super::{CoordsError, CoordsFloat};
 /// let unit_y = Vector2::unit_y();
 ///
 /// assert_eq!(unit_x.dot(&unit_y), 0.0);
-/// assert_eq!(unit_x.normal_dir().unwrap(), unit_y);
+/// assert_eq!(unit_x.normal_dir()?, unit_y);
 ///
 /// let two: f64 = 2.0;
 /// let x_plus_y: Vector2<f64> = unit_x + unit_y;
@@ -149,7 +149,9 @@ impl<T: CoordsFloat> Vector2<T> {
     /// See [Vector2] example.
     ///
     pub fn normal_dir(&self) -> Result<Vector2<T>, CoordsError> {
-        Self(-self.1, self.0).unit_dir() // unit(-y, x)
+        Self(-self.1, self.0)
+            .unit_dir() // unit(-y, x)
+            .map_err(|_| CoordsError::InvalidNormDir)
     }
 
     /// Compute the dot product between two vectors


### PR DESCRIPTION
- add a variant to `CoordsError` to distinguish failure in unit vector computation vs normal vector computation
- remove `ManagerError`; panicking is probably fine since the error is thrown at init, not during the execution of an algorithm

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Other

- [x] Breaking change

## Necessary follow-up

- [x] Other: the `CMapError` should also be removed, but it will result in significant changes, so it will be in another PR
