### PR TITLE
refactor(core): replace attribute-related panics with warnings

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -60,12 +60,17 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
     }
 
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
-        let new_val = self
-            .remove(inp.into())
-            .expect("E: cannot split attribute value - value not found in storage");
-        let (lhs_val, rhs_val) = AttributeUpdate::split(new_val);
-        self.set(lhs_out.into(), lhs_val);
-        self.set(rhs_out.into(), rhs_val);
+        let new_val = self.remove(inp.into());
+        if let Some(val) = new_val {
+            let (lhs_val, rhs_val) = AttributeUpdate::split(val);
+            self.set(lhs_out.into(), lhs_val);
+            self.set(rhs_out.into(), rhs_val);
+        } else {
+            println!("W: cannot split attribute value (not found in storage)");
+            println!("   setting both new values to `None`");
+            let _ = self.remove(lhs_out.into());
+            let _ = self.remove(rhs_out.into());
+        }
     }
 }
 
@@ -174,12 +179,17 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
     }
 
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
-        let new_val = self
-            .remove(inp.into())
-            .expect("E: cannot split attribute value - value not found in storage");
-        let (lhs_val, rhs_val) = AttributeUpdate::split(new_val);
-        self.set(lhs_out.into(), lhs_val);
-        self.set(rhs_out.into(), rhs_val);
+        let new_val = self.remove(inp.into());
+        if let Some(val) = new_val {
+            let (lhs_val, rhs_val) = AttributeUpdate::split(val);
+            self.set(lhs_out.into(), lhs_val);
+            self.set(rhs_out.into(), rhs_val);
+        } else {
+            println!("W: cannot split attribute value (not found in storage)");
+            println!("   setting both new values to `None`");
+            let _ = self.remove(lhs_out.into());
+            let _ = self.remove(rhs_out.into());
+        }
     }
 }
 

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -245,6 +245,9 @@ impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrComp
 
     fn replace(&mut self, id: A::IdentifierType, val: A) -> Option<A> {
         let idx = &self.index_map[id.to_usize().unwrap()];
+        if idx.is_none() {
+            return None;
+        }
         self.data.push(val);
         Some(self.data.swap_remove(idx.unwrap()))
     }

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -54,13 +54,16 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
         match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
             (Some(v1), Some(v2)) => self.set(out.into(), AttributeUpdate::merge(v1, v2)),
             (Some(v), None) | (None, Some(v)) => {
-                self.set(out.into(), AttributeUpdate::merge_undefined(Some(v)));
+                self.set(out.into(), AttributeUpdate::merge_incomplete(v));
             }
             (None, None) => {
-                // AttributeUpdate::merge_undefined(None)
-                println!("W: cannot merge two null attribute value");
-                println!("   setting new target value to `None`");
-                let _ = self.remove(out.into());
+                if let Some(v) = AttributeUpdate::merge_default() {
+                    self.set(out.into(), v);
+                } else {
+                    println!("W: cannot merge two null attribute value");
+                    println!("   setting new target value to `None`");
+                    let _ = self.remove(out.into());
+                }
             }
         };
     }
