### PR TITLE
feat(core): add utility method `set_beta` to `CMap2`

### DIFF
--- a/honeycomb-core/src/cmap/dim2/utils.rs
+++ b/honeycomb-core/src/cmap/dim2/utils.rs
@@ -20,7 +20,7 @@ use std::{fs::File, io::Write};
 
 /// **Utilities**
 impl<T: CoordsFloat> CMap2<T> {
-    /// Set the values of the specified beta function of a dart.
+    /// Set the value of the specified beta function of a dart.
     ///
     /// # Arguments
     ///

--- a/honeycomb-core/src/cmap/dim2/utils.rs
+++ b/honeycomb-core/src/cmap/dim2/utils.rs
@@ -20,6 +20,21 @@ use std::{fs::File, io::Write};
 
 /// **Utilities**
 impl<T: CoordsFloat> CMap2<T> {
+    /// Set the values of the specified beta function of a dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- ID of the dart of interest.
+    /// - `val: DartIdentifier` -- Value of the image of `dart_id` through the beta `I` function.
+    ///
+    /// ## Generic
+    ///
+    /// - `const I: u8` -- Beta function to edit.
+    ///
+    pub fn set_beta<const I: u8>(&mut self, dart_id: DartIdentifier, val: DartIdentifier) {
+        self.betas[dart_id as usize][I as usize] = val;
+    }
+
     /// Set the values of the beta functions of a dart.
     ///
     /// # Arguments

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -104,9 +104,7 @@ fn delete_darts<T: CoordsFloat>(
     }
 
     for (dart, vertex) in kept_boundary_components {
-        let b1 = cmap.beta::<1>(dart);
-        let b0 = cmap.beta::<0>(dart);
-        cmap.set_betas(dart, [b0, b1, NULL_DART_ID]); // set beta2(dart) to 0
+        cmap.set_beta::<2>(dart, NULL_DART_ID); // set beta2(dart) to 0
         cmap.insert_vertex(cmap.vertex_id(dart), vertex);
     }
 }


### PR DESCRIPTION
The method was removed before, but I now have a use case in the last phase of the clipping routine of `grisubal`.
