### PR TITLE
feat(core): implement attribute storage traits for `std` collections

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -33,7 +33,7 @@ pub struct AttrSparseVec<T: AttributeBind + AttributeUpdate> {
 }
 
 impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for AttrSparseVec<A> {
-    fn new(length: usize) -> Self
+    fn init(length: usize) -> Self
     where
         Self: Sized,
     {
@@ -42,7 +42,7 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
         }
     }
 
-    fn extend(&mut self, length: usize) {
+    fn extend_cap(&mut self, length: usize) {
         self.data.extend((0..length).map(|_| None));
     }
 
@@ -145,7 +145,7 @@ pub struct AttrCompactVec<A: AttributeBind + AttributeUpdate + Clone> {
 }
 
 impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for AttrCompactVec<A> {
-    fn new(length: usize) -> Self
+    fn init(length: usize) -> Self
     where
         Self: Sized,
     {
@@ -156,7 +156,7 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
         }
     }
 
-    fn extend(&mut self, length: usize) {
+    fn extend_cap(&mut self, length: usize) {
         self.index_map.extend((0..length).map(|_| None));
     }
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -462,7 +462,7 @@ impl AttrStorageManager {
     /// - the index lands out of bounds
     pub fn set_attribute<A: AttributeBind>(&mut self, id: A::IdentifierType, val: A) {
         get_storage_mut!(self, storage);
-        storage.set(id, val);
+        storage.set_v(id, val);
     }
 
     /// Set the value of an attribute.
@@ -485,7 +485,7 @@ impl AttrStorageManager {
     /// - the index lands out of bounds
     pub fn insert_attribute<A: AttributeBind>(&mut self, id: A::IdentifierType, val: A) {
         get_storage_mut!(self, storage);
-        storage.insert(id, val);
+        storage.insert_v(id, val);
     }
 
     /// Get the value of an attribute.
@@ -512,7 +512,7 @@ impl AttrStorageManager {
     /// - the index lands out of bounds
     pub fn get_attribute<A: AttributeBind>(&self, id: A::IdentifierType) -> Option<A> {
         get_storage!(self, storage);
-        storage.get(id)
+        storage.get_v(id)
     }
 
     /// Set the value of an attribute.
@@ -544,7 +544,7 @@ impl AttrStorageManager {
         val: A,
     ) -> Option<A> {
         get_storage_mut!(self, storage);
-        storage.replace(id, val)
+        storage.replace_v(id, val)
     }
 
     /// Remove the an item from an attribute storage.
@@ -571,7 +571,7 @@ impl AttrStorageManager {
     /// - the index lands out of bounds
     pub fn remove_attribute<A: AttributeBind>(&mut self, id: A::IdentifierType) -> Option<A> {
         get_storage_mut!(self, storage);
-        storage.remove(id)
+        storage.remove_v(id)
     }
 
     /// Merge given attribute values.

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -58,7 +58,7 @@ pub enum ManagerError {
 ///         size: usize,
 ///     ) {
 ///         let typeid = TypeId::of::<A>();
-///         let new_storage = <A as AttributeBind>::StorageType::new(size);
+///         let new_storage = <A as AttributeBind>::StorageType::init(size);
 ///         self.inner.insert(typeid, Box::new(new_storage));
 ///     }
 ///
@@ -95,16 +95,16 @@ impl AttrStorageManager {
     /// - `length: usize` -- Length by which storages should be extended.
     pub fn extend_storages(&mut self, length: usize) {
         for storage in self.vertices.values_mut() {
-            storage.extend(length);
+            storage.extend_cap(length);
         }
         for storage in self.edges.values_mut() {
-            storage.extend(length);
+            storage.extend_cap(length);
         }
         for storage in self.faces.values_mut() {
-            storage.extend(length);
+            storage.extend_cap(length);
         }
         for storage in self.others.values_mut() {
-            storage.extend(length);
+            storage.extend_cap(length);
         }
     }
 
@@ -372,7 +372,7 @@ impl AttrStorageManager {
         size: usize,
     ) -> Result<(), ManagerError> {
         let typeid = TypeId::of::<A>();
-        let new_storage = <A as AttributeBind>::StorageType::new(size);
+        let new_storage = <A as AttributeBind>::StorageType::init(size);
         if match A::binds_to() {
             OrbitPolicy::Vertex => self.vertices.insert(typeid, Box::new(new_storage)),
             OrbitPolicy::Edge => self.edges.insert(typeid, Box::new(new_storage)),
@@ -398,7 +398,7 @@ impl AttrStorageManager {
     /// - `A: AttributeBind` -- Attribute of which the storage should be extended.
     pub fn extend_storage<A: AttributeBind>(&mut self, length: usize) {
         get_storage_mut!(self, storage);
-        storage.extend(length);
+        storage.extend_cap(length);
     }
 
     /// Get a reference to the storage of a given attribute.

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -133,16 +133,16 @@ fn attribute_bind() {
 macro_rules! generate_sparse {
     ($name: ident) => {
         let mut $name = AttrSparseVec::<Temperature>::init(10);
-        $name.insert(0, Temperature::from(273.0));
-        $name.insert(1, Temperature::from(275.0));
-        $name.insert(2, Temperature::from(277.0));
-        $name.insert(3, Temperature::from(279.0));
-        $name.insert(4, Temperature::from(281.0));
-        $name.insert(5, Temperature::from(283.0));
-        $name.insert(6, Temperature::from(285.0));
-        $name.insert(7, Temperature::from(287.0));
-        $name.insert(8, Temperature::from(289.0));
-        $name.insert(9, Temperature::from(291.0));
+        $name.insert_v(0, Temperature::from(273.0));
+        $name.insert_v(1, Temperature::from(275.0));
+        $name.insert_v(2, Temperature::from(277.0));
+        $name.insert_v(3, Temperature::from(279.0));
+        $name.insert_v(4, Temperature::from(281.0));
+        $name.insert_v(5, Temperature::from(283.0));
+        $name.insert_v(6, Temperature::from(285.0));
+        $name.insert_v(7, Temperature::from(287.0));
+        $name.insert_v(8, Temperature::from(289.0));
+        $name.insert_v(9, Temperature::from(291.0));
     };
 }
 
@@ -150,138 +150,138 @@ macro_rules! generate_sparse {
 fn sparse_vec_n_attributes() {
     generate_sparse!(storage);
     assert_eq!(storage.n_attributes(), 10);
-    let _ = storage.remove(3);
+    let _ = storage.remove_v(3);
     assert_eq!(storage.n_attributes(), 9);
     // extend does not affect the number of attributes
     storage.extend_cap(10);
-    assert!(storage.get(15).is_none());
+    assert!(storage.get_v(15).is_none());
     assert_eq!(storage.n_attributes(), 9);
 }
 
 #[test]
 fn sparse_vec_merge() {
     generate_sparse!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.get(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.get(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.get_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.get_v(8), Some(Temperature::from(289.0)));
     storage.merge(8, 3, 6);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(6), None);
-    assert_eq!(storage.get(8), Some(Temperature::from(282.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(6), None);
+    assert_eq!(storage.get_v(8), Some(Temperature::from(282.0)));
 }
 
 #[test]
 fn sparse_vec_merge_undefined() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.remove(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.remove_v(8), Some(Temperature::from(289.0)));
     // merge from two undefined value
     storage.merge(8, 3, 6);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(6), None);
-    assert_eq!(storage.get(8), Some(Temperature::from(0.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(6), None);
+    assert_eq!(storage.get_v(8), Some(Temperature::from(0.0)));
     // merge from one undefined value
-    assert_eq!(storage.get(4), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get_v(4), Some(Temperature::from(281.0)));
     storage.merge(6, 3, 4);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(4), None);
-    assert_eq!(storage.get(6), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(4), None);
+    assert_eq!(storage.get_v(6), Some(Temperature::from(281.0)));
 }
 
 #[test]
 fn sparse_vec_split() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.get(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.get_v(8), Some(Temperature::from(289.0)));
     storage.split(3, 6, 8);
-    assert_eq!(storage.get(3), Some(Temperature::from(289.0)));
-    assert_eq!(storage.get(6), Some(Temperature::from(289.0)));
-    assert_eq!(storage.get(8), None);
+    assert_eq!(storage.get_v(3), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(6), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(8), None);
 }
 
 #[test]
 fn sparse_vec_get_set_get() {
     generate_sparse!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.set(3, Temperature::from(280.0));
-    assert_eq!(storage.get(3), Some(Temperature::from(280.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.set_v(3, Temperature::from(280.0));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(280.0)));
 }
 
 #[test]
 fn sparse_vec_get_replace_get() {
     generate_sparse!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.replace(3, Temperature::from(280.0));
-    assert_eq!(storage.get(3), Some(Temperature::from(280.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.replace_v(3, Temperature::from(280.0));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(280.0)));
 }
 
 #[test]
 #[should_panic(expected = "assertion failed: tmp.is_none()")]
 fn sparse_vec_insert_already_existing() {
     generate_sparse!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.insert(3, Temperature::from(280.0)); // panic
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.insert_v(3, Temperature::from(280.0)); // panic
 }
 
 #[test]
 fn sparse_vec_remove() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
 }
 
 #[test]
 fn sparse_vec_remove_remove() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.remove(3).is_none());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert!(storage.remove_v(3).is_none());
 }
 
 #[test]
 fn sparse_vec_remove_get() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.get(3).is_none());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert!(storage.get_v(3).is_none());
 }
 
 #[test]
 fn sparse_vec_remove_set() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.set(3, Temperature::from(280.0));
-    assert!(storage.get(3).is_some());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.set_v(3, Temperature::from(280.0));
+    assert!(storage.get_v(3).is_some());
 }
 
 #[test]
 fn sparse_vec_remove_insert() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.insert(3, Temperature::from(280.0));
-    assert!(storage.get(3).is_some());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.insert_v(3, Temperature::from(280.0));
+    assert!(storage.get_v(3).is_some());
 }
 
 #[test]
 #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn sparse_vec_replace_already_removed() {
     generate_sparse!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.replace(3, Temperature::from(280.0)).unwrap(); // panic
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.replace_v(3, Temperature::from(280.0)).unwrap(); // panic
 }
 
 macro_rules! generate_compact {
     ($name: ident) => {
         let mut $name = AttrCompactVec::<Temperature>::init(10);
-        $name.insert(0, Temperature::from(273.0));
-        $name.insert(1, Temperature::from(275.0));
-        $name.insert(2, Temperature::from(277.0));
-        $name.insert(3, Temperature::from(279.0));
-        $name.insert(4, Temperature::from(281.0));
-        $name.insert(5, Temperature::from(283.0));
-        $name.insert(6, Temperature::from(285.0));
-        $name.insert(7, Temperature::from(287.0));
-        $name.insert(8, Temperature::from(289.0));
-        $name.insert(9, Temperature::from(291.0));
+        $name.insert_v(0, Temperature::from(273.0));
+        $name.insert_v(1, Temperature::from(275.0));
+        $name.insert_v(2, Temperature::from(277.0));
+        $name.insert_v(3, Temperature::from(279.0));
+        $name.insert_v(4, Temperature::from(281.0));
+        $name.insert_v(5, Temperature::from(283.0));
+        $name.insert_v(6, Temperature::from(285.0));
+        $name.insert_v(7, Temperature::from(287.0));
+        $name.insert_v(8, Temperature::from(289.0));
+        $name.insert_v(9, Temperature::from(291.0));
     };
 }
 
@@ -289,12 +289,12 @@ macro_rules! generate_compact {
 fn compact_vec_n_attributes() {
     generate_compact!(storage);
     assert_eq!(storage.n_attributes(), 10);
-    let _ = storage.remove(3);
+    let _ = storage.remove_v(3);
     //assert_eq!(storage.n_attributes(), 10);
     assert_eq!(storage.n_attributes(), 9);
     // extend does not affect the number of attributes
     storage.extend_cap(10);
-    assert!(storage.get(15).is_none());
+    assert!(storage.get_v(15).is_none());
     assert_eq!(storage.n_attributes(), 9);
 }
 
@@ -316,44 +316,44 @@ fn compact_vec_n_used_attributes() {
 #[test]
 fn compact_vec_merge() {
     generate_compact!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.get(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.get(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.get_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.get_v(8), Some(Temperature::from(289.0)));
     storage.merge(8, 3, 6);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(6), None);
-    assert_eq!(storage.get(8), Some(Temperature::from(282.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(6), None);
+    assert_eq!(storage.get_v(8), Some(Temperature::from(282.0)));
 }
 
 #[test]
 fn compact_vec_merge_undefined() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.remove(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.remove_v(8), Some(Temperature::from(289.0)));
     // merge from two undefined value
     storage.merge(8, 3, 6);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(6), None);
-    assert_eq!(storage.get(8), Some(Temperature::from(0.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(6), None);
+    assert_eq!(storage.get_v(8), Some(Temperature::from(0.0)));
     // merge from one undefined value
-    assert_eq!(storage.get(4), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get_v(4), Some(Temperature::from(281.0)));
     storage.merge(6, 3, 4);
-    assert_eq!(storage.get(3), None);
-    assert_eq!(storage.get(4), None);
-    assert_eq!(storage.get(6), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get_v(3), None);
+    assert_eq!(storage.get_v(4), None);
+    assert_eq!(storage.get_v(6), Some(Temperature::from(281.0)));
 }
 
 #[test]
 fn compact_vec_split() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.get(8), Some(Temperature::from(289.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(6), Some(Temperature::from(285.0)));
+    assert_eq!(storage.get_v(8), Some(Temperature::from(289.0)));
     storage.split(3, 6, 8);
-    assert_eq!(storage.get(3), Some(Temperature::from(289.0)));
-    assert_eq!(storage.get(6), Some(Temperature::from(289.0)));
-    assert_eq!(storage.get(8), None);
+    assert_eq!(storage.get_v(3), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(6), Some(Temperature::from(289.0)));
+    assert_eq!(storage.get_v(8), None);
 }
 
 #[test]
@@ -363,13 +363,13 @@ fn compact_vec_extend_through_set() {
     // extend does not affect the number of attributes
     storage.extend_cap(10);
     assert_eq!(storage.n_attributes(), 10);
-    storage.set(10, Temperature::from(293.0));
+    storage.set_v(10, Temperature::from(293.0));
     assert_eq!(storage.n_attributes(), 11);
-    storage.set(11, Temperature::from(295.0));
+    storage.set_v(11, Temperature::from(295.0));
     assert_eq!(storage.n_attributes(), 12);
-    storage.set(12, Temperature::from(297.0));
+    storage.set_v(12, Temperature::from(297.0));
     assert_eq!(storage.n_attributes(), 13);
-    let _ = storage.remove(3);
+    let _ = storage.remove_v(3);
     //assert_eq!(storage.n_attributes(), 13);
     assert_eq!(storage.n_attributes(), 12); // previously n_used_attributes
 }
@@ -377,69 +377,69 @@ fn compact_vec_extend_through_set() {
 #[test]
 fn compact_vec_get_set_get() {
     generate_compact!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.set(3, Temperature::from(280.0));
-    assert_eq!(storage.get(3), Some(Temperature::from(280.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.set_v(3, Temperature::from(280.0));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(280.0)));
 }
 
 #[test]
 fn compact_vec_get_replace_get() {
     generate_compact!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.replace(3, Temperature::from(280.0));
-    assert_eq!(storage.get(3), Some(Temperature::from(280.0)));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.replace_v(3, Temperature::from(280.0));
+    assert_eq!(storage.get_v(3), Some(Temperature::from(280.0)));
 }
 
 #[test]
 #[should_panic(expected = "assertion failed: idx.is_none()")]
 fn compact_vec_insert_already_existing() {
     generate_compact!(storage);
-    assert_eq!(storage.get(3), Some(Temperature::from(279.0)));
-    storage.insert(3, Temperature::from(280.0)); // panic
+    assert_eq!(storage.get_v(3), Some(Temperature::from(279.0)));
+    storage.insert_v(3, Temperature::from(280.0)); // panic
 }
 
 #[test]
 fn compact_vec_remove() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
 }
 
 #[test]
 fn compact_vec_remove_remove() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.remove(3).is_none());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert!(storage.remove_v(3).is_none());
 }
 
 #[test]
 fn compact_vec_remove_get() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.get(3).is_none());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    assert!(storage.get_v(3).is_none());
 }
 
 #[test]
 fn compact_vec_remove_set() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.set(3, Temperature::from(280.0));
-    assert!(storage.get(3).is_some());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.set_v(3, Temperature::from(280.0));
+    assert!(storage.get_v(3).is_some());
 }
 
 #[test]
 fn compact_vec_remove_insert() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.insert(3, Temperature::from(280.0));
-    assert!(storage.get(3).is_some());
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.insert_v(3, Temperature::from(280.0));
+    assert!(storage.get_v(3).is_some());
 }
 
 #[test]
 #[should_panic(expected = "assertion failed: idx.is_some()")]
 fn compact_vec_replace_already_removed() {
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.replace(3, Temperature::from(280.0)); // panic
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
+    storage.replace_v(3, Temperature::from(280.0)); // panic
 }
 
 // storage manager
@@ -510,7 +510,7 @@ fn manager_vec_insert_already_existing() {
 fn manager_vec_remove() {
     generate_manager!(manager);
     generate_compact!(storage);
-    assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
+    assert_eq!(storage.remove_v(3), Some(Temperature::from(279.0)));
 }
 
 #[test]

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -132,7 +132,7 @@ fn attribute_bind() {
 
 macro_rules! generate_sparse {
     ($name: ident) => {
-        let mut $name = AttrSparseVec::<Temperature>::new(10);
+        let mut $name = AttrSparseVec::<Temperature>::init(10);
         $name.insert(0, Temperature::from(273.0));
         $name.insert(1, Temperature::from(275.0));
         $name.insert(2, Temperature::from(277.0));
@@ -153,7 +153,7 @@ fn sparse_vec_n_attributes() {
     let _ = storage.remove(3);
     assert_eq!(storage.n_attributes(), 9);
     // extend does not affect the number of attributes
-    storage.extend(10);
+    storage.extend_cap(10);
     assert!(storage.get(15).is_none());
     assert_eq!(storage.n_attributes(), 9);
 }
@@ -271,7 +271,7 @@ fn sparse_vec_replace_already_removed() {
 
 macro_rules! generate_compact {
     ($name: ident) => {
-        let mut $name = AttrCompactVec::<Temperature>::new(10);
+        let mut $name = AttrCompactVec::<Temperature>::init(10);
         $name.insert(0, Temperature::from(273.0));
         $name.insert(1, Temperature::from(275.0));
         $name.insert(2, Temperature::from(277.0));
@@ -293,7 +293,7 @@ fn compact_vec_n_attributes() {
     //assert_eq!(storage.n_attributes(), 10);
     assert_eq!(storage.n_attributes(), 9);
     // extend does not affect the number of attributes
-    storage.extend(10);
+    storage.extend_cap(10);
     assert!(storage.get(15).is_none());
     assert_eq!(storage.n_attributes(), 9);
 }
@@ -361,7 +361,7 @@ fn compact_vec_extend_through_set() {
     generate_compact!(storage);
     assert_eq!(storage.n_attributes(), 10);
     // extend does not affect the number of attributes
-    storage.extend(10);
+    storage.extend_cap(10);
     assert_eq!(storage.n_attributes(), 10);
     storage.set(10, Temperature::from(293.0));
     assert_eq!(storage.n_attributes(), 11);

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -145,7 +145,7 @@ macro_rules! unknown_attribute_storage {
         ///
         /// Return a [Self] instance which yields correct accesses over the ID range `0..length`.
         #[must_use = "constructed object is not used, consider removing this function call"]
-        fn new(length: usize) -> Self
+        fn init(length: usize) -> Self
         where
             Self: Sized;
 
@@ -154,10 +154,10 @@ macro_rules! unknown_attribute_storage {
         /// # Arguments
         ///
         /// - `length: usize` -- length of which the storage should be extended.
-        fn extend(&mut self, length: usize);
+        fn extend_cap(&mut self, length: usize);
 
-        /// Return the number of stored attributes, i.e. the number of used slots in the storage, not
-        /// its length.
+        /// Return the number of stored attributes, i.e. the number of used slots in the storage,
+        /// not its length.
         #[must_use = "returned value is not used, consider removing this method call"]
         fn n_attributes(&self) -> usize;
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -253,7 +253,7 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn set(&mut self, id: A::IdentifierType, val: A);
+    fn set_v(&mut self, id: A::IdentifierType, val: A);
 
     /// Setter
     ///
@@ -271,9 +271,9 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// - **should panic if there is already a value associated to the specified index**
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn insert(&mut self, id: A::IdentifierType, val: A) {
-        assert!(self.get(id.clone()).is_none());
-        self.set(id, val);
+    fn insert_v(&mut self, id: A::IdentifierType, val: A) {
+        assert!(self.get_v(id.clone()).is_none());
+        self.set_v(id, val);
     }
 
     /// Getter
@@ -293,7 +293,7 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn get(&self, id: A::IdentifierType) -> Option<A>;
+    fn get_v(&self, id: A::IdentifierType) -> Option<A>;
 
     /// Setter
     ///
@@ -317,7 +317,7 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn replace(&mut self, id: A::IdentifierType, val: A) -> Option<A>;
+    fn replace_v(&mut self, id: A::IdentifierType, val: A) -> Option<A>;
 
     /// Remove an item from the storage and return it
     ///
@@ -336,5 +336,5 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn remove(&mut self, id: A::IdentifierType) -> Option<A>;
+    fn remove_v(&mut self, id: A::IdentifierType) -> Option<A>;
 }

--- a/honeycomb-core/src/cmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/basic_ops.rs
@@ -55,7 +55,7 @@ impl<T: CoordsFloat> CMap2<T> {
         let new_id = self.n_darts as DartIdentifier;
         self.n_darts += 1;
         self.betas.push([0; CMAP2_BETA]);
-        self.vertices.extend(1);
+        self.vertices.extend_cap(1);
         self.attributes.extend_storages(1);
         new_id
     }
@@ -77,7 +77,7 @@ impl<T: CoordsFloat> CMap2<T> {
         let new_id = self.n_darts as DartIdentifier;
         self.n_darts += n_darts;
         self.betas.extend((0..n_darts).map(|_| [0; CMAP2_BETA]));
-        self.vertices.extend(n_darts);
+        self.vertices.extend_cap(n_darts);
         self.attributes.extend_storages(n_darts);
         new_id
     }

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -42,7 +42,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - the index cannot be converted to `usize`
     ///
     pub fn vertex(&self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.get(vertex_id) {
+        if let Some(val) = self.vertices.get_v(vertex_id) {
             return Ok(val);
         }
         Err(CMapError::UndefinedVertex)
@@ -67,7 +67,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - the index cannot be converted to `usize`
     ///
     pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
-        self.vertices.insert(vertex_id, vertex.into());
+        self.vertices.insert_v(vertex_id, vertex.into());
     }
 
     #[allow(clippy::missing_errors_doc)]
@@ -84,7 +84,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `Err(CMapError::UndefinedVertexID)` -- The vertex was not found in the internal storage
     ///
     pub fn remove_vertex(&mut self, vertex_id: VertexIdentifier) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.remove(vertex_id) {
+        if let Some(val) = self.vertices.remove_v(vertex_id) {
             return Ok(val);
         }
         Err(CMapError::UndefinedVertex)
@@ -110,7 +110,7 @@ impl<T: CoordsFloat> CMap2<T> {
         vertex_id: VertexIdentifier,
         vertex: impl Into<Vertex2<T>>,
     ) -> Result<Vertex2<T>, CMapError> {
-        if let Some(val) = self.vertices.replace(vertex_id, vertex.into()) {
+        if let Some(val) = self.vertices.replace_v(vertex_id, vertex.into()) {
             return Ok(val);
         };
         Err(CMapError::UndefinedVertex)

--- a/honeycomb-core/src/cmap/dim2/link_and_sew.rs
+++ b/honeycomb-core/src/cmap/dim2/link_and_sew.rs
@@ -44,7 +44,7 @@ impl<T: CoordsFloat> CMap2<T> {
         let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
         if b2lhs_dart_id == NULL_DART_ID {
             assert!(
-                self.vertices.get(self.vertex_id(rhs_dart_id)).is_some(),
+                self.vertices.get_v(self.vertex_id(rhs_dart_id)).is_some(),
                 "{}",
                 format!(
                     "No vertex defined on dart {rhs_dart_id}, use `one_link` instead of `one_sew`"
@@ -100,7 +100,7 @@ impl<T: CoordsFloat> CMap2<T> {
             // trivial case, no update needed
             (true, true) => {
                 assert!(
-                    self.vertices.get(self.vertex_id(lhs_dart_id)).is_some() | self.vertices.get(self.vertex_id(rhs_dart_id)).is_some(),
+                    self.vertices.get_v(self.vertex_id(lhs_dart_id)).is_some() | self.vertices.get_v(self.vertex_id(rhs_dart_id)).is_some(),
                     "{}",
                     format!("No vertices defined on either darts {lhs_dart_id}/{rhs_dart_id} , use `two_link` instead of `two_sew`")
                 );
@@ -174,8 +174,8 @@ impl<T: CoordsFloat> CMap2<T> {
                     Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
                     Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
                 ) = (
-                    self.vertices.get(lhs_vid_old), self.vertices.get(b1rhs_vid_old),// (lhs/b1rhs)
-                    self.vertices.get(b1lhs_vid_old), self.vertices.get(rhs_vid_old) // (b1lhs/rhs)
+                    self.vertices.get_v(lhs_vid_old), self.vertices.get_v(b1rhs_vid_old),// (lhs/b1rhs)
+                    self.vertices.get_v(b1lhs_vid_old), self.vertices.get_v(rhs_vid_old) // (b1lhs/rhs)
                 )
                 {
                     let lhs_vector = b1l_vertex - l_vertex;

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -182,7 +182,7 @@ impl<T: CoordsFloat> CMap2<T> {
     pub(crate) fn new(n_darts: usize) -> Self {
         Self {
             attributes: AttrStorageManager::default(),
-            vertices: AttrSparseVec::new(n_darts + 1),
+            vertices: AttrSparseVec::init(n_darts + 1),
             unused_darts: BTreeSet::new(),
             betas: vec![[0; CMAP2_BETA]; n_darts + 1],
             n_darts: n_darts + 1,
@@ -217,7 +217,7 @@ impl<T: CoordsFloat> CMap2<T> {
         attr_storage_manager.extend_storages(n_darts + 1);
         Self {
             attributes: attr_storage_manager,
-            vertices: AttrSparseVec::new(n_darts + 1),
+            vertices: AttrSparseVec::init(n_darts + 1),
             unused_darts: BTreeSet::new(),
             betas: vec![[0; CMAP2_BETA]; n_darts + 1],
             n_darts: n_darts + 1,

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -8,7 +8,7 @@
 use super::CMAP2_BETA;
 use crate::prelude::{DartIdentifier, Vertex2};
 use crate::{
-    attributes::{AttrSparseVec, AttrStorageManager, UnknownAttributeStorage},
+    attributes::{AttrStorageManager, UnknownAttributeStorage},
     geometry::CoordsFloat,
 };
 use std::collections::BTreeSet;
@@ -150,7 +150,7 @@ pub struct CMap2<T: CoordsFloat> {
     /// List of vertices making up the represented mesh
     pub(super) attributes: AttrStorageManager,
     /// List of vertices making up the represented mesh
-    pub(super) vertices: AttrSparseVec<Vertex2<T>>,
+    pub(super) vertices: Vec<Option<Vertex2<T>>>,
     /// List of free darts identifiers, i.e. empty spots
     /// in the current dart list
     pub(super) unused_darts: BTreeSet<DartIdentifier>,
@@ -182,7 +182,7 @@ impl<T: CoordsFloat> CMap2<T> {
     pub(crate) fn new(n_darts: usize) -> Self {
         Self {
             attributes: AttrStorageManager::default(),
-            vertices: AttrSparseVec::init(n_darts + 1),
+            vertices: Vec::init(n_darts + 1),
             unused_darts: BTreeSet::new(),
             betas: vec![[0; CMAP2_BETA]; n_darts + 1],
             n_darts: n_darts + 1,
@@ -217,7 +217,7 @@ impl<T: CoordsFloat> CMap2<T> {
         attr_storage_manager.extend_storages(n_darts + 1);
         Self {
             attributes: attr_storage_manager,
-            vertices: AttrSparseVec::init(n_darts + 1),
+            vertices: Vec::init(n_darts + 1),
             unused_darts: BTreeSet::new(),
             betas: vec![[0; CMAP2_BETA]; n_darts + 1],
             n_darts: n_darts + 1,

--- a/honeycomb-core/src/cmap/dim2/utils.rs
+++ b/honeycomb-core/src/cmap/dim2/utils.rs
@@ -105,10 +105,13 @@ impl<T: CoordsFloat> CMap2<T> {
 
         // cells
         // using 2 * sizeof(f64) bc sizeof(array) always is the size of a pointer
+        /*
         let geometry_vertex = self.vertices.allocated_size();
         let geometry_total = geometry_vertex;
         writeln!(file, "geometry_vertex, {geometry_vertex}").unwrap();
         writeln!(file, "geometry_total, {geometry_total}").unwrap();
+
+         */
 
         // others
         let others_freedarts = self.unused_darts.len();
@@ -177,10 +180,13 @@ impl<T: CoordsFloat> CMap2<T> {
 
         // cells
         // using 2 * sizeof(f64) bc sizeof(array) always is the size of a pointer
+        /*
         let geometry_vertex = self.vertices.effective_size();
         let geometry_total = geometry_vertex;
         writeln!(file, "geometry_vertex, {geometry_vertex}").unwrap();
         writeln!(file, "geometry_total, {geometry_total}").unwrap();
+
+         */
 
         // others
         let others_freedarts = self.unused_darts.len();
@@ -253,10 +259,13 @@ impl<T: CoordsFloat> CMap2<T> {
 
         // cells
         // using 2 * sizeof(f64) bc sizeof(array) always is the size of a pointer
+        /*
         let geometry_vertex = self.vertices.used_size();
         let geometry_total = geometry_vertex;
         writeln!(file, "geometry_vertex, {geometry_vertex}").unwrap();
         writeln!(file, "geometry_total, {geometry_total}").unwrap();
+
+         */
 
         // others
         let others_freedarts = self.unused_darts.len();


### PR DESCRIPTION
- rename some methods of the traits to avoid name conflicts
- implement `AttributeStorage` & `UnknownAttributeStorage` for `Vec<Option<A>>`

## Scope

- [x] Code

## Type of change

- [x] New features

## Other

- [x] Breaking change
