### PR TITLE
refactor!(core): remove `CMapError`

### DIFF
--- a/benches/benches/core/cmap2/basic_ops.rs
+++ b/benches/benches/core/cmap2/basic_ops.rs
@@ -12,7 +12,7 @@
 // ------ IMPORTS
 
 use honeycomb_benches::FloatType;
-use honeycomb_core::prelude::{CMap2, CMapBuilder, CMapError, DartIdentifier, Vertex2};
+use honeycomb_core::prelude::{CMap2, CMapBuilder, DartIdentifier, Vertex2};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
@@ -108,7 +108,7 @@ library_benchmark_group!(
 #[bench::small(&mut get_map(16))]
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
-fn read_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn read_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.vertex(1))
 }
 
@@ -116,7 +116,7 @@ fn read_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapErr
 #[bench::small(&mut get_sparse_map(16))]
 #[bench::medium(&mut get_sparse_map(64))]
 #[bench::large(&mut get_sparse_map(256))]
-fn read_missing_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn read_missing_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.vertex(1))
 }
 
@@ -133,7 +133,7 @@ fn insert_vertex(map: &mut CMap2<FloatType>) {
 #[bench::small(&mut get_map(16))]
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
-fn replace_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn replace_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.replace_vertex(1, (0.0, 0.0)))
 }
 
@@ -141,7 +141,7 @@ fn replace_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMap
 #[bench::small(&mut get_sparse_map(16))]
 #[bench::medium(&mut get_sparse_map(64))]
 #[bench::large(&mut get_sparse_map(256))]
-fn set_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn set_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.replace_vertex(1, (0.0, 0.0)))
 }
 
@@ -149,7 +149,7 @@ fn set_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapErro
 #[bench::small(&mut get_map(16))]
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
-fn remove_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn remove_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.remove_vertex(1))
 }
 
@@ -157,7 +157,7 @@ fn remove_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapE
 #[bench::small(&mut get_sparse_map(16))]
 #[bench::medium(&mut get_sparse_map(64))]
 #[bench::large(&mut get_sparse_map(256))]
-fn remove_missing_vertex(map: &mut CMap2<FloatType>) -> Result<Vertex2<FloatType>, CMapError> {
+fn remove_missing_vertex(map: &mut CMap2<FloatType>) -> Option<Vertex2<FloatType>> {
     black_box(map.remove_vertex(1))
 }
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -85,7 +85,7 @@ fn temperature_map() {
         map.get_attribute::<Temperature>(map.vertex_id(4)),
         Some(Temperature::from(275.))
     );
-    assert_eq!(map.vertex(map.vertex_id(4)), Ok(Vertex2::from((2., 0.))));
+    assert_eq!(map.vertex(map.vertex_id(4)), Some(Vertex2::from((2., 0.))));
     // unsew another
     map.one_unsew(1);
     assert_ne!(map.vertex_id(2), map.vertex_id(3));
@@ -97,8 +97,8 @@ fn temperature_map() {
         map.get_attribute::<Temperature>(map.vertex_id(3)),
         Some(Temperature::from(275.))
     );
-    assert_eq!(map.vertex(map.vertex_id(2)), Ok(Vertex2::from((1., 0.))));
-    assert_eq!(map.vertex(map.vertex_id(3)), Ok(Vertex2::from((1., 0.))));
+    assert_eq!(map.vertex(map.vertex_id(2)), Some(Vertex2::from((1., 0.))));
+    assert_eq!(map.vertex(map.vertex_id(3)), Some(Vertex2::from((1., 0.))));
 }
 
 // --- unit tests

--- a/honeycomb-core/src/cmap/common.rs
+++ b/honeycomb-core/src/cmap/common.rs
@@ -15,15 +15,3 @@ pub type DartIdentifier = u32;
 
 /// Null value for dart identifiers
 pub const NULL_DART_ID: DartIdentifier = 0;
-
-// --- maps
-
-/// Map-level error enum
-///
-/// This enum is used to describe all non-panic errors that can occur when operating on a map.
-#[derive(Debug, PartialEq)]
-pub enum CMapError {
-    /// Variant used when requesting a vertex using an ID that has no associated vertex
-    /// in storage.
-    UndefinedVertex,
-}

