### PR TITLE
refactor!(core): remove lifetime from `OrbitPolicy` & update `AttributeBind`

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -317,7 +317,7 @@ impl AttrStorageManager {
 
 macro_rules! get_storage {
     ($slf: ident, $id: ident) => {
-        let probably_storage = match A::binds_to() {
+        let probably_storage = match A::BIND_POLICY {
             OrbitPolicy::Vertex => $slf.vertices.get(&TypeId::of::<A>()),
             OrbitPolicy::Edge => $slf.edges.get(&TypeId::of::<A>()),
             OrbitPolicy::Face => $slf.faces.get(&TypeId::of::<A>()),
@@ -332,7 +332,7 @@ macro_rules! get_storage {
 
 macro_rules! get_storage_mut {
     ($slf: ident, $id: ident) => {
-        let probably_storage = match A::binds_to() {
+        let probably_storage = match A::BIND_POLICY {
             OrbitPolicy::Vertex => $slf.vertices.get_mut(&TypeId::of::<A>()),
             OrbitPolicy::Edge => $slf.edges.get_mut(&TypeId::of::<A>()),
             OrbitPolicy::Face => $slf.faces.get_mut(&TypeId::of::<A>()),
@@ -373,7 +373,7 @@ impl AttrStorageManager {
     ) -> Result<(), ManagerError> {
         let typeid = TypeId::of::<A>();
         let new_storage = <A as AttributeBind>::StorageType::new(size);
-        if match A::binds_to() {
+        if match A::BIND_POLICY {
             OrbitPolicy::Vertex => self.vertices.insert(typeid, Box::new(new_storage)),
             OrbitPolicy::Edge => self.edges.insert(typeid, Box::new(new_storage)),
             OrbitPolicy::Face => self.faces.insert(typeid, Box::new(new_storage)),
@@ -414,7 +414,7 @@ impl AttrStorageManager {
     /// - downcasting `Box<dyn UnknownAttributeStorage>` to `<A as AttributeBind>::StorageType` fails
     #[must_use = "unused getter result - please remove this method call"]
     pub fn get_storage<A: AttributeBind>(&self) -> &<A as AttributeBind>::StorageType {
-        let probably_storage = match A::binds_to() {
+        let probably_storage = match A::BIND_POLICY {
             OrbitPolicy::Vertex => &self.vertices[&TypeId::of::<A>()],
             OrbitPolicy::Edge => &self.edges[&TypeId::of::<A>()],
             OrbitPolicy::Face => &self.faces[&TypeId::of::<A>()],
@@ -435,7 +435,7 @@ impl AttrStorageManager {
     /// - `A: AttributeBind` -- Attribute stored by the fetched storage.
     pub fn remove_storage<A: AttributeBind>(&mut self) {
         // we could return it ?
-        let _ = match A::binds_to() {
+        let _ = match A::BIND_POLICY {
             OrbitPolicy::Vertex => &self.vertices.remove(&TypeId::of::<A>()),
             OrbitPolicy::Edge => &self.edges.remove(&TypeId::of::<A>()),
             OrbitPolicy::Face => &self.faces.remove(&TypeId::of::<A>()),

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -35,9 +35,7 @@ impl AttributeUpdate for Temperature {
 impl AttributeBind for Temperature {
     type StorageType = AttrSparseVec<Temperature>;
     type IdentifierType = VertexIdentifier;
-    fn binds_to() -> OrbitPolicy {
-        OrbitPolicy::Vertex
-    }
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
 }
 
 impl From<f32> for Temperature {
@@ -120,7 +118,7 @@ fn attribute_update() {
 
 #[test]
 fn attribute_bind() {
-    assert_eq!(Temperature::binds_to(), OrbitPolicy::Vertex);
+    assert_eq!(Temperature::BIND_POLICY, OrbitPolicy::Vertex);
     let inst: <Temperature as AttributeBind>::IdentifierType = 0;
     let ref_inst: FaceIdentifier = 0;
     let prim_inst: u32 = 0;

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -35,7 +35,7 @@ impl AttributeUpdate for Temperature {
 impl AttributeBind for Temperature {
     type StorageType = AttrSparseVec<Temperature>;
     type IdentifierType = VertexIdentifier;
-    fn binds_to<'a>() -> OrbitPolicy<'a> {
+    fn binds_to() -> OrbitPolicy {
         OrbitPolicy::Vertex
     }
 }

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -113,10 +113,7 @@ pub trait AttributeUpdate: Sized {
 /// impl AttributeBind for Temperature {
 ///     type StorageType = AttrSparseVec<Self>;
 ///     type IdentifierType = FaceIdentifier;
-///
-///     fn binds_to() -> OrbitPolicy {
-///         OrbitPolicy::Face
-///     }
+///     const BIND_POLICY: OrbitPolicy = OrbitPolicy::Face;
 /// }
 /// ```
 pub trait AttributeBind: Debug + Sized + Any {
@@ -126,9 +123,9 @@ pub trait AttributeBind: Debug + Sized + Any {
     /// Identifier type of the entity the attribute is bound to.
     type IdentifierType: From<DartIdentifier> + num_traits::ToPrimitive + Clone;
 
-    /// Return an [`OrbitPolicy`] that can be used to identify the kind of topological entity to
-    /// which the attribute is associated.
-    fn binds_to() -> OrbitPolicy;
+    /// [`OrbitPolicy`] determining the kind of topological entity to which the attribute
+    /// is associated.
+    const BIND_POLICY: OrbitPolicy;
 }
 
 macro_rules! unknown_attribute_storage {

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -114,7 +114,7 @@ pub trait AttributeUpdate: Sized {
 ///     type StorageType = AttrSparseVec<Self>;
 ///     type IdentifierType = FaceIdentifier;
 ///
-///     fn binds_to<'a>() -> OrbitPolicy<'a> {
+///     fn binds_to() -> OrbitPolicy {
 ///         OrbitPolicy::Face
 ///     }
 /// }
@@ -128,7 +128,7 @@ pub trait AttributeBind: Debug + Sized + Any {
 
     /// Return an [`OrbitPolicy`] that can be used to identify the kind of topological entity to
     /// which the attribute is associated.
-    fn binds_to<'a>() -> OrbitPolicy<'a>;
+    fn binds_to() -> OrbitPolicy;
 }
 
 macro_rules! unknown_attribute_storage {

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeSet, VecDeque};
 /// This is used to define special cases of orbits that are often used in
 /// algorithms. These special cases correspond to *i-cells*.
 #[derive(Debug, PartialEq)]
-pub enum OrbitPolicy<'a> {
+pub enum OrbitPolicy {
     /// 0-cell orbit.
     Vertex,
     /// 1-cell orbit.
@@ -25,7 +25,7 @@ pub enum OrbitPolicy<'a> {
     /// 2-cell orbit.
     Face,
     /// Ordered array of beta functions that define the orbit.
-    Custom(&'a [u8]),
+    Custom(&'static [u8]),
 }
 
 /// Generic 2D orbit implementation
@@ -66,7 +66,7 @@ pub struct Orbit2<'a, T: CoordsFloat> {
     /// Reference to the map containing the beta functions used in the BFS.
     map_handle: &'a CMap2<T>,
     /// Policy used by the orbit for the BFS. It can be predetermined or custom.
-    orbit_policy: OrbitPolicy<'a>,
+    orbit_policy: OrbitPolicy,
     /// Set used to identify which dart is marked during the BFS.
     marked: BTreeSet<DartIdentifier>,
     /// Queue used to store which dart must be visited next during the BFS.
@@ -98,11 +98,7 @@ impl<'a, T: CoordsFloat> Orbit2<'a, T> {
     /// See [`CMap2`] example.
     ///
     #[must_use = "orbits are lazy and do nothing unless consumed"]
-    pub fn new(
-        map_handle: &'a CMap2<T>,
-        orbit_policy: OrbitPolicy<'a>,
-        dart: DartIdentifier,
-    ) -> Self {
+    pub fn new(map_handle: &'a CMap2<T>, orbit_policy: OrbitPolicy, dart: DartIdentifier) -> Self {
         let mut marked = BTreeSet::<DartIdentifier>::new();
         marked.insert(NULL_DART_ID); // we don't want to include the null dart in the orbit
         marked.insert(dart); // we're starting here, so we mark it beforehand

--- a/honeycomb-core/src/geometry/vertex.rs
+++ b/honeycomb-core/src/geometry/vertex.rs
@@ -220,7 +220,7 @@ impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
     type StorageType = AttrSparseVec<Self>;
     type IdentifierType = VertexIdentifier;
 
-    fn binds_to<'a>() -> OrbitPolicy<'a> {
+    fn binds_to() -> OrbitPolicy {
         OrbitPolicy::Vertex
     }
 }

--- a/honeycomb-core/src/geometry/vertex.rs
+++ b/honeycomb-core/src/geometry/vertex.rs
@@ -219,8 +219,5 @@ impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
 impl<T: CoordsFloat> AttributeBind for Vertex2<T> {
     type StorageType = AttrSparseVec<Self>;
     type IdentifierType = VertexIdentifier;
-
-    fn binds_to() -> OrbitPolicy {
-        OrbitPolicy::Vertex
-    }
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
 }

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -446,7 +446,7 @@ impl AttributeUpdate for Boundary {
 }
 
 impl AttributeBind for Boundary {
-    fn binds_to<'a>() -> OrbitPolicy<'a> {
+    fn binds_to() -> OrbitPolicy {
         OrbitPolicy::Custom(&[])
     }
 

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -446,11 +446,7 @@ impl AttributeUpdate for Boundary {
 }
 
 impl AttributeBind for Boundary {
-    fn binds_to() -> OrbitPolicy {
-        OrbitPolicy::Custom(&[])
-    }
-
-    type IdentifierType = DartIdentifier;
-
     type StorageType = AttrSparseVec<Self>;
+    type IdentifierType = DartIdentifier;
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
 }


### PR DESCRIPTION
- remove arbitrary lifetime from `OrbitPolicy`
- replace `AttributeBind::binds_to()` with a const `OrbitPolicy`

I don't think we need runtime-valued orbit policy, & this simplifies the struct

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Other

- [x] Breaking change