@@ -179,13 +182,16 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
         match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
             (Some(v1), Some(v2)) => self.set(out.into(), AttributeUpdate::merge(v1, v2)),
             (Some(v), None) | (None, Some(v)) => {
-                self.set(out.into(), AttributeUpdate::merge_undefined(Some(v)));
+                self.set(out.into(), AttributeUpdate::merge_incomplete(v));
             }
             (None, None) => {
-                // AttributeUpdate::merge_undefined(None)
-                println!("W: cannot merge two null attribute value");
-                println!("   setting new target value to `None`");
-                let _ = self.remove(out.into());
+                if let Some(v) = AttributeUpdate::merge_default() {
+                    self.set(out.into(), v);
+                } else {
+                    println!("W: cannot merge two null attribute value");
+                    println!("   setting new target value to `None`");
+                    let _ = self.remove(out.into());
+                }
             }
         };
     }

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -57,7 +57,7 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
                 self.set(out.into(), AttributeUpdate::merge_incomplete(v));
             }
             (None, None) => {
-                if let Some(v) = AttributeUpdate::merge_default() {
+                if let Some(v) = AttributeUpdate::merge_from_none() {
                     self.set(out.into(), v);
                 } else {
                     println!("W: cannot merge two null attribute value");
@@ -185,7 +185,7 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
                 self.set(out.into(), AttributeUpdate::merge_incomplete(v));
             }
             (None, None) => {
-                if let Some(v) = AttributeUpdate::merge_default() {
+                if let Some(v) = AttributeUpdate::merge_from_none() {
                     self.set(out.into(), v);
                 } else {
                     println!("W: cannot merge two null attribute value");

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -51,12 +51,18 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
     }
 
     fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier) {
-        let new_val = match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
-            (Some(v1), Some(v2)) => AttributeUpdate::merge(v1, v2),
-            (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_undefined(Some(v)),
-            (None, None) => AttributeUpdate::merge_undefined(None),
+        match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
+            (Some(v1), Some(v2)) => self.set(out.into(), AttributeUpdate::merge(v1, v2)),
+            (Some(v), None) | (None, Some(v)) => {
+                self.set(out.into(), AttributeUpdate::merge_undefined(Some(v)));
+            }
+            (None, None) => {
+                // AttributeUpdate::merge_undefined(None)
+                println!("W: cannot merge two null attribute value");
+                println!("   setting new target value to `None`");
+                let _ = self.remove(out.into());
+            }
         };
-        self.set(out.into(), new_val);
     }
 
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
@@ -170,12 +176,18 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
     }
 
     fn merge(&mut self, out: DartIdentifier, lhs_inp: DartIdentifier, rhs_inp: DartIdentifier) {
-        let new_val = match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
-            (Some(v1), Some(v2)) => AttributeUpdate::merge(v1, v2),
-            (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_undefined(Some(v)),
-            (None, None) => AttributeUpdate::merge_undefined(None),
+        match (self.remove(lhs_inp.into()), self.remove(rhs_inp.into())) {
+            (Some(v1), Some(v2)) => self.set(out.into(), AttributeUpdate::merge(v1, v2)),
+            (Some(v), None) | (None, Some(v)) => {
+                self.set(out.into(), AttributeUpdate::merge_undefined(Some(v)));
+            }
+            (None, None) => {
+                // AttributeUpdate::merge_undefined(None)
+                println!("W: cannot merge two null attribute value");
+                println!("   setting new target value to `None`");
+                let _ = self.remove(out.into());
+            }
         };
-        self.set(out.into(), new_val);
     }
 
     fn split(&mut self, lhs_out: DartIdentifier, rhs_out: DartIdentifier, inp: DartIdentifier) {
@@ -225,10 +237,8 @@ impl<A: AttributeBind + AttributeUpdate + Copy> AttributeStorage<A> for AttrComp
         self.index_map[id.to_usize().unwrap()].map(|idx| self.data[idx])
     }
 
-    // FIXME: panics instead of returning None
     fn replace(&mut self, id: A::IdentifierType, val: A) -> Option<A> {
         let idx = &self.index_map[id.to_usize().unwrap()];
-        assert!(idx.is_some());
         self.data.push(val);
         Some(self.data.swap_remove(idx.unwrap()))
     }

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -13,5 +13,6 @@ pub use manager::AttrStorageManager;
 pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
 
 // ------ TESTS
+
 #[cfg(test)]
 mod tests;

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -27,8 +27,12 @@ impl AttributeUpdate for Temperature {
         (attr, attr)
     }
 
-    fn merge_undefined(attr: Option<Self>) -> Self {
-        attr.unwrap_or(Temperature { val: 0.0 })
+    fn merge_incomplete(attr: Self) -> Self {
+        Temperature::from(attr.val / 2.0)
+    }
+
+    fn merge_default() -> Option<Self> {
+        Some(Temperature::from(0.0))
     }
 }
 
@@ -112,8 +116,11 @@ fn attribute_update() {
     let t_ref = Temperature { val: 285.5 };
 
     assert_eq!(Temperature::split(t_new), (t_ref, t_ref)); // or Temperature::_
-    assert_eq!(Temperature::merge_undefined(Some(t_ref)), t_ref);
-    assert_eq!(Temperature::merge_undefined(None), Temperature::from(0.0));
+    assert_eq!(
+        Temperature::merge_incomplete(t_ref),
+        Temperature::from(t_ref.val / 2.0)
+    );
+    assert_eq!(Temperature::merge_default(), Some(Temperature::from(0.0)));
 }
 
 #[test]

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -191,7 +191,7 @@ fn sparse_vec_merge_undefined() {
     storage.merge(6, 3, 4);
     assert_eq!(storage.get(3), None);
     assert_eq!(storage.get(4), None);
-    assert_eq!(storage.get(6), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get(6), Some(Temperature::from(281.0 / 2.0)));
 }
 
 #[test]
@@ -346,7 +346,7 @@ fn compact_vec_merge_undefined() {
     storage.merge(6, 3, 4);
     assert_eq!(storage.get(3), None);
     assert_eq!(storage.get(4), None);
-    assert_eq!(storage.get(6), Some(Temperature::from(281.0)));
+    assert_eq!(storage.get(6), Some(Temperature::from(281.0 / 2.0)));
 }
 
 #[test]
@@ -440,11 +440,10 @@ fn compact_vec_remove_insert() {
 }
 
 #[test]
-#[should_panic(expected = "assertion failed: idx.is_some()")]
 fn compact_vec_replace_already_removed() {
     generate_compact!(storage);
     assert_eq!(storage.remove(3), Some(Temperature::from(279.0)));
-    storage.replace(3, Temperature::from(280.0)); // panic
+    assert!(storage.replace(3, Temperature::from(280.0)).is_none());
 }
 
 // storage manager
@@ -585,7 +584,10 @@ fn manager_merge_undefined_attribute() {
     manager.merge_attribute::<Temperature>(6, 3, 4);
     assert_eq!(manager.get_attribute::<Temperature>(3), None);
     assert_eq!(manager.get_attribute::<Temperature>(4), None);
-    assert_eq!(manager.get_attribute(6), Some(Temperature::from(281.0)));
+    assert_eq!(
+        manager.get_attribute(6),
+        Some(Temperature::from(281.0 / 2.0))
+    );
 }
 
 #[test]

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -31,7 +31,7 @@ impl AttributeUpdate for Temperature {
         Temperature::from(attr.val / 2.0)
     }
 
-    fn merge_default() -> Option<Self> {
+    fn merge_from_none() -> Option<Self> {
         Some(Temperature::from(0.0))
     }
 }
@@ -120,7 +120,7 @@ fn attribute_update() {
         Temperature::merge_incomplete(t_ref),
         Temperature::from(t_ref.val / 2.0)
     );
-    assert_eq!(Temperature::merge_default(), Some(Temperature::from(0.0)));
+    assert_eq!(Temperature::merge_from_none(), Some(Temperature::from(0.0)));
 }
 
 #[test]

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -43,11 +43,11 @@ use dyn_clone::{clone_trait_object, DynClone};
 ///     }
 ///
 ///     fn merge_incomplete(attr: Self) -> Self {
-///         Temperature::from(attr.val / 2.0)
+///         Temperature { val: attr.val / 2.0 }
 ///     }
 ///
 ///     fn merge_default() -> Option<Self> {
-///         Some(Temperature::from(0.0))
+///         Some(Temperature { val: 0.0 })
 ///     }
 /// }
 ///
@@ -111,11 +111,11 @@ pub trait AttributeUpdate: Sized {
 /// #     }
 /// #
 /// #     fn merge_incomplete(attr: Self) -> Self {
-/// #         Temperature::from(attr.val / 2.0)
+/// #         Temperature { val: attr.val / 2.0 }
 /// #     }
 /// #
 /// #     fn merge_default() -> Option<Self> {
-/// #         Some(Temperature::from(0.0))
+/// #         Some(Temperature { val: 0.0 })
 /// #     }
 /// # }
 ///

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -78,6 +78,7 @@ pub trait AttributeUpdate: Sized {
     /// value.
     ///
     /// The default implementation return `None`.
+    #[allow(clippy::must_use_candidate)]
     fn merge_default() -> Option<Self> {
         None
     }

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -46,7 +46,7 @@ use dyn_clone::{clone_trait_object, DynClone};
 ///         Temperature { val: attr.val / 2.0 }
 ///     }
 ///
-///     fn merge_default() -> Option<Self> {
+///     fn merge_from_none() -> Option<Self> {
 ///         Some(Temperature { val: 0.0 })
 ///     }
 /// }
@@ -79,7 +79,7 @@ pub trait AttributeUpdate: Sized {
     ///
     /// The default implementation return `None`.
     #[allow(clippy::must_use_candidate)]
-    fn merge_default() -> Option<Self> {
+    fn merge_from_none() -> Option<Self> {
         None
     }
 }
@@ -115,7 +115,7 @@ pub trait AttributeUpdate: Sized {
 /// #         Temperature { val: attr.val / 2.0 }
 /// #     }
 /// #
-/// #     fn merge_default() -> Option<Self> {
+/// #     fn merge_from_none() -> Option<Self> {
 /// #         Some(Temperature { val: 0.0 })
 /// #     }
 /// # }

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -6,7 +6,6 @@
 // ------ IMPORTS
 
 use crate::prelude::{DartIdentifier, OrbitPolicy};
-use core::panic;
 use downcast_rs::{impl_downcast, Downcast};
 use std::any::Any;
 use std::fmt::Debug;
@@ -43,8 +42,12 @@ use dyn_clone::{clone_trait_object, DynClone};
 ///         (attr, attr)
 ///     }
 ///
-///     fn merge_undefined(attr: Option<Self>) -> Self {
-///         attr.unwrap_or(Temperature { val: 0.0 })
+///     fn merge_incomplete(attr: Self) -> Self {
+///         Temperature::from(attr.val / 2.0)
+///     }
+///
+///     fn merge_default() -> Option<Self> {
+///         Some(Temperature::from(0.0))
 ///     }
 /// }
 ///
@@ -63,24 +66,20 @@ pub trait AttributeUpdate: Sized {
     /// Splitting routine, i.e. how to obtain the two attributes from a single one.
     fn split(attr: Self) -> (Self, Self);
 
-    /// Fallback merging routine, i.e. how to obtain the new attribute value from potentially
-    /// undefined instances.
+    /// Fallback merging routine, i.e. how to obtain the new attribute value from a single existing
+    /// value.
     ///
-    /// The default implementation may panic if no attribute can be used to create a value. The
-    /// reason for that is as follows:
+    /// The default implementation simply returns the passed value.
+    fn merge_incomplete(attr: Self) -> Self {
+        attr
+    }
+
+    /// Fallback merging routine, i.e. how to obtain the new attribute value from no existing
+    /// value.
     ///
-    /// This trait and its methods were designed with the (un)sewing operation in mind. Their
-    /// purpose is to simplify the code needed to propagate updates of attributes affected by the
-    /// (un)sewing operation. Considering this context, as well as the definition of (un)linking
-    /// operations, this panic seems reasonable: If the darts you are sewing have totally undefined
-    /// attributes, you should most likely be linking them instead of sewing.
-    fn merge_undefined(attr: Option<Self>) -> Self {
-        attr.unwrap_or_else(|| {
-            panic!(
-                "E: attempt to merge two undefined {} instances",
-                std::any::type_name::<Self>()
-            );
-        })
+    /// The default implementation return `None`.
+    fn merge_default() -> Option<Self> {
+        None
     }
 }
 
@@ -111,8 +110,12 @@ pub trait AttributeUpdate: Sized {
 /// #         (attr, attr)
 /// #     }
 /// #
-/// #     fn merge_undefined(attr: Option<Self>) -> Self {
-/// #         attr.unwrap_or(Temperature { val: 0.0 })
+/// #     fn merge_incomplete(attr: Self) -> Self {
+/// #         Temperature::from(attr.val / 2.0)
+/// #     }
+/// #
+/// #     fn merge_default() -> Option<Self> {
+/// #         Some(Temperature::from(0.0))
 /// #     }
 /// # }
 ///

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -69,7 +69,9 @@ impl<T: CoordsFloat> CMap2<T> {
                 .vertex(self.vertex_id(b1d1_old))
                 .expect("E: attempt to split an edge that is not fully defined in the first place");
             // unsew current dart
-            self.one_unlink(base_dart1);
+            // self.one_unlink(base_dart1);
+            self.betas[base_dart1 as usize][1] = 0;
+            self.betas[b1d1_old as usize][0] = 0;
             // rebuild the edge
             self.one_link(base_dart1, b1d1_new);
             self.one_link(b1d1_new, b1d1_old);
@@ -91,8 +93,12 @@ impl<T: CoordsFloat> CMap2<T> {
                 .vertex(self.vertex_id(base_dart2))
                 .expect("E: attempt to split an edge that is not fully defined in the first place");
             // unsew current darts
-            self.one_unlink(base_dart1);
-            self.one_unlink(base_dart2);
+            // self.one_unlink(base_dart1);
+            self.betas[base_dart1 as usize][1] = 0;
+            self.betas[b1d1_old as usize][0] = 0;
+            // self.one_unlink(base_dart2);
+            self.betas[base_dart2 as usize][1] = 0;
+            self.betas[b1d2_old as usize][0] = 0;
             self.two_unlink(base_dart1);
             // rebuild the edge
             self.one_link(base_dart1, b1d1_new);
@@ -200,7 +206,9 @@ impl<T: CoordsFloat> CMap2<T> {
         let seg = v2 - v1;
 
         // unsew current dart
-        self.one_unlink(base_dart1);
+        // self.one_unlink(base_dart1);
+        self.betas[base_dart1 as usize][1] = 0;
+        self.betas[b1d1_old as usize][0] = 0;
         if base_dart2 != NULL_DART_ID {
             self.two_unlink(base_dart1);
         }
@@ -227,7 +235,9 @@ impl<T: CoordsFloat> CMap2<T> {
         // if b2(base_dart1) is defined, insert vertices / darts on its side too
         if base_dart2 != NULL_DART_ID {
             let b1d2_old = self.beta::<1>(base_dart2);
-            self.one_unlink(base_dart2);
+            // self.one_unlink(base_dart2);
+            self.betas[base_dart2 as usize][1] = 0;
+            self.betas[b1d2_old as usize][0] = 0;
             let mut prev_d = base_dart2;
             darts.iter().rev().for_each(|d| {
                 self.two_link(prev_d, *d);

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -173,16 +173,14 @@ fn two_sew_no_b1() {
 }
 
 #[test]
-#[should_panic(
-    expected = "No vertices defined on either darts 1/2 , use `two_link` instead of `two_sew`"
-)]
+// #[should_panic] // FIXME: find a way to test what's printed?
 fn two_sew_no_attributes() {
     let mut map: CMap2<f64> = CMap2::new(2);
     map.two_sew(1, 2); // should panic
 }
 
 #[test]
-#[should_panic(expected = "E: attempt to merge two undefined vertices")]
+// #[should_panic] // FIXME: find a way to test what's printed?
 fn two_sew_no_attributes_bis() {
     let mut map: CMap2<f64> = CMap2::new(4);
     map.one_link(1, 2);
@@ -233,14 +231,14 @@ fn one_sew_incomplete_beta() {
     assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
 }
 #[test]
-#[should_panic(expected = "No vertex defined on dart 2, use `one_link` instead of `one_sew`")]
+// #[should_panic] // FIXME: find a way to test what's printed?
 fn one_sew_no_attributes() {
     let mut map: CMap2<f64> = CMap2::new(2);
     map.one_sew(1, 2); // should panic
 }
 
 #[test]
-#[should_panic(expected = "E: attempt to merge two undefined vertices")]
+// #[should_panic] // FIXME: find a way to test what's printed?
 fn one_sew_no_attributes_bis() {
     let mut map: CMap2<f64> = CMap2::new(3);
     map.two_link(1, 2);

--- a/honeycomb-core/src/geometry/vertex.rs
+++ b/honeycomb-core/src/geometry/vertex.rs
@@ -197,8 +197,7 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 ///
 /// - **MERGING POLICY** - The new vertex is placed at the midpoint between the two existing ones.
 /// - **SPLITTING POLICY** - The current vertex is duplicated.
-/// - **UNDEFINED ATTRIBUTES MERGING** - The new vertex takes the value of the one provided if it
-///   exists, otherwise the function panics.
+/// - **(PARTIALLY) UNDEFINED ATTRIBUTES MERGING** - The default implementations are used.
 impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
     fn merge(attr1: Self, attr2: Self) -> Self {
         Self::average(&attr1, &attr2)
@@ -206,10 +205,6 @@ impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
 
     fn split(attr: Self) -> (Self, Self) {
         (attr, attr)
-    }
-
-    fn merge_undefined(attr: Option<Self>) -> Self {
-        attr.expect("E: attempt to merge two undefined vertices")
     }
 }
 

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -440,7 +440,7 @@ impl AttributeUpdate for Boundary {
         unreachable!()
     }
 
-    fn merge_default() -> Option<Self> {
+    fn merge_from_none() -> Option<Self> {
         Some(Boundary::None)
     }
 }

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -440,8 +440,8 @@ impl AttributeUpdate for Boundary {
         unreachable!()
     }
 
-    fn merge_undefined(attr: Option<Self>) -> Self {
-        attr.unwrap_or(Boundary::None)
+    fn merge_default() -> Option<Self> {
+        Some(Boundary::None)
     }
 }
 


### PR DESCRIPTION
- sew methods now behave like link methods even if there are no attribute defined (instead of panicking)
- update `UnknownAttributeStorage` implementations to print warnings instead of panick when attributes are missing
- replace `AttributeUpdate::merge_undefined` with two distinct functions depending if there's one or no attribute available

The PR has mixed content, the changes I started required more and more stuff to be changed as a consequence

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Other

- [x] Breaking change