--- a/honeycomb-core/src/cmap/common.rs
+++ b/honeycomb-core/src/cmap/common.rs
@@ -1,9 +1,5 @@
 //! Crate-level common definitions
 
-// ------ IMPORTS
-
-use std::fmt::Debug;
-
 // ------ CONTENT
 
 // --- darts

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -156,9 +156,9 @@ impl<T: CoordsFloat> CMap2<T> {
     /// //  1 -3-4-5- 2
     /// //    >->->->
     /// assert_eq!(&new_darts, &[3, 4, 5]);
-    /// assert_eq!(map.vertex(3), Ok(Vertex2(0.25, 0.0)));
-    /// assert_eq!(map.vertex(4), Ok(Vertex2(0.50, 0.0)));
-    /// assert_eq!(map.vertex(5), Ok(Vertex2(0.75, 0.0)));
+    /// assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+    /// assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+    /// assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
     ///
     /// assert_eq!(map.beta::<1>(1), 3);
     /// assert_eq!(map.beta::<1>(3), 4);

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORT
 
-use crate::prelude::{AttributeBind, AttributeUpdate, CMap2, CMapError, Vertex2, VertexIdentifier};
+use crate::prelude::{AttributeBind, AttributeUpdate, CMap2, Vertex2, VertexIdentifier};
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
     geometry::CoordsFloat,
@@ -22,30 +22,26 @@ impl<T: CoordsFloat> CMap2<T> {
         self.vertices.n_attributes()
     }
 
-    #[allow(clippy::missing_errors_doc)]
     /// Fetch vertex value associated to a given identifier.
     ///
     /// # Arguments
     ///
     /// - `vertex_id: VertexIdentifier` -- Identifier of the given vertex.
     ///
-    /// # Return / Errors
+    /// # Return
     ///
-    /// This method return a `Result` taking the following values:
-    /// - `Ok(v: Vertex2)` if there is a vertex associated to this ID.
-    /// - `Err(CMapError::UndefinedVertexID)` -- otherwise
+    /// This method return a `Option` taking the following values:
+    /// - `Some(v: Vertex2)` if there is a vertex associated to this ID.
+    /// - `None` -- otherwise
     ///
     /// # Panics
     ///
     /// The method may panic if:
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
-    ///
-    pub fn vertex(&self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.get(vertex_id) {
-            return Ok(val);
-        }
-        Err(CMapError::UndefinedVertex)
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn vertex(&self, vertex_id: VertexIdentifier) -> Option<Vertex2<T>> {
+        self.vertices.get(vertex_id)
     }
 
     /// Insert a vertex in the combinatorial map.
@@ -65,32 +61,31 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - **there is already a vertex associated to the specified index**
     /// - the index lands out of bounds
     /// - the index cannot be converted to `usize`
-    ///
     pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
         self.vertices.insert(vertex_id, vertex.into());
     }
 
-    #[allow(clippy::missing_errors_doc)]
     /// Remove a vertex from the combinatorial map.
     ///
     /// # Arguments
     ///
     /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to remove.
     ///
-    /// # Return / Errors
+    /// # Return
     ///
-    /// This method return a `Result` taking the following values:
-    /// - `Ok(v: Vertex2)` -- The vertex was successfully removed & its value was returned
-    /// - `Err(CMapError::UndefinedVertexID)` -- The vertex was not found in the internal storage
+    /// This method return a `Option` taking the following values:
+    /// - `Some(v: Vertex2)` -- The vertex was successfully removed & its value was returned
+    /// - `None` -- The vertex was not found in the internal storage
     ///
-    pub fn remove_vertex(&mut self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.remove(vertex_id) {
-            return Ok(val);
-        }
-        Err(CMapError::UndefinedVertex)
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    pub fn remove_vertex(&mut self, vertex_id: VertexIdentifier) -> Option<Vertex2<T>> {
+        self.vertices.remove(vertex_id)
     }
 
-    #[allow(clippy::missing_errors_doc)]
     /// Try to overwrite the given vertex with a new value.
     ///
     /// # Arguments
@@ -98,22 +93,24 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to replace.
     /// - `vertex: impl<Into<Vertex2>>` -- New value for the vertex.
     ///
-    /// # Return / Errors
+    /// # Return
     ///
-    /// This method return a `Result` taking the following values:
-    /// - `Ok(v: Vertex2)` -- The vertex was successfully overwritten & its previous value was
+    /// This method return an `Option` taking the following values:
+    /// - `Some(v: Vertex2)` -- The vertex was successfully overwritten & its previous value was
     ///   returned
-    /// - `Err(CMapError::UnknownVertexID)` -- The vertex was not found in the internal storage
+    /// - `None` -- The vertex was set, but no value were overwritten
     ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
     pub fn replace_vertex(
         &mut self,
         vertex_id: VertexIdentifier,
         vertex: impl Into<Vertex2<T>>,
-    ) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.replace(vertex_id, vertex.into()) {
-            return Ok(val);
-        };
-        Err(CMapError::UndefinedVertex)
+    ) -> Option<Vertex2<T>> {
+        self.vertices.replace(vertex_id, vertex.into())
     }
 }
 

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -195,10 +195,10 @@ mod tests {
         map.one_link(5, 6);
         map.one_link(6, 4);
         map.two_link(2, 4);
-        assert!(map.replace_vertex(1, (0.0, 0.0)).is_err());
-        assert!(map.replace_vertex(2, (1.0, 0.0)).is_err());
-        assert!(map.replace_vertex(6, (1.0, 1.0)).is_err());
-        assert!(map.replace_vertex(3, (0.0, 1.0)).is_err());
+        assert!(map.replace_vertex(1, (0.0, 0.0)).is_none());
+        assert!(map.replace_vertex(2, (1.0, 0.0)).is_none());
+        assert!(map.replace_vertex(6, (1.0, 1.0)).is_none());
+        assert!(map.replace_vertex(3, (0.0, 1.0)).is_none());
         map
     }
 

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -141,7 +141,6 @@ use std::collections::BTreeSet;
 /// assert_eq!(value_iterator.next(), Some(Vertex2::from((1.0, 0.0)))); // vertex ID 5
 /// assert_eq!(value_iterator.next(), Some(Vertex2::from((1.0, 1.0)))); // vertex ID 6
 ///
