### PR TITLE
feat(kernels): implement polygon triangulation routines

### DIFF
--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -22,3 +22,4 @@
 // ------ MODULE DECLARATIONS
 
 pub mod grisubal;
+pub mod triangulation;

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
+use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
 pub fn process_cell<T: CoordsFloat>(
@@ -6,4 +6,69 @@ pub fn process_cell<T: CoordsFloat>(
     face_id: FaceIdentifier,
     new_darts: &[DartIdentifier],
 ) {
+    let mut n = Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).count();
+
+    // early rets
+    if n <= 3 {
+        println!("I: "); //TODO: complete
+        return;
+    }
+    if (n - 3) * 2 != new_darts.len() {
+        println!("W: "); //TODO: complete
+        return;
+    }
+
+    let mut darts: Vec<_> =
+        Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).collect();
+    let mut vertices: Vec<_> = darts
+        .iter()
+        .map(|dart_id| {
+            cmap.vertex(cmap.vertex_id(*dart_id))
+                .expect("E: found a topological vertex with no associated coordinates")
+        })
+        .collect();
+    let mut ndart_id = new_darts[0];
+    while n > 3 {
+        let ear = (0..n)
+            .find(|idx| {
+                let v1 = vertices[*idx];
+                let v2 = vertices[(*idx + 1) % n];
+                let v3 = vertices[(*idx + 2) % n];
+                let v4 = vertices[(*idx + 3) % n];
+                // we can easily check if two edges make up an ear using orientation
+                let v_in = v3 - v2; // BC
+                let v_out = v4 - v3; // CD
+                let v_new = v1 - v3; // CA
+                let or1 = (v_in.x() * v_new.y() - v_new.x() * v_in.y()).signum(); // in ^ new
+                let or2 = (-v_new.x() * v_out.y() + v_out.x() * v_new.y()).signum(); // -new ^ out
+                or1 == or2
+            })
+            .unwrap(); // safe unwrap bc of the two ear theorem
+
+        // edit cell; we use the nd1/nd2 edge to create a triangle from the ear
+        // nd1 is on the side of the tri, nd2 on the side of the rest of the cell
+        let d_ear1 = darts[ear];
+        let d_ear2 = darts[(ear + 1) % n];
+        let b0_d_ear1 = cmap.beta::<0>(d_ear1);
+        let b1_d_ear2 = cmap.beta::<1>(d_ear2);
+        let nd1 = ndart_id;
+        let nd2 = ndart_id + 1;
+        ndart_id += 2;
+        cmap.one_unlink(b0_d_ear1);
+        cmap.one_unlink(d_ear2);
+        cmap.one_link(d_ear2, nd1);
+        cmap.one_link(nd1, d_ear1);
+        cmap.one_link(b0_d_ear1, nd2);
+        cmap.one_link(nd2, b1_d_ear2);
+        cmap.two_link(nd1, nd2);
+
+        // edit existing vectors
+        darts.remove(ear + 1);
+        darts.push(nd2);
+        darts.swap_remove(ear);
+        vertices.remove(ear + 1);
+
+        // update n
+        n = Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), nd2).count();
+    }
 }

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -43,11 +43,11 @@ pub fn process_cell<T: CoordsFloat>(
 
     // early rets
     if n <= 3 {
-        println!("I: "); //TODO: complete
+        println!("I: face {face_id} is an {n}-gon -- skipping triangulation");
         return;
     }
     if (n - 3) * 2 != new_darts.len() {
-        println!("W: "); //TODO: complete
+        println!("W: not enough pre-allocated darts to triangulate face {face_id} -- skipping triangulation");
         return;
     }
 

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -1,6 +1,39 @@
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
+/// Triangulates a face using the ear clipping method.
+///
+/// This function triangulates a cell (face) of a 2D combinatorial map by iteratively
+/// clipping ears (triangles) from the polygon until only a single triangle remains.
+///
+/// Note that:
+/// - the function assumes that the polygon is simple (no self-intersections or holes).
+/// - the implementation might need adjustments for parallel operations or when working with
+///   identifiers not greater than existing ones.
+///
+/// # Arguments
+///
+/// - `cmap: &mut CMap2` - A mutable reference to the modified `CMap2`.
+/// - `face_id: FaceIdentifier` - Identifier of the face to triangulate within the map.
+/// - `new_darts: &[DartIdentifier]` - Identifiers of pre-allocated darts for the new edges;
+///   the slice length should match the expected number of edges created by the triangulation. For
+///   an `n`-sided polygon, the number of created edge is `n-3`, so the number of dart is `(n-3)*2`.
+///
+/// # Behavior
+///
+/// - The function begins by checking if the face has 3 or fewer vertices, in which case
+///   it's already triangulated or cannot be further processed.
+/// - It ensures that the number of new darts provided matches the triangulation requirement.
+/// - Iteratively finds an 'ear' of the polygon, where an ear is defined by three consecutive
+///   vertices where the triangle formed by these vertices is inside the original polygon.
+/// - Clips this ear by updating the combinatorial map's structure, effectively removing one
+///   vertex from the polygon per iteration.
+/// - Updates the list of darts and vertices accordingly after each ear clip.
+/// - Continues until the polygon is reduced to a triangle.
+///
+/// # Panics
+///
+/// The function will panic if a dart of the face does not have an associated vertex.
 pub fn process_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,
@@ -54,6 +87,8 @@ pub fn process_cell<T: CoordsFloat>(
         let nd1 = ndart_id;
         let nd2 = ndart_id + 1;
         ndart_id += 2;
+        // FIXME: using link methods only works if new identifiers are greater than all existing
+        // FIXME: using sew methods in parallel could crash bc of the panic when no vertex defined
         cmap.one_unlink(b0_d_ear1);
         cmap.one_unlink(d_ear2);
         cmap.one_link(d_ear2, nd1);

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -8,6 +8,7 @@ macro_rules! crossp_from_verts {
     };
 }
 
+#[allow(clippy::missing_panics_doc)]
 /// Triangulates a face using the ear clipping method.
 ///
 /// This function triangulates a cell (face) of a 2D combinatorial map by iteratively
@@ -39,9 +40,23 @@ macro_rules! crossp_from_verts {
 /// - Updates the list of darts and vertices accordingly after each ear clip.
 /// - Continues until the polygon is reduced to a triangle.
 ///
-/// # Panics
+/// # Errors
 ///
-/// The function will panic if a dart of the face does not have an associated vertex.
+/// This function will return an error if the face wasn't triangulated. There can be multiple
+/// reason for this:
+/// - The face is incompatible with the operation (made of 1, 2 or 3 vertices)
+/// - The number of pre-allocated darts did not match the expected number (see [#arguments])
+/// - The face contains one or more undefined vertices
+/// - The face does not contain an ear
+///
+/// Note that in all cases except the last, the face will remain the same as it was before the
+/// function call.
+///
+/// Because the ear clipping algorithm works iteratively, the face may be modified a few times
+/// before reaching a state where no ear can be found. Note, however, that this cannot occur if
+/// the face satisfies requirements mentionned above because of the [Two ears theorem][TET].
+///
+/// [TET]: https://en.wikipedia.org/wiki/Two_ears_theorem
 pub fn process_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -1,0 +1,9 @@
+use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
+use honeycomb_core::geometry::CoordsFloat;
+
+fn process_cell<T: CoordsFloat>(
+    cmap: &mut CMap2<T>,
+    face_id: FaceIdentifier,
+    new_darts: &[DartIdentifier],
+) {
+}

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -47,13 +47,14 @@ pub fn process_cell<T: CoordsFloat>(
     face_id: FaceIdentifier,
     new_darts: &[DartIdentifier],
 ) -> Result<(), TriangulateError> {
-    // early checks - check # of darts & face size
-    let mut n = Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).count();
-    check_requirements(n, new_darts.len(), face_id)?;
-
-    // get darts
+    // fetch darts using a custom orbit so that they're ordered
     let mut darts: Vec<_> =
         Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).collect();
+    let mut n = darts.len();
+
+    // early checks - check # of darts & face size
+    check_requirements(n, new_darts.len(), face_id)?;
+
     // get associated vertices - check for undefined vertices
     let mut vertices = fetch_face_vertices(cmap, &darts, face_id)?;
 

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -7,15 +7,6 @@ macro_rules! crossp_from_verts {
     };
 }
 
