### PR TITLE
refactor: replace some panics with `unreachable!()`

### DIFF
--- a/honeycomb-core/src/cmap/builder/io/mod.rs
+++ b/honeycomb-core/src/cmap/builder/io/mod.rs
@@ -73,7 +73,7 @@ macro_rules! build_vertices {
         $v.chunks_exact(3)
             .map(|slice| {
                 // WE IGNORE Z values
-                let &[x, y, _] = slice else { panic!() };
+                let &[x, y, _] = slice else { unreachable!() };
                 Vertex2(T::from(x).unwrap(), T::from(y).unwrap())
             })
             .collect()

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -62,7 +62,7 @@ macro_rules! build_vertices {
         $v.chunks_exact(3)
             .map(|slice| {
                 // WE IGNORE Z values
-                let &[x, y, _] = slice else { panic!() };
+                let &[x, y, _] = slice else { unreachable!() };
                 Vertex2::from((T::from(x).unwrap(), T::from(y).unwrap()))
             })
             .collect()


### PR DESCRIPTION
With this, the only few panics left in the code are "acceptable" ones, (e.g. panic when not finding the file to open). 

`grep -rni --include="*.rs" "panic\!"` output:

```
./honeycomb-core/src/cmap/builder/io/mod.rs:27:            Vtk::import(file_path).unwrap_or_else(|e| panic!("E: failed to load file: {e:?}"));
./honeycomb-core/src/cmap/builder/io/mod.rs:49:            Vtk::import(value).unwrap_or_else(|e| panic!("E: failed to load file: {e:?}"));
./honeycomb-core/src/cmap/builder/io/tests.rs:32:            _ => panic!("cmap was built incorrectly"),
./examples/examples/io/read.rs:11:            Err(e) => panic!("Error while building map: {e:?}"),
./honeycomb-kernels/src/grisubal/mod.rs:144:        Err(e) => panic!("E: could not open specified vtk file - {e}"),
```

## Scope

- [x] Code

## Type of change

- [x] Refactor