-/// # Ok(())
 /// # }
 /// ```
 #[cfg_attr(feature = "utils", derive(Clone))]

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -65,8 +65,7 @@ use std::collections::BTreeSet;
 ///   progressive changes applied to the structure.
 ///
 /// ```
-/// # use honeycomb_core::prelude::CMapError;
-/// # fn main() -> Result<(), CMapError> {
+/// # fn main() {
 ///
 /// use honeycomb_core::prelude::{CMap2, CMapBuilder, Orbit2, OrbitPolicy, Vertex2};
 ///
@@ -111,11 +110,11 @@ use std::collections::BTreeSet;
 /// // the returned values were the average of the sewn vertices
 /// assert_eq!(
 ///     map.replace_vertex(2, Vertex2::from((1.0, 0.0))),
-///     Ok(Vertex2::from((1.5, 0.0)))
+///     Some(Vertex2(1.5, 0.0))
 /// );
 /// assert_eq!(
 ///     map.replace_vertex(3, Vertex2::from((0.0, 1.0))),
-///     Ok(Vertex2::from((0.0, 1.5)))
+///     Some(Vertex2(0.0, 1.5))
 /// );
 ///
 /// // separate the diagonal from the rest

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -62,12 +62,12 @@ fn example_test() {
     // adjust bottom-right & top-left vertex position
     assert_eq!(
         map.replace_vertex(2, Vertex2::from((1.0, 0.0))),
-        Ok(Vertex2::from((1.5, 0.0)))
+        Some(Vertex2::from((1.5, 0.0)))
     );
     assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.0, 0.0)));
     assert_eq!(
         map.replace_vertex(3, Vertex2::from((0.0, 1.0))),
-        Ok(Vertex2::from((0.0, 1.5)))
+        Some(Vertex2::from((0.0, 1.5)))
     );
     assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
 