-macro_rules! is_vert_on_edge {
-    ($p: ident, $a: ident, $b: ident) => {{
-        let slope = ($b.y() - $a.y()) / ($b.x() - $a.x());
-        let expected_y = $a.y() * slope * ($p.x() - $a.x());
-        ($p.y() - expected_y).abs() / ($p.y().abs() + expected_y.abs()).min(T::max_value())
-            < T::epsilon()
-    }};
-}
-
 /// Triangulates a face using the ear clipping method.
 ///
 /// This function triangulates a cell (face) of a 2D combinatorial map by iteratively

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -1,7 +1,7 @@
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::geometry::CoordsFloat;
 
-fn process_cell<T: CoordsFloat>(
+pub fn process_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,
     new_darts: &[DartIdentifier],

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -41,11 +41,11 @@ pub fn process_cell<T: CoordsFloat>(
 
     // early rets
     if n <= 3 {
-        println!("I: "); //TODO: complete
+        println!("I: face {face_id} is an {n}-gon -- skipping triangulation");
         return;
     }
     if (n - 3) * 2 != new_darts.len() {
-        println!("W: "); //TODO: complete
+        println!("W: not enough pre-allocated darts to triangulate face {face_id} -- skipping triangulation");
         return;
     }
 
@@ -104,7 +104,7 @@ pub fn process_cell<T: CoordsFloat>(
         cmap.one_sew(cmap.beta::<1>(cmap.beta::<1>(d0)), d0);
         cmap.replace_vertex(cmap.vertex_id(*sdart), v0);
     } else {
-        println!("W: "); //TODO: complete
+        println!("W: face {face_id} isn't fannable -- skipping triangulation");
     }
 }
 
@@ -144,11 +144,11 @@ pub fn process_convex_cell<T: CoordsFloat>(
 
     // early rets
     if n <= 3 {
-        println!("I: "); //TODO: complete
+        println!("I: face {face_id} is an {n}-gon -- skipping triangulation");
         return;
     }
     if (n - 3) * 2 != new_darts.len() {
-        println!("W: "); //TODO: complete
+        println!("W: not enough pre-allocated darts to triangulate face {face_id} -- skipping triangulation");
         return;
     }
 

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -79,3 +79,43 @@ pub fn process_cell<T: CoordsFloat>(
         println!("W: "); //TODO: complete
     }
 }
+
+pub fn process_convex_cell<T: CoordsFloat>(
+    cmap: &mut CMap2<T>,
+    face_id: FaceIdentifier,
+    new_darts: &[DartIdentifier],
+) {
+    let n = Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).count();
+
+    // early rets
+    if n <= 3 {
+        println!("I: "); //TODO: complete
+        return;
+    }
+    if (n - 3) * 2 != new_darts.len() {
+        println!("W: "); //TODO: complete
+        return;
+    }
+
+    let sdart = face_id as DartIdentifier;
+
+    // if we found a dart from the previous computations, it means the polygon is "fannable"
+    // THIS CANNOT BE PARALLELIZED AS IS
+    let b0_sdart = cmap.beta::<0>(sdart);
+    let v0 = cmap.vertex(cmap.vertex_id(sdart)).unwrap();
+    cmap.one_unsew(b0_sdart);
+    let mut d0 = sdart;
+    for sl in new_darts.chunks_exact(2) {
+        let [d1, d2] = sl else { unreachable!() };
+        let b1_d0 = cmap.beta::<1>(d0);
+        let b1b1_d0 = cmap.beta::<1>(cmap.beta::<1>(d0));
+        cmap.one_unsew(b1_d0);
+        cmap.two_link(*d1, *d2);
+        cmap.one_link(*d2, b1b1_d0);
+        cmap.one_sew(b1_d0, *d1);
+        cmap.one_sew(*d1, d0);
+        d0 = *d2;
+    }
+    cmap.one_sew(cmap.beta::<1>(cmap.beta::<1>(d0)), d0);
+    cmap.replace_vertex(cmap.vertex_id(sdart), v0);
+}

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -2,6 +2,7 @@ use crate::triangulation::{check_requirements, fetch_face_vertices, TriangulateE
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
+#[allow(clippy::missing_panics_doc)]
 /// Triangulates a face using a fan triangulation method.
 ///
 /// This function triangulates a cell (face) in a 2D combinatorial map by creating a fan of
@@ -27,9 +28,17 @@ use honeycomb_core::geometry::CoordsFloat;
 /// - If such a star vertex is found, the function proceeds to create triangles by linking
 ///   new darts in a fan-like structure from this vertex. Otherwise, the cell is left unchanged
 ///
-/// # Panics
+/// # Errors
 ///
-/// The function will panic if a dart of the face does not have an associated vertex.
+/// This function will return an error if the face wasn't triangulated. There can be multiple
+/// reason for this:
+/// - The face is incompatible with the operation (made of 1, 2 or 3 vertices)
+/// - The number of pre-allocated darts did not match the expected number (see [#arguments])
+/// - The face contains one or more undefined vertices
+/// - The face isn't starrable
+///
+/// Note that in any of these cases, the face will remain the same as it was before the function
+/// call.
 pub fn process_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,
@@ -100,13 +109,15 @@ pub fn process_cell<T: CoordsFloat>(
     Ok(())
 }
 
+#[allow(clippy::missing_panics_doc)]
 /// Triangulates a face using a fan triangulation method.
 ///
 /// This function triangulates a cell (face) in a 2D combinatorial map by creating a fan of
 /// triangles from a the first vertex of
 ///
-/// **Note that this function assumes the polygon is convex and may fail or produce incorrect
-/// results if called on a non-convex cell**.
+/// **Note that this function assumes the polygon is convex and correctly defined (i.e. all vertices
+/// are) and may fail or produce incorrect results if called on a cell that does not verify these
+/// requirements**.
 ///
 /// # Arguments
 ///
@@ -124,9 +135,15 @@ pub fn process_cell<T: CoordsFloat>(
 /// - The function creates triangles by linking new darts in a fan-like structure to the first
 ///   vertex of the polygon. **This is done unconditionnally, whether the polygon is convex or not**.
 ///
-/// # Panics
+/// # Errors
 ///
-/// The function will panic if a dart of the face does not have an associated vertex.
+/// This function will return an error if the face wasn't triangulated. There can be multiple
+/// reason for this:
+/// - The face is incompatible with the operation (made of 1, 2 or 3 vertices)
+/// - The number of pre-allocated darts did not match the expected number (see [#arguments])
+///
+/// Note that in any of these cases, the face will remain the same as it was before the function
+/// call.
 pub fn process_convex_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -1,0 +1,9 @@
+use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
+use honeycomb_core::geometry::CoordsFloat;
+
+fn process_cell<T: CoordsFloat>(
+    cmap: &mut CMap2<T>,
+    face_id: FaceIdentifier,
+    new_darts: &[DartIdentifier],
+) {
+}

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -1,4 +1,4 @@
-use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
+use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
 fn process_cell<T: CoordsFloat>(
@@ -6,4 +6,71 @@ fn process_cell<T: CoordsFloat>(
     face_id: FaceIdentifier,
     new_darts: &[DartIdentifier],
 ) {
+    // fetch darts using a custom orbit so that they're ordered
+    let darts: Vec<_> =
+        Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).collect();
+    let n = darts.len();
+    if (n - 3) * 2 != new_darts.len() {
+        println!("W: "); //TODO: complete
+        return;
+    }
+
+    let vertices: Vec<_> = darts
+        .iter()
+        .map(|dart_id| {
+            cmap.vertex(cmap.vertex_id(*dart_id))
+                .expect("E: found a topological vertex with no associated coordinates")
+        })
+        .collect();
+
+    // iterating by ref so that we can still access the list
+    let star = darts
+        .iter()
+        .zip(vertices.iter())
+        .enumerate()
+        .find_map(|(id, (d0, v0))| {
+            let mut tmp = vertices
+                .windows(2)
+                // remove segments directly attached to v0
+                .filter(|_| !((n + id) % n == 0 || (n + id - 1) % n == 0))
+                .map(|val| {
+                    let [v1, v2] = val else { unreachable!() };
+                    let vec_in = *v1 - *v0;
+                    let vec_out = *v2 - *v1;
+                    let cosine = vec_in.dot(&vec_out) / (vec_in.norm() * vec_out.norm());
+                    cosine.acos() // angle in rad
+                });
+            let signum = tmp.next().map(|v| v.signum()).unwrap();
+            let mut diff = false;
+            tmp.for_each(|v| {
+                diff = v.signum() != signum;
+            });
+            if diff {
+                None
+            } else {
+                Some(d0)
+            }
+        });
+
+    if let Some(sdart) = star {
+        // if we found a dart from the previous computations, it means the polygon is "fannable"
+        // THIS CANNOT BE PARALLELIZED AS IS
+        let b0_sdart = cmap.beta::<0>(*sdart);
+        cmap.one_unsew(b0_sdart);
+        let mut d0 = *sdart;
+        for sl in new_darts.chunks_exact(2) {
+            let [d1, d2] = sl else { unreachable!() };
+            let b1_d0 = cmap.beta::<1>(d0);
+            let b1b1_d0 = cmap.beta::<1>(cmap.beta::<1>(d0));
+            cmap.one_unsew(b1_d0);
+            cmap.two_link(*d1, *d2);
+            cmap.one_link(*d2, b1b1_d0);
+            cmap.one_sew(b1_d0, *d1);
+            cmap.one_sew(*d1, d0);
+            d0 = *d2;
+        }
+        cmap.one_sew(cmap.beta::<1>(cmap.beta::<1>(d0)), d0);
+    } else {
+        println!("W: "); //TODO: complete
+    }
 }

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -1,7 +1,7 @@
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
-fn process_cell<T: CoordsFloat>(
+pub fn process_cell<T: CoordsFloat>(
     cmap: &mut CMap2<T>,
     face_id: FaceIdentifier,
     new_darts: &[DartIdentifier],
@@ -10,6 +10,12 @@ fn process_cell<T: CoordsFloat>(
     let darts: Vec<_> =
         Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).collect();
     let n = darts.len();
+
+    // early rets
+    if n == 3 {
+        println!("I: "); //TODO: complete
+        return;
+    }
     if (n - 3) * 2 != new_darts.len() {
         println!("W: "); //TODO: complete
         return;

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -74,7 +74,7 @@ pub fn process_cell<T: CoordsFloat>(
                     let vec_out = *v2 - *v1;
                     vec_in.x() * vec_out.y() - vec_out.x() * vec_in.y()
                 });
-            let signum = tmp.next().map(|v| v.signum()).unwrap();
+            let signum = tmp.next().map(T::signum).unwrap();
             for v in tmp {
                 if v.signum() != signum || v.abs() < T::epsilon() {
                     return None;

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -1,4 +1,6 @@
-use crate::triangulation::{check_requirements, fetch_face_vertices, TriangulateError};
+use crate::triangulation::{
+    check_requirements, crossp_from_verts, fetch_face_vertices, TriangulateError,
+};
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::CoordsFloat;
 
@@ -68,9 +70,7 @@ pub fn process_cell<T: CoordsFloat>(
                 .filter(|(i_seg, _)| !((n + i_seg) % n == id || (n + i_seg - 1) % n == id))
                 .map(|(_, val)| {
                     let [v1, v2] = val else { unreachable!() };
-                    let vec_in = *v1 - *v0;
-                    let vec_out = *v2 - *v1;
-                    vec_in.x() * vec_out.y() - vec_out.x() * vec_in.y()
+                    crossp_from_verts(v0, v1, v2)
                 });
             let signum = tmp.next().map(T::signum).unwrap();
             for v in tmp {

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -123,6 +123,11 @@ fn fetch_face_vertices<T: CoordsFloat>(
     }
 }
 
+/// Compute the cross product: `v1v2 x v2v3`.
+fn crossp_from_verts<T: CoordsFloat>(v1: &Vertex2<T>, v2: &Vertex2<T>, v3: &Vertex2<T>) -> T {
+    (v2.x() - v1.x()) * (v3.y() - v2.y()) - (v2.y() - v1.y()) * (v3.x() - v2.x())
+}
+
 // ------ TESTS
 
 #[cfg(test)]

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -71,7 +71,7 @@ pub fn check_requirements(
     Ok(())
 }
 
-pub fn fetch_face_vertices<T: CoordsFloat>(
+fn fetch_face_vertices<T: CoordsFloat>(
     cmap: &CMap2<T>,
     darts: &[DartIdentifier],
     face_id: FaceIdentifier,

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -1,8 +1,26 @@
+//! Polygon triangulation functions
+//!
+//! This module contains implementations of simple polygon triangulation methods. These are not
+//! meshing functions; our goal with these is to cut existing cells of an irregular mesh into
+//! triangular cells.
+//!
+//! With consideration to the above, we implement two polygon triangulation methods:
+//! - fanning -- two versions of this are implemented:
+//!     - a defensive one where the function actively search for a valid vertex to fan from
+//!     - a specific one which assume the cell is convex; it fans the polygon from its first vertex
+//! - ear clipping -- this method isn't algorithmically efficient, but (a) we operate on small
+//!   cells, and (b) it covers our needs (non-fannable polygons without holes)
+
+// ------ MODULE DECLARATIONS
+
 mod ear_clipping;
 mod fan;
 
+// ------ PUBLIC RE-EXPORTS
+
 pub use ear_clipping::process_cell as earclip_cell;
 pub use fan::process_cell as fan_cell;
+pub use fan::process_convex_cell as fan_convex_cell;
 
 // ------ TESTS
 

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -26,15 +26,49 @@ use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
 // ------ CONTENT
 
+/// Error-modeling enum for triangulation routines.
 pub enum TriangulateError {
+    /// The face to triangulate is already a triangle.
     AlreadyTriangulated,
+    /// The face has no ear to use for triangulation using the ear clipping method.
     NoEar,
+    /// The face is not fannable, i.e. there is no "star" vertex.
     NonFannable,
+    /// The number of darts passed to create the new segments is too low. The `usize` value
+    /// is the number of missing darts.
     NotEnoughDarts(usize),
+    /// The number of darts passed to create the new segments is too high. The `usize` value
+    /// is the number of excess darts.
     TooManyDarts(usize),
+    /// The face is not fit for triangulation. The `String` contains information about the reason.
     UndefinedFace(String),
 }
 
+#[allow(clippy::missing_errors_doc)]
+/// Checks if a face meets the requirements for triangulation.
+///
+/// This function performs several checks on a face before it can be triangulated:
+/// 1. Ensures the face has at least 3 vertices.
+/// 2. Verifies that the face is not already triangulated.
+/// 3. Confirms that the correct number of darts have been allocated for triangulation.
+///
+/// # Arguments
+///
+/// * `n_darts_face` - The number of darts in the face to be triangulated.
+/// * `n_darts_allocated` - The number of darts allocated for the triangulation process.
+/// * `face_id` - The identifier of the face being checked.
+///
+/// # Return / Errors
+///
+/// This function can return:
+/// - `Ok(())` if all checks pass and the face is ready for triangulation.
+/// - `Err(TriangulateError)` if any check fails, with a specific error describing the issue.
+///
+/// A failed check can result in the following errors:
+/// - `TriangulateError::UndefinedFace` - If the face has fewer than 3 vertices.
+/// - `TriangulateError::AlreadyTriangulated` - If the face already has exactly 3 vertices.
+/// - `TriangulateError::NotEnoughDarts` - If there aren't enough darts allocated for triangulation.
+/// - `TriangulateError::TooManyDarts` - If there are too many darts allocated for triangulation.
 #[allow(
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -18,13 +18,14 @@ mod fan;
 
 // ------ PUBLIC RE-EXPORTS
 
-use crate::triangulation::TriangulateError::UndefinedFace;
 pub use ear_clipping::process_cell as earclip_cell;
 pub use fan::process_cell as fan_cell;
 pub use fan::process_convex_cell as fan_convex_cell;
+
+// ------ CONTENT
+
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
-// ------ CONTENT
 
 /// Error-modeling enum for triangulation routines.
 pub enum TriangulateError {
@@ -114,7 +115,7 @@ fn fetch_face_vertices<T: CoordsFloat>(
         .iter()
         .map(|dart_id| cmap.vertex(cmap.vertex_id(*dart_id)));
     if tmp.clone().any(|v| v.is_none()) {
-        Err(UndefinedFace(format!(
+        Err(TriangulateError::UndefinedFace(format!(
             "face {face_id} has one or more undefined vertices"
         )))
     } else {

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -1,0 +1,2 @@
+mod ear_clipping;
+mod fan;

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -1,2 +1,10 @@
 mod ear_clipping;
 mod fan;
+
+pub use ear_clipping::process_cell as earclip_cell;
+pub use fan::process_cell as fan_cell;
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests;

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -21,6 +21,53 @@ mod fan;
 pub use ear_clipping::process_cell as earclip_cell;
 pub use fan::process_cell as fan_cell;
 pub use fan::process_convex_cell as fan_convex_cell;
+use honeycomb_core::cmap::FaceIdentifier;
+// ------ CONTENT
+
+pub enum TriangulateError {
+    AlreadyTriangulated,
+    NoEar,
+    NonFannable,
+    NotEnoughDarts(usize),
+    TooManyDarts(usize),
+    UndefinedFace(String),
+}
+
+#[allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_abs_to_unsigned
+)]
+pub fn check_requirements(
+    n_darts_face: usize,
+    n_darts_allocated: usize,
+    face_id: FaceIdentifier,
+) -> Result<(), TriangulateError> {
+    match n_darts_face {
+        1 | 2 => {
+            return Err(TriangulateError::UndefinedFace(format!(
+                "face {face_id} has less than three vertices"
+            )));
+        }
+        3 => {
+            return Err(TriangulateError::AlreadyTriangulated);
+        }
+        _ => {}
+    }
+
+    // check the value of n_allocated - n_expected
+    match n_darts_allocated as isize - (n_darts_face as isize - 3) * 2 {
+        diff @ ..0 => {
+            return Err(TriangulateError::NotEnoughDarts(diff.abs() as usize));
+        }
+        0 => {}
+        diff @ 1.. => {
+            return Err(TriangulateError::TooManyDarts(diff as usize));
+        }
+    }
+
+    Ok(())
+}
 
 // ------ TESTS
 

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -1,4 +1,4 @@
-use crate::triangulation::fan_cell;
+use crate::triangulation::{earclip_cell, fan_cell};
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::prelude::CMapBuilder;
 
@@ -135,47 +135,51 @@ fn earclip_cells() {
     let hex1: FaceIdentifier = 1;
     let hex2: FaceIdentifier = 7;
     let squ: FaceIdentifier = 13;
-    let nop: FaceIdentifier = 17;
+    let smh: FaceIdentifier = 17;
     let tri: FaceIdentifier = 26;
 
-    /*
-    // the hex will be
+    // the hex will be split in 4
     let nd = map.add_free_darts(6);
     let new_darts = (nd..nd + 6).collect::<Vec<_>>();
-    fan_cell(&mut map, hex1, &new_darts);
+    earclip_cell(&mut map, hex1, &new_darts);
 
     assert_eq!(map.i_cell::<2>(hex1 as DartIdentifier).count(), 3);
     assert_eq!(map.i_cell::<2>(3).count(), 3);
     assert_eq!(map.i_cell::<2>(4).count(), 3);
     assert_eq!(map.i_cell::<2>(5).count(), 3);
 
-    // the hex will be
+    // the hex will be split in 4
     let nd = map.add_free_darts(6);
     let new_darts = (nd..nd + 6).collect::<Vec<_>>();
-    fan_cell(&mut map, hex2, &new_darts);
+    earclip_cell(&mut map, hex2, &new_darts);
 
     assert_eq!(map.i_cell::<2>(hex2 as DartIdentifier).count(), 3);
     assert_eq!(map.i_cell::<2>(8).count(), 3);
     assert_eq!(map.i_cell::<2>(10).count(), 3);
     assert_eq!(map.i_cell::<2>(11).count(), 3);
 
-    // the square will be split in two
+    // the square will be split in 2
     let nd = map.add_free_darts(2);
     let new_darts = (nd..nd + 2).collect::<Vec<_>>();
-    fan_cell(&mut map, squ, &new_darts);
+    earclip_cell(&mut map, squ, &new_darts);
 
     assert_eq!(map.i_cell::<2>(squ as DartIdentifier).count(), 3);
     assert_eq!(map.i_cell::<2>(15).count(), 3);
 
-    // this will be a no-op since the polygon isn't fannable
+    // 9-gon is split in 7
     let nd = map.add_free_darts(12);
     let new_darts = (nd..nd + 12).collect::<Vec<_>>();
-    fan_cell(&mut map, nop, &new_darts);
+    earclip_cell(&mut map, smh, &new_darts);
 
-    assert_eq!(map.i_cell::<2>(nop as DartIdentifier).count(), 9); // unchanged
+    assert_eq!(map.i_cell::<2>(smh as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(18).count(), 3);
+    assert_eq!(map.i_cell::<2>(19).count(), 3);
+    assert_eq!(map.i_cell::<2>(21).count(), 3);
+    assert_eq!(map.i_cell::<2>(22).count(), 3);
+    assert_eq!(map.i_cell::<2>(23).count(), 3);
+    assert_eq!(map.i_cell::<2>(24).count(), 3);
 
-    fan_cell(&mut map, tri, &[]);
+    earclip_cell(&mut map, tri, &[]);
 
     assert_eq!(map.i_cell::<2>(tri as DartIdentifier).count(), 3); // unchanged
-     */
 }

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -1,5 +1,5 @@
 use crate::triangulation::fan_cell;
-use honeycomb_core::cmap::{CMap2, FaceIdentifier};
+use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::prelude::CMapBuilder;
 
 // you can copy paste this function into the render example to see what the mesh looks like
@@ -87,21 +87,42 @@ fn fan_cell_convex() {
     let nop: FaceIdentifier = 17;
     let tri: FaceIdentifier = 26;
 
+    // the hex will be
     let nd = map.add_free_darts(6);
     let new_darts = (nd..nd + 6).collect::<Vec<_>>();
     fan_cell(&mut map, hex1, &new_darts);
 
+    assert_eq!(map.i_cell::<2>(hex1 as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(3).count(), 3);
+    assert_eq!(map.i_cell::<2>(4).count(), 3);
+    assert_eq!(map.i_cell::<2>(5).count(), 3);
+
+    // the hex will be
     let nd = map.add_free_darts(6);
     let new_darts = (nd..nd + 6).collect::<Vec<_>>();
     fan_cell(&mut map, hex2, &new_darts);
 
+    assert_eq!(map.i_cell::<2>(hex2 as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(8).count(), 3);
+    assert_eq!(map.i_cell::<2>(10).count(), 3);
+    assert_eq!(map.i_cell::<2>(11).count(), 3);
+
+    // the square will be split in two
     let nd = map.add_free_darts(2);
     let new_darts = (nd..nd + 2).collect::<Vec<_>>();
     fan_cell(&mut map, squ, &new_darts);
 
+    assert_eq!(map.i_cell::<2>(squ as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(15).count(), 3);
+
+    // this will be a no-op since the polygon isn't fannable
     let nd = map.add_free_darts(12);
     let new_darts = (nd..nd + 12).collect::<Vec<_>>();
     fan_cell(&mut map, nop, &new_darts);
 
+    assert_eq!(map.i_cell::<2>(nop as DartIdentifier).count(), 9); // unchanged
+
     fan_cell(&mut map, tri, &[]);
+
+    assert_eq!(map.i_cell::<2>(tri as DartIdentifier).count(), 3); // unchanged
 }

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -77,7 +77,7 @@ fn generate_map() -> CMap2<f64> {
 }
 
 #[test]
-fn fan_cell_convex() {
+fn fan_cells() {
     // generate a map with all kinds of cell
     let mut map = generate_map();
     // we know these by construction
@@ -125,4 +125,57 @@ fn fan_cell_convex() {
     fan_cell(&mut map, tri, &[]);
 
     assert_eq!(map.i_cell::<2>(tri as DartIdentifier).count(), 3); // unchanged
+}
+
+#[test]
+fn earclip_cells() {
+    // generate a map with all kinds of cell
+    let mut map = generate_map();
+    // we know these by construction
+    let hex1: FaceIdentifier = 1;
+    let hex2: FaceIdentifier = 7;
+    let squ: FaceIdentifier = 13;
+    let nop: FaceIdentifier = 17;
+    let tri: FaceIdentifier = 26;
+
+    /*
+    // the hex will be
+    let nd = map.add_free_darts(6);
+    let new_darts = (nd..nd + 6).collect::<Vec<_>>();
+    fan_cell(&mut map, hex1, &new_darts);
+
+    assert_eq!(map.i_cell::<2>(hex1 as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(3).count(), 3);
+    assert_eq!(map.i_cell::<2>(4).count(), 3);
+    assert_eq!(map.i_cell::<2>(5).count(), 3);
+
+    // the hex will be
+    let nd = map.add_free_darts(6);
+    let new_darts = (nd..nd + 6).collect::<Vec<_>>();
+    fan_cell(&mut map, hex2, &new_darts);
+
+    assert_eq!(map.i_cell::<2>(hex2 as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(8).count(), 3);
+    assert_eq!(map.i_cell::<2>(10).count(), 3);
+    assert_eq!(map.i_cell::<2>(11).count(), 3);
+
+    // the square will be split in two
+    let nd = map.add_free_darts(2);
+    let new_darts = (nd..nd + 2).collect::<Vec<_>>();
+    fan_cell(&mut map, squ, &new_darts);
+
+    assert_eq!(map.i_cell::<2>(squ as DartIdentifier).count(), 3);
+    assert_eq!(map.i_cell::<2>(15).count(), 3);
+
+    // this will be a no-op since the polygon isn't fannable
+    let nd = map.add_free_darts(12);
+    let new_darts = (nd..nd + 12).collect::<Vec<_>>();
+    fan_cell(&mut map, nop, &new_darts);
+
+    assert_eq!(map.i_cell::<2>(nop as DartIdentifier).count(), 9); // unchanged
+
+    fan_cell(&mut map, tri, &[]);
+
+    assert_eq!(map.i_cell::<2>(tri as DartIdentifier).count(), 3); // unchanged
+     */
 }

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -1,0 +1,82 @@
+use honeycomb_core::cmap::CMap2;
+use honeycomb_core::prelude::CMapBuilder;
+
+// you can copy paste this function into the render example to see what the mesh looks like
+// it contains:
+// - one convex hexagon
+// - one concave (still fannable) hexagon
+// - one square
+// - one triangle
+// - one non-fannable n-gon
+fn generate_map() -> CMap2<f64> {
+    let mut cmap: CMap2<f64> = CMapBuilder::default().n_darts(28).build().unwrap();
+
+    // topology
+    cmap.one_link(1, 2);
+    cmap.one_link(2, 3);
+    cmap.one_link(3, 4);
+    cmap.one_link(4, 5);
+    cmap.one_link(5, 6);
+    cmap.one_link(6, 1);
+
+    cmap.one_link(7, 8);
+    cmap.one_link(8, 9);
+    cmap.one_link(9, 10);
+    cmap.one_link(10, 11);
+    cmap.one_link(11, 12);
+    cmap.one_link(12, 7);
+
+    cmap.one_link(13, 14);
+    cmap.one_link(14, 15);
+    cmap.one_link(15, 16);
+    cmap.one_link(16, 13);
+
+    cmap.one_link(17, 18);
+    cmap.one_link(18, 19);
+    cmap.one_link(19, 20);
+    cmap.one_link(20, 21);
+    cmap.one_link(21, 22);
+    cmap.one_link(22, 23);
+    cmap.one_link(23, 24);
+    cmap.one_link(24, 25);
+    cmap.one_link(25, 17);
+
+    cmap.one_link(26, 27);
+    cmap.one_link(27, 28);
+    cmap.one_link(28, 26);
+
+    cmap.two_link(3, 7);
+    cmap.two_link(4, 13);
+    cmap.two_link(10, 27);
+    cmap.two_link(11, 26);
+    cmap.two_link(12, 14);
+    cmap.two_link(15, 17);
+    cmap.two_link(18, 28);
+
+    // geometry
+    cmap.insert_vertex(1, (1.0, 0.0));
+    cmap.insert_vertex(2, (2.0, 0.0));
+    cmap.insert_vertex(3, (2.5, 0.5));
+    cmap.insert_vertex(4, (2.0, 1.0));
+    cmap.insert_vertex(5, (1.0, 1.0));
+    cmap.insert_vertex(6, (0.5, 0.5));
+    cmap.insert_vertex(9, (3.0, 1.0));
+    cmap.insert_vertex(10, (3.0, 2.0));
+    cmap.insert_vertex(11, (2.5, 1.0));
+    cmap.insert_vertex(12, (2.0, 2.0));
+    cmap.insert_vertex(16, (1.0, 2.0));
+    cmap.insert_vertex(20, (3.0, 3.0));
+    cmap.insert_vertex(21, (2.7, 3.0));
+    cmap.insert_vertex(22, (2.7, 2.3));
+    cmap.insert_vertex(23, (1.3, 2.3));
+    cmap.insert_vertex(24, (1.3, 3.0));
+    cmap.insert_vertex(25, (1.0, 3.0));
+
+    cmap
+}
+
+#[cfg(test)]
+fn fan_cell_convex() {
+    // generate a map with all kinds of cell
+    let map = generate_map();
+}

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -1,4 +1,5 @@
-use honeycomb_core::cmap::CMap2;
+use crate::triangulation::fan_cell;
+use honeycomb_core::cmap::{CMap2, FaceIdentifier};
 use honeycomb_core::prelude::CMapBuilder;
 
 // you can copy paste this function into the render example to see what the mesh looks like
@@ -75,8 +76,32 @@ fn generate_map() -> CMap2<f64> {
     cmap
 }
 
-#[cfg(test)]
+#[test]
 fn fan_cell_convex() {
     // generate a map with all kinds of cell
-    let map = generate_map();
+    let mut map = generate_map();
+    // we know these by construction
+    let hex1: FaceIdentifier = 1;
+    let hex2: FaceIdentifier = 7;
+    let squ: FaceIdentifier = 13;
+    let nop: FaceIdentifier = 17;
+    let tri: FaceIdentifier = 26;
+
+    let nd = map.add_free_darts(6);
+    let new_darts = (nd..nd + 6).collect::<Vec<_>>();
+    fan_cell(&mut map, hex1, &new_darts);
+
+    let nd = map.add_free_darts(6);
+    let new_darts = (nd..nd + 6).collect::<Vec<_>>();
+    fan_cell(&mut map, hex2, &new_darts);
+
+    let nd = map.add_free_darts(2);
+    let new_darts = (nd..nd + 2).collect::<Vec<_>>();
+    fan_cell(&mut map, squ, &new_darts);
+
+    let nd = map.add_free_darts(12);
+    let new_darts = (nd..nd + 12).collect::<Vec<_>>();
+    fan_cell(&mut map, nop, &new_darts);
+
+    fan_cell(&mut map, tri, &[]);
 }

--- a/honeycomb/src/lib.rs
+++ b/honeycomb/src/lib.rs
@@ -68,7 +68,7 @@ pub mod prelude {
     // ------ KERNELS RE-EXPORTS
 
     #[cfg(feature = "kernels")]
-    pub use honeycomb_kernels::grisubal;
+    pub use honeycomb_kernels::{grisubal, triangulation};
 
     // ------ RENDER RE-EXPORTS
 


### PR DESCRIPTION
Implement two polygon triangulation methods:
- ear clipping, which works on all polygons with no hole
- fanning, which only works on a subset of polygons; there is a generic implementation of this method and one dedicated to convex polygons

## Scope

- [x] Code

## Type of change

- [x] New feature(s)