@@ -104,7 +104,7 @@ fn example_test() {
 }
 
 #[test]
-#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UndefinedVertex")]
+#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn remove_vertex_twice() {
     // in its default state, all darts/vertices of a map are considered to be used
     let mut map: CMap2<f64> = CMap2::new(4);
@@ -288,9 +288,9 @@ fn split_edge_complete() {
     assert_eq!(map.vertex_id(8), 7);
     assert_eq!(map.vertex_id(7), 7);
 
-    assert_eq!(map.vertex(2), Ok(Vertex2::from((1.0, 0.0))));
-    assert_eq!(map.vertex(7), Ok(Vertex2::from((1.5, 0.0))));
-    assert_eq!(map.vertex(3), Ok(Vertex2::from((2.0, 0.0))));
+    assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
+    assert_eq!(map.vertex(7), Some(Vertex2::from((1.5, 0.0))));
+    assert_eq!(map.vertex(3), Some(Vertex2::from((2.0, 0.0))));
 }
 
 #[test]
@@ -318,9 +318,9 @@ fn split_edge_isolated() {
     assert_eq!(map.vertex_id(3), 3);
     assert_eq!(map.vertex_id(4), 3);
 
-    assert_eq!(map.vertex(1), Ok(Vertex2::from((0.0, 0.0))));
-    assert_eq!(map.vertex(3), Ok(Vertex2::from((0.6, 0.0))));
-    assert_eq!(map.vertex(2), Ok(Vertex2::from((1.0, 0.0))));
+    assert_eq!(map.vertex(1), Some(Vertex2::from((0.0, 0.0))));
+    assert_eq!(map.vertex(3), Some(Vertex2::from((0.6, 0.0))));
+    assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn split_single_dart() {
     assert_eq!(map.beta::<1>(1), 3);
     assert_eq!(map.beta::<1>(3), 2);
     assert_eq!(map.beta::<2>(3), NULL_DART_ID);
-    assert_eq!(map.vertex(3), Ok(Vertex2::from((0.5, 0.0))));
+    assert_eq!(map.vertex(3), Some(Vertex2::from((0.5, 0.0))));
 }
 
 #[test]
@@ -382,9 +382,9 @@ fn splitn_edge_complete() {
     //  1         2 -7-8-9- 3         4
     //    ---1-->             ---3-->
     assert_eq!(&new_darts, &[7, 8, 9]);
-    assert_eq!(map.vertex(7), Ok(Vertex2(1.25, 0.0)));
-    assert_eq!(map.vertex(8), Ok(Vertex2(1.50, 0.0)));
-    assert_eq!(map.vertex(9), Ok(Vertex2(1.75, 0.0)));
+    assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
+    assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
+    assert_eq!(map.vertex(9), Some(Vertex2(1.75, 0.0)));
 
     assert_eq!(map.beta::<1>(2), 7);
     assert_eq!(map.beta::<1>(7), 8);
@@ -419,9 +419,9 @@ fn splitn_edge_isolated() {
     //  1 -3-4-5- 2
     //    >->->->
     assert_eq!(&new_darts, &[3, 4, 5]);
-    assert_eq!(map.vertex(3), Ok(Vertex2(0.25, 0.0)));
-    assert_eq!(map.vertex(4), Ok(Vertex2(0.50, 0.0)));
-    assert_eq!(map.vertex(5), Ok(Vertex2(0.75, 0.0)));
+    assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+    assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+    assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
 
     assert_eq!(map.beta::<1>(1), 3);
     assert_eq!(map.beta::<1>(3), 4);
@@ -452,9 +452,9 @@ fn splitn_single_dart() {
     // after
     //  1 -> 3 -> 4 -> 5 -> 2 ->
     assert_eq!(&new_darts, &[3, 4, 5]);
-    assert_eq!(map.vertex(3), Ok(Vertex2(0.25, 0.0)));
-    assert_eq!(map.vertex(4), Ok(Vertex2(0.50, 0.0)));
-    assert_eq!(map.vertex(5), Ok(Vertex2(0.75, 0.0)));
+    assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+    assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+    assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
 
     assert_eq!(map.beta::<1>(1), 3);
     assert_eq!(map.beta::<1>(3), 4);

--- a/honeycomb-core/src/cmap/mod.rs
+++ b/honeycomb-core/src/cmap/mod.rs
@@ -10,7 +10,7 @@ pub use collections::{
     EdgeCollection, EdgeIdentifier, FaceCollection, FaceIdentifier, VertexCollection,
     VertexIdentifier, VolumeIdentifier, NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
 };
-pub use common::{CMapError, DartIdentifier, NULL_DART_ID};
+pub use common::{DartIdentifier, NULL_DART_ID};
 pub use dim2::{
     orbits::{Orbit2, OrbitPolicy},
     structure::CMap2,

--- a/honeycomb-core/src/prelude.rs
+++ b/honeycomb-core/src/prelude.rs
@@ -2,9 +2,9 @@
 
 pub use crate::attributes::{AttributeBind, AttributeUpdate};
 pub use crate::cmap::{
-    BuilderError, CMap2, CMapBuilder, CMapError, DartIdentifier, EdgeIdentifier, FaceIdentifier,
-    Orbit2, OrbitPolicy, VertexIdentifier, VolumeIdentifier, NULL_DART_ID, NULL_EDGE_ID,
-    NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
+    BuilderError, CMap2, CMapBuilder, DartIdentifier, EdgeIdentifier, FaceIdentifier, Orbit2,
+    OrbitPolicy, VertexIdentifier, VolumeIdentifier, NULL_DART_ID, NULL_EDGE_ID, NULL_FACE_ID,
+    NULL_VERTEX_ID, NULL_VOLUME_ID,
 };
 pub use crate::geometry::{CoordsError, CoordsFloat, Vector2, Vertex2};
 

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -192,19 +192,19 @@ fn regular_intersections() {
     // check new vertices at intersection
     assert_eq!(
         cmap.vertex(cmap.vertex_id(cmap.beta::<1>(2))),
-        Ok(Vertex2(1.0, 0.5))
+        Some(Vertex2(1.0, 0.5))
     );
     assert_eq!(
         cmap.vertex(cmap.vertex_id(cmap.beta::<1>(7))),
-        Ok(Vertex2(1.5, 1.0))
+        Some(Vertex2(1.5, 1.0))
     );
     assert_eq!(
         cmap.vertex(cmap.vertex_id(cmap.beta::<1>(10))),
-        Ok(Vertex2(1.0, 1.5))
+        Some(Vertex2(1.0, 1.5))
     );
     assert_eq!(
         cmap.vertex(cmap.vertex_id(cmap.beta::<1>(3))),
-        Ok(Vertex2(0.5, 1.0))
+        Some(Vertex2(0.5, 1.0))
     );
 
     let mut edges = generate_edge_data(&mut cmap, &geometry, &segments, &intersection_darts);

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -59,9 +59,9 @@ pub mod prelude {
 
     pub use honeycomb_core::attributes::{AttributeBind, AttributeUpdate};
     pub use honeycomb_core::cmap::{
-        BuilderError, CMap2, CMapBuilder, CMapError, DartIdentifier, EdgeIdentifier,
-        FaceIdentifier, GridDescriptor, Orbit2, OrbitPolicy, VertexIdentifier, VolumeIdentifier,
-        NULL_DART_ID, NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
+        BuilderError, CMap2, CMapBuilder, DartIdentifier, EdgeIdentifier, FaceIdentifier,
+        GridDescriptor, Orbit2, OrbitPolicy, VertexIdentifier, VolumeIdentifier, NULL_DART_ID,
+        NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
     };
     pub use honeycomb_core::geometry::{CoordsError, CoordsFloat, Vector2, Vertex2};
 


### PR DESCRIPTION
This enum had a single variant: `CMapError::UndefinedVertex`. Removing the error and replacing `Result`s with `Option`s simplifies the code and makes the vertex/attribute metho signatures consistent. 

important changes are in the `honeycomb-core/src/cmap/dim2/embed.rs` file

## Scope

- [x] Code: core crate, other changes are just fixes 

## Type of change

- [x] Refactor

## Other

- [x] Breaking change