### PR TITLE
refactor!(core): change `split_edge` & `splitn_edge` to use preallocated darts

### DIFF
--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -50,7 +50,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///  1             2    =>    1      3      2   | + denote darts that encode vertex IDs
     ///    <----2----+              <-4-- <-2-+     |
     /// ```
-    pub fn split_edge(
+    pub fn split_edge_noalloc(
         &mut self,
         edge_id: EdgeIdentifier,
         new_darts: (DartIdentifier, DartIdentifier), // 2D => statically known number of darts
@@ -176,7 +176,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// // split
     /// let nds = map.add_free_darts(6);
     /// let new_darts: Vec<_> = (nds..nds+6).collect();
-    /// map.splitn_edge(1, &new_darts ,&[0.25, 0.50, 0.75]);
+    /// map.splitn_edge_no_alloc(1, &new_darts ,&[0.25, 0.50, 0.75]);
     /// // after
     /// //    <-<-<-<
     /// //  1 -3-4-5- 2
@@ -201,7 +201,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// assert_eq!(map.beta::<2>(4), 6);
     /// assert_eq!(map.beta::<2>(5), 2);
     /// ```
-    pub fn splitn_edge(
+    pub fn splitn_edge_no_alloc(
         &mut self,
         edge_id: EdgeIdentifier,
         new_darts: &[DartIdentifier],

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -261,38 +261,28 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This implementation is 2D specific.
     /// </div>
     ///
-    /// This method takes all darts of an edge and rebuild connections in order to create a new
-    /// point on this edge. The position of the point defaults to the midway point, but it can
-    /// optionally be specified.
+    /// This method is a variant of [`split_edge`] where inline dart allocations are removed.
     ///
-    /// In order to minimize editing of embedded data, the original darts are kept to their
-    /// original vertices while the new darts are used to model the new point.
-    ///
-    /// For an illustration of both principles, refer to the example.
+    /// The method follows the same logic as the regular [`split_edge`], the only difference being
+    /// that the new darts won't be added to the map on the fly. Instead, the method uses the two
+    /// darts passed as argument (`new_darts`) to build the new segments. Consequently, there is no
+    /// guarantee that IDs will be consistent between this and the regular method.
     ///
     /// # Arguments
     ///
     /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
+    /// - `new_darts: (DartIdentifier, DartIdentifier)` -- Dart IDs used to build the new segments.
     /// - `midpoint_vertex: Option<T>` -- Relative position of the new vertex, starting from the
     ///   vertex of the dart sharing `edge_id` as its identifier.
+    ///
+    /// ## Dart IDs Requirements & Usage
+    ///
+    /// TODO
     ///
     /// # Panics
     ///
     /// This method may panic if the edge upon which the operation is performed does not have two
     /// defined vertices.
-    ///
-    /// # Example
-    ///
-    /// Given an edge made of darts `1` and `2`, these darts respectively encoding vertices
-    /// `(0.0, 0.0)` and `(2.0, 0.0)`, calling `map.split_edge(1, Some(0.2))` would result in the
-    /// creation of two new darts, a new vertex (ID `3`) at position `(0.4, 0.0)` and the following
-    /// topology:
-    ///
-    /// ```text
-    ///    +----1---->              +-1-> +-3->     |
-    ///  1             2    =>    1      3      2   | + denote darts that encode vertex IDs
-    ///    <----2----+              <-4-- <-2-+     |
-    /// ```
     pub fn split_edge_noalloc(
         &mut self,
         edge_id: EdgeIdentifier,
@@ -387,63 +377,27 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This implementation is 2D specific.
     /// </div>
     ///
+    /// This method is a variant of [`splitn_edge`] where inline dart allocations are removed.
+    ///
+    /// The method follows the same logic as the regular [`splitn_edge`], the only difference being
+    /// that the new darts won't be added to the map on the fly. Instead, the method uses darts
+    /// passed as argument (`new_darts`) to build the new segments. Consequently, there is no
+    /// guarantee that IDs will be consistent between this and the regular method.
+    ///
     /// # Arguments
     ///
     /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
-    /// - `midpoint_vertices: I` -- Relative positions of new vertices, starting from the
+    /// - `new_darts: &[DartIdentifier]` -- Dart IDs used to build the new segments.
+    /// - `midpoint_vertices: &[T]` -- Relative positions of new vertices, starting from the
     ///   vertex of the dart sharing `edge_id` as its identifier.
     ///
-    /// ## Generics
+    /// ## Dart IDs Requirements & Usage
     ///
-    /// - `I: Iterator<Item = T>` -- Iterator over `T` values. These should be in the `]0; 1[` open range.
+    /// TODO
     ///
     /// # Panics
     ///
     /// This method may panic if the edge upon which the operation is performed does not have two defined vertices.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use honeycomb_core::prelude::{CMap2, CMapBuilder, NULL_DART_ID, Vertex2};
-    /// // before
-    /// //    <--2---
-    /// //  1         2
-    /// //    ---1-->
-    /// let mut map: CMap2<f64> = CMapBuilder::default()
-    ///                             .n_darts(2)
-    ///                             .build()
-    ///                             .unwrap();
-    /// map.two_link(1, 2);
-    /// map.insert_vertex(1, (0.0, 0.0));
-    /// map.insert_vertex(2, (1.0, 0.0));
-    /// // split
-    /// let nds = map.add_free_darts(6);
-    /// let new_darts: Vec<_> = (nds..nds+6).collect();
-    /// map.splitn_edge_no_alloc(1, &new_darts ,&[0.25, 0.50, 0.75]);
-    /// // after
-    /// //    <-<-<-<
-    /// //  1 -3-4-5- 2
-    /// //    >->->->
-    /// assert_eq!(&new_darts[0..3], &[3, 4, 5]);
-    /// assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
-    /// assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
-    /// assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
-    ///
-    /// assert_eq!(map.beta::<1>(1), 3);
-    /// assert_eq!(map.beta::<1>(3), 4);
-    /// assert_eq!(map.beta::<1>(4), 5);
-    /// assert_eq!(map.beta::<1>(5), NULL_DART_ID);
-    ///
-    /// assert_eq!(map.beta::<1>(2), 6);
-    /// assert_eq!(map.beta::<1>(6), 7);
-    /// assert_eq!(map.beta::<1>(7), 8);
-    /// assert_eq!(map.beta::<1>(8), NULL_DART_ID);
-    ///
-    /// assert_eq!(map.beta::<2>(1), 8);
-    /// assert_eq!(map.beta::<2>(3), 7);
-    /// assert_eq!(map.beta::<2>(4), 6);
-    /// assert_eq!(map.beta::<2>(5), 2);
-    /// ```
     pub fn splitn_edge_no_alloc(
         &mut self,
         edge_id: EdgeIdentifier,

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -10,7 +10,250 @@ use crate::prelude::{CMap2, DartIdentifier, EdgeIdentifier, Vertex2, NULL_DART_I
 
 // ------ CONTENT
 
-/// **Advanced operations: edge splitting**
+/// **Advanced operations: edge splitting -- standard variants**
+impl<T: CoordsFloat> CMap2<T> {
+    /// Split an edge into two segments.
+    ///
+    /// <div class="warning">
+    /// This implementation is 2D specific.
+    /// </div>
+    ///
+    /// This method takes all darts of an edge and rebuild connections in order to create a new
+    /// point on this edge. The position of the point defaults to the midway point, but it can
+    /// optionally be specified.
+    ///
+    /// In order to minimize editing of embedded data, the original darts are kept to their
+    /// original vertices while the new darts are used to model the new point.
+    ///
+    /// For an illustration of both principles, refer to the example.
+    ///
+    /// # Arguments
+    ///
+    /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
+    /// - `midpoint_vertex: Option<T>` -- Relative position of the new vertex, starting from the
+    ///   vertex of the dart sharing `edge_id` as its identifier.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the edge upon which the operation is performed does not have two
+    /// defined vertices.
+    ///
+    /// # Example
+    ///
+    /// Given an edge made of darts `1` and `2`, these darts respectively encoding vertices
+    /// `(0.0, 0.0)` and `(2.0, 0.0)`, calling `map.split_edge(1, Some(0.2))` would result in the
+    /// creation of two new darts, a new vertex (ID `3`) at position `(0.4, 0.0)` and the following
+    /// topology:
+    ///
+    /// ```text
+    ///    +----1---->              +-1-> +-3->     |
+    ///  1             2    =>    1      3      2   | + denote darts that encode vertex IDs
+    ///    <----2----+              <-4-- <-2-+     |
+    /// ```
+    pub fn split_edge(&mut self, edge_id: EdgeIdentifier, midpoint_vertex: Option<T>) {
+        if midpoint_vertex.is_some_and(|t| (t >= T::one()) | (t <= T::zero())) {
+            println!("W: vertex placement for split is not in ]0;1[ -- result may be incoherent");
+        }
+        // base darts making up the edge
+        let base_dart1 = edge_id as DartIdentifier;
+        let base_dart2 = self.beta::<2>(base_dart1);
+        // (*): unwrapping is ok since splitting an edge that does not have both its vertices
+        //      defined is undefined behavior, therefore panic
+        if base_dart2 == NULL_DART_ID {
+            let b1d1_old = self.beta::<1>(base_dart1);
+            let b1d1_new = self.add_free_dart();
+            let v1 = self // (*)
+                .vertex(self.vertex_id(base_dart1))
+                .expect("E: attempt to split an edge that is not fully defined in the first place");
+            let v2 = self // (*)
+                .vertex(self.vertex_id(b1d1_old))
+                .expect("E: attempt to split an edge that is not fully defined in the first place");
+            // unsew current dart
+            // self.one_unlink(base_dart1);
+            self.betas[base_dart1 as usize][1] = 0;
+            self.betas[b1d1_old as usize][0] = 0;
+            // rebuild the edge
+            self.one_link(base_dart1, b1d1_new);
+            self.one_link(b1d1_new, b1d1_old);
+            // insert the new vertex
+            let seg = v2 - v1;
+            self.insert_vertex(
+                self.vertex_id(b1d1_new),
+                midpoint_vertex.map_or(Vertex2::average(&v1, &v2), |t| v1 + seg * t),
+            );
+        } else {
+            let b1d1_old = self.beta::<1>(base_dart1);
+            let b1d2_old = self.beta::<1>(base_dart2);
+            let b1d1_new = self.add_free_darts(2);
+            let b1d2_new = b1d1_new + 1;
+            let v1 = self // (*)
+                .vertex(self.vertex_id(base_dart1))
+                .expect("E: attempt to split an edge that is not fully defined in the first place");
+            let v2 = self // (*)
+                .vertex(self.vertex_id(base_dart2))
+                .expect("E: attempt to split an edge that is not fully defined in the first place");
+            // unsew current darts
+            // self.one_unlink(base_dart1);
+            self.betas[base_dart1 as usize][1] = 0;
+            self.betas[b1d1_old as usize][0] = 0;
+            // self.one_unlink(base_dart2);
+            self.betas[base_dart2 as usize][1] = 0;
+            self.betas[b1d2_old as usize][0] = 0;
+            self.two_unlink(base_dart1);
+            // rebuild the edge
+            self.one_link(base_dart1, b1d1_new);
+            if b1d1_old != NULL_DART_ID {
+                self.one_link(b1d1_new, b1d1_old);
+            }
+            self.one_link(base_dart2, b1d2_new);
+            if b1d2_old != NULL_DART_ID {
+                self.one_link(b1d2_new, b1d2_old);
+            }
+            self.two_link(base_dart1, b1d2_new);
+            self.two_link(base_dart2, b1d1_new);
+            // insert the new vertex
+            let seg = v2 - v1;
+            self.insert_vertex(
+                self.vertex_id(b1d1_new),
+                midpoint_vertex.map_or(Vertex2::average(&v1, &v2), |t| v1 + seg * t),
+            );
+        }
+    }
+
+    /// Split an edge into `n` segments.
+    ///
+    /// <div class="warning">
+    /// This implementation is 2D specific.
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `edge_id: EdgeIdentifier` -- Edge to split in two.
+    /// - `midpoint_vertices: I` -- Relative positions of new vertices, starting from the
+    ///   vertex of the dart sharing `edge_id` as its identifier.
+    ///
+    /// ## Generics
+    ///
+    /// - `I: Iterator<Item = T>` -- Iterator over `T` values. These should be in the `]0; 1[` open range.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if the edge upon which the operation is performed does not have two defined vertices.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use honeycomb_core::prelude::{CMap2, CMapBuilder, NULL_DART_ID, Vertex2};
+    /// // before
+    /// //    <--2---
+    /// //  1         2
+    /// //    ---1-->
+    /// let mut map: CMap2<f64> = CMapBuilder::default()
+    ///                             .n_darts(2)
+    ///                             .build()
+    ///                             .unwrap();
+    /// map.two_link(1, 2);
+    /// map.insert_vertex(1, (0.0, 0.0));
+    /// map.insert_vertex(2, (1.0, 0.0));
+    /// // split
+    /// let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    /// // after
+    /// //    <-<-<-<
+    /// //  1 -3-4-5- 2
+    /// //    >->->->
+    /// assert_eq!(&new_darts, &[3, 4, 5]);
+    /// assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+    /// assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+    /// assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+    ///
+    /// assert_eq!(map.beta::<1>(1), 3);
+    /// assert_eq!(map.beta::<1>(3), 4);
+    /// assert_eq!(map.beta::<1>(4), 5);
+    /// assert_eq!(map.beta::<1>(5), NULL_DART_ID);
+    ///
+    /// assert_eq!(map.beta::<1>(2), 6);
+    /// assert_eq!(map.beta::<1>(6), 7);
+    /// assert_eq!(map.beta::<1>(7), 8);
+    /// assert_eq!(map.beta::<1>(8), NULL_DART_ID);
+    ///
+    /// assert_eq!(map.beta::<2>(1), 8);
+    /// assert_eq!(map.beta::<2>(3), 7);
+    /// assert_eq!(map.beta::<2>(4), 6);
+    /// assert_eq!(map.beta::<2>(5), 2);
+    /// ```
+    pub fn splitn_edge(
+        &mut self,
+        edge_id: EdgeIdentifier,
+        midpoint_vertices: impl IntoIterator<Item = T>,
+    ) -> Vec<DartIdentifier> {
+        // base darts making up the edge
+        let base_dart1 = edge_id as DartIdentifier;
+        let base_dart2 = self.beta::<2>(base_dart1);
+        let b1d1_old = self.beta::<1>(base_dart1);
+
+        // (*): unwrapping is ok since splitting an edge that does not have both its vertices
+        //      defined is undefined behavior, therefore panic
+        let v1 = self // (*)
+            .vertex(self.vertex_id(base_dart1))
+            .expect("E: attempt to split an edge that is not fully defined in the first place");
+        let v2 = self // (*)
+            .vertex(self.vertex_id(if base_dart2 == NULL_DART_ID {
+                b1d1_old
+            } else {
+                base_dart2
+            }))
+            .expect("E: attempt to split an edge that is not fully defined in the first place");
+        let seg = v2 - v1;
+
+        // unsew current dart
+        // self.one_unlink(base_dart1);
+        self.betas[base_dart1 as usize][1] = 0;
+        self.betas[b1d1_old as usize][0] = 0;
+        if base_dart2 != NULL_DART_ID {
+            self.two_unlink(base_dart1);
+        }
+        // insert new vertices / darts on base_dart1's side
+        let mut prev_d = base_dart1;
+        let darts: Vec<DartIdentifier> = midpoint_vertices
+            .into_iter()
+            .map(|t| {
+                if (t >= T::one()) | (t <= T::zero()) {
+                    println!(
+                        "W: vertex placement for split is not in ]0;1[ -- result may be incoherent"
+                    );
+                }
+                let new_v = v1 + seg * t;
+                let new_d = self.add_free_dart();
+                self.one_link(prev_d, new_d);
+                self.insert_vertex(new_d, new_v);
+                prev_d = new_d;
+                new_d
+            })
+            .collect();
+        self.one_link(prev_d, b1d1_old);
+
+        // if b2(base_dart1) is defined, insert vertices / darts on its side too
+        if base_dart2 != NULL_DART_ID {
+            let b1d2_old = self.beta::<1>(base_dart2);
+            // self.one_unlink(base_dart2);
+            self.betas[base_dart2 as usize][1] = 0;
+            self.betas[b1d2_old as usize][0] = 0;
+            let mut prev_d = base_dart2;
+            darts.iter().rev().for_each(|d| {
+                self.two_link(prev_d, *d);
+                let new_d = self.add_free_dart();
+                self.one_link(prev_d, new_d);
+                prev_d = new_d;
+            });
+            self.one_link(prev_d, b1d2_old);
+            self.two_link(prev_d, base_dart1);
+        }
+
+        darts
+    }
+}
+
+/// **Advanced operations: edge splitting -- no allocation variants**
 impl<T: CoordsFloat> CMap2<T> {
     /// Split an edge into two segments.
     ///

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -261,7 +261,9 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This implementation is 2D specific.
     /// </div>
     ///
-    /// This method is a variant of [`split_edge`] where inline dart allocations are removed.
+    /// This method is a variant of [`split_edge`] where inline dart allocations are removed. The
+    /// aim of this variant is to enhance performance by enabling the user to pre-allocate a number
+    /// of darts.
     ///
     /// The method follows the same logic as the regular [`split_edge`], the only difference being
     /// that the new darts won't be added to the map on the fly. Instead, the method uses the two
@@ -277,7 +279,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// ## Dart IDs Requirements & Usage
     ///
-    /// TODO
+    /// Because of the dimension, the number of dart needed to perform this operation is at most
+    /// two. These are the requirements for these two darts:
+    /// - identifiers are passed as a tuple.
+    /// - the first dart of the tuple will always be used if the operation is successful.
+    /// - the second dart of the tuple will only be used if the original edge is made of two darts;
+    ///   if that is not the case, the second dart ID can be `NULL_DART_ID`.
+    /// - both of these darts should be free
     ///
     /// # Panics
     ///
@@ -377,7 +385,9 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This implementation is 2D specific.
     /// </div>
     ///
-    /// This method is a variant of [`splitn_edge`] where inline dart allocations are removed.
+    /// This method is a variant of [`splitn_edge`] where inline dart allocations are removed. The
+    /// aim of this variant is to enhance performance by enabling the user to pre-allocate a number
+    /// of darts.
     ///
     /// The method follows the same logic as the regular [`splitn_edge`], the only difference being
     /// that the new darts won't be added to the map on the fly. Instead, the method uses darts
@@ -393,7 +403,14 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// ## Dart IDs Requirements & Usage
     ///
-    /// TODO
+    /// Because of the dimension, we can easily compute the number of dart needed to perform this
+    /// operation. These are the requirements for the darts:
+    /// - identifiers are passed as a slice:
+    ///   - slice length should verify `new_darts.len() == 2 * midpoint_vertices.len()`
+    /// - the first half of the slice will always be used if the operation is successful.
+    /// - the second half of the slice will only be used if the original edge is made of two darts;
+    ///   if that is not the case, the second half IDs can all be `NULL_DART_ID`s.
+    /// - all of these darts should be free
     ///
     /// # Panics
     ///

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -210,8 +210,8 @@ impl<T: CoordsFloat> CMap2<T> {
         // check pre-allocated darts reqs
         let n_t = midpoint_vertices.len();
         let n_d = new_darts.len();
-        if n_d != 2 * (n_t + 1) {
-            println!("W: inconsistent number of darts ({n_d}) & number of midpoints ({n_t}) - the method expects `2 * (n_mid + 1)` darts");
+        if n_d != 2 * n_t {
+            println!("W: inconsistent number of darts ({n_d}) & number of midpoints ({n_t}) - the method expects `2 * n_mid` darts");
             println!("   skipping split...");
             return;
         }
@@ -249,7 +249,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
         // insert new vertices / darts on base_dart1's side
         let mut prev_d = base_dart1;
-        let darts = &new_darts[0..=n_t];
+        let darts = &new_darts[0..n_t];
         if darts.iter().any(|d| *d == NULL_DART_ID) {
             println!("W: the null dart cannot be used to split an existing edge");
             println!("   skipping split...");
@@ -273,7 +273,7 @@ impl<T: CoordsFloat> CMap2<T> {
 
         // if b2(base_dart1) is defined, insert vertices / darts on its side too
         if base_dart2 != NULL_DART_ID {
-            let other_darts = &new_darts[n_t + 1..];
+            let other_darts = &new_darts[n_t..];
             if other_darts.iter().any(|d| *d == NULL_DART_ID) {
                 println!("W: the null dart cannot be used to split an existing edge");
                 println!("   skipping split...");

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -741,17 +741,10 @@ mod split_edge_noalloc {
         map.insert_vertex(1, (0.0, 0.0));
         // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
         // split
-        let nds = map.add_free_darts(3);
+        let nds = map.add_free_darts(6);
         map.splitn_edge_no_alloc(
             1,
-            &[
-                nds,
-                nds + 1,
-                nds + 2,
-                NULL_DART_ID,
-                NULL_DART_ID,
-                NULL_DART_ID,
-            ],
+            &[nds, nds + 1, nds + 2, nds + 3, nds + 4, nds + 5],
             &[0.25, 0.50, 0.75],
         );
     }

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -268,7 +268,8 @@ fn split_edge_complete() {
     map.insert_vertex(3, (2.0, 0.0));
     map.insert_vertex(4, (3.0, 0.0));
     // split
-    map.split_edge(2, None);
+    let nds = map.add_free_darts(2);
+    map.split_edge(2, (nds, nds + 1), None);
     // after
     //    <--6---   <8- <5-   <--4---
     //  1         2    7    3         4
@@ -302,7 +303,8 @@ fn split_edge_isolated() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    map.split_edge(1, Some(0.6));
+    let nds = map.add_free_darts(2);
+    map.split_edge(1, (nds, nds + 1), Some(0.6));
     // after
     //    <-4- <2-
     //  1     3    2
@@ -330,7 +332,8 @@ fn split_single_dart() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    map.split_edge(1, None);
+    let nd = map.add_free_dart(); // a single dart is enough in this case
+    map.split_edge(1, (nd, NULL_DART_ID), None);
     // after
     //  1 -> 3 -> 2 ->
     assert_eq!(map.beta::<1>(1), 3);
@@ -350,7 +353,8 @@ fn split_edge_missing_vertex() {
     map.insert_vertex(1, (0.0, 0.0));
     // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
     // split
-    map.split_edge(1, None);
+    let nds = map.add_free_darts(2);
+    map.split_edge(1, (nds, nds + 1), None);
 }
 
 // splitn_edge

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -378,12 +378,14 @@ fn splitn_edge_complete() {
     map.insert_vertex(3, (2.0, 0.0));
     map.insert_vertex(4, (3.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(2, [0.25, 0.50, 0.75]);
+    let nds = map.add_free_darts(6);
+    let new_darts = (nds..nds + 6).collect::<Vec<_>>();
+    map.splitn_edge(2, &new_darts, &[0.25, 0.50, 0.75]);
     // after
     //    <--6---             <--4---
     //  1         2 -7-8-9- 3         4
     //    ---1-->             ---3-->
-    assert_eq!(&new_darts, &[7, 8, 9]);
+    assert_eq!(&new_darts[0..3], &[7, 8, 9]);
     assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
     assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
     assert_eq!(map.vertex(9), Some(Vertex2(1.75, 0.0)));
@@ -415,12 +417,14 @@ fn splitn_edge_isolated() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    let nds = map.add_free_darts(6);
+    let new_darts = (nds..nds + 6).collect::<Vec<_>>();
+    map.splitn_edge(1, &new_darts, &[0.25, 0.50, 0.75]);
     // after
     //    <-<-<-<
     //  1 -3-4-5- 2
     //    >->->->
-    assert_eq!(&new_darts, &[3, 4, 5]);
+    assert_eq!(&new_darts[0..3], &[3, 4, 5]);
     assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
     assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
     assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
@@ -450,10 +454,22 @@ fn splitn_single_dart() {
     map.insert_vertex(1, (0.0, 0.0));
     map.insert_vertex(2, (1.0, 0.0));
     // split
-    let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    let nds = map.add_free_darts(3);
+    map.splitn_edge(
+        1,
+        &[
+            nds,
+            nds + 1,
+            nds + 2,
+            NULL_DART_ID,
+            NULL_DART_ID,
+            NULL_DART_ID,
+        ],
+        &[0.25, 0.50, 0.75],
+    );
     // after
     //  1 -> 3 -> 4 -> 5 -> 2 ->
-    assert_eq!(&new_darts, &[3, 4, 5]);
+    // assert_eq!(&new_darts, &[3, 4, 5]);
     assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
     assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
     assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
@@ -480,7 +496,19 @@ fn splitn_edge_missing_vertex() {
     map.insert_vertex(1, (0.0, 0.0));
     // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
     // split
-    map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    let nds = map.add_free_darts(3);
+    map.splitn_edge(
+        1,
+        &[
+            nds,
+            nds + 1,
+            nds + 2,
+            NULL_DART_ID,
+            NULL_DART_ID,
+            NULL_DART_ID,
+        ],
+        &[0.25, 0.50, 0.75],
+    );
 }
 
 // --- IO

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -269,7 +269,7 @@ fn split_edge_complete() {
     map.insert_vertex(4, (3.0, 0.0));
     // split
     let nds = map.add_free_darts(2);
-    map.split_edge(2, (nds, nds + 1), None);
+    map.split_edge_noalloc(2, (nds, nds + 1), None);
     // after
     //    <--6---   <8- <5-   <--4---
     //  1         2    7    3         4
@@ -304,7 +304,7 @@ fn split_edge_isolated() {
     map.insert_vertex(2, (1.0, 0.0));
     // split
     let nds = map.add_free_darts(2);
-    map.split_edge(1, (nds, nds + 1), Some(0.6));
+    map.split_edge_noalloc(1, (nds, nds + 1), Some(0.6));
     // after
     //    <-4- <2-
     //  1     3    2
@@ -333,7 +333,7 @@ fn split_single_dart() {
     map.insert_vertex(2, (1.0, 0.0));
     // split
     let nd = map.add_free_dart(); // a single dart is enough in this case
-    map.split_edge(1, (nd, NULL_DART_ID), None);
+    map.split_edge_noalloc(1, (nd, NULL_DART_ID), None);
     // after
     //  1 -> 3 -> 2 ->
     assert_eq!(map.beta::<1>(1), 3);
@@ -354,7 +354,7 @@ fn split_edge_missing_vertex() {
     // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
     // split
     let nds = map.add_free_darts(2);
-    map.split_edge(1, (nds, nds + 1), None);
+    map.split_edge_noalloc(1, (nds, nds + 1), None);
 }
 
 // splitn_edge
@@ -380,7 +380,7 @@ fn splitn_edge_complete() {
     // split
     let nds = map.add_free_darts(6);
     let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-    map.splitn_edge(2, &new_darts, &[0.25, 0.50, 0.75]);
+    map.splitn_edge_no_alloc(2, &new_darts, &[0.25, 0.50, 0.75]);
     // after
     //    <--6---             <--4---
     //  1         2 -7-8-9- 3         4
@@ -419,7 +419,7 @@ fn splitn_edge_isolated() {
     // split
     let nds = map.add_free_darts(6);
     let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-    map.splitn_edge(1, &new_darts, &[0.25, 0.50, 0.75]);
+    map.splitn_edge_no_alloc(1, &new_darts, &[0.25, 0.50, 0.75]);
     // after
     //    <-<-<-<
     //  1 -3-4-5- 2
@@ -455,7 +455,7 @@ fn splitn_single_dart() {
     map.insert_vertex(2, (1.0, 0.0));
     // split
     let nds = map.add_free_darts(3);
-    map.splitn_edge(
+    map.splitn_edge_no_alloc(
         1,
         &[
             nds,
@@ -497,7 +497,7 @@ fn splitn_edge_missing_vertex() {
     // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
     // split
     let nds = map.add_free_darts(3);
-    map.splitn_edge(
+    map.splitn_edge_no_alloc(
         1,
         &[
             nds,

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -249,266 +249,512 @@ fn one_sew_no_attributes_bis() {
 
 // split_edge
 
-#[test]
-fn split_edge_complete() {
-    // before
-    //    <--6---   <--5---   <--4---
-    //  1         2         3         4
-    //    ---1-->   ---2-->   ---3-->
-    let mut map: CMap2<f64> = CMap2::new(6);
-    map.one_link(1, 2);
-    map.one_link(2, 3);
-    map.one_link(4, 5);
-    map.one_link(5, 6);
-    map.two_link(1, 6);
-    map.two_link(2, 5);
-    map.two_link(3, 4);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    map.insert_vertex(3, (2.0, 0.0));
-    map.insert_vertex(4, (3.0, 0.0));
-    // split
-    let nds = map.add_free_darts(2);
-    map.split_edge_noalloc(2, (nds, nds + 1), None);
-    // after
-    //    <--6---   <8- <5-   <--4---
-    //  1         2    7    3         4
-    //    ---1-->   -2> -7>   ---3-->
-    assert_eq!(map.beta::<2>(2), 8);
-    assert_eq!(map.beta::<1>(1), 2);
-    assert_eq!(map.beta::<1>(2), 7);
-    assert_eq!(map.beta::<1>(7), 3);
+mod split_edge_standard {
+    use super::*;
 
-    assert_eq!(map.beta::<2>(5), 7);
-    assert_eq!(map.beta::<1>(4), 5);
-    assert_eq!(map.beta::<1>(5), 8);
-    assert_eq!(map.beta::<1>(8), 6);
+    #[test]
+    fn split_edge_complete() {
+        // before
+        //    <--6---   <--5---   <--4---
+        //  1         2         3         4
+        //    ---1-->   ---2-->   ---3-->
+        let mut map: CMap2<f64> = CMap2::new(6);
+        map.one_link(1, 2);
+        map.one_link(2, 3);
+        map.one_link(4, 5);
+        map.one_link(5, 6);
+        map.two_link(1, 6);
+        map.two_link(2, 5);
+        map.two_link(3, 4);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        map.insert_vertex(3, (2.0, 0.0));
+        map.insert_vertex(4, (3.0, 0.0));
+        // split
+        map.split_edge(2, None);
+        // after
+        //    <--6---   <8- <5-   <--4---
+        //  1         2    7    3         4
+        //    ---1-->   -2> -7>   ---3-->
+        assert_eq!(map.beta::<2>(2), 8);
+        assert_eq!(map.beta::<1>(1), 2);
+        assert_eq!(map.beta::<1>(2), 7);
+        assert_eq!(map.beta::<1>(7), 3);
 
-    assert_eq!(map.vertex_id(8), 7);
-    assert_eq!(map.vertex_id(7), 7);
+        assert_eq!(map.beta::<2>(5), 7);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), 8);
+        assert_eq!(map.beta::<1>(8), 6);
 
-    assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
-    assert_eq!(map.vertex(7), Some(Vertex2::from((1.5, 0.0))));
-    assert_eq!(map.vertex(3), Some(Vertex2::from((2.0, 0.0))));
+        assert_eq!(map.vertex_id(8), 7);
+        assert_eq!(map.vertex_id(7), 7);
+
+        assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
+        assert_eq!(map.vertex(7), Some(Vertex2::from((1.5, 0.0))));
+        assert_eq!(map.vertex(3), Some(Vertex2::from((2.0, 0.0))));
+    }
+
+    #[test]
+    fn split_edge_isolated() {
+        // before
+        //    <--2---
+        //  1         2
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        map.split_edge(1, Some(0.6));
+        // after
+        //    <-4- <2-
+        //  1     3    2
+        //    -1-> -3>
+        assert_eq!(map.beta::<2>(1), 4);
+        assert_eq!(map.beta::<1>(1), 3);
+
+        assert_eq!(map.beta::<2>(2), 3);
+        assert_eq!(map.beta::<1>(2), 4);
+
+        assert_eq!(map.vertex_id(3), 3);
+        assert_eq!(map.vertex_id(4), 3);
+
+        assert_eq!(map.vertex(1), Some(Vertex2::from((0.0, 0.0))));
+        assert_eq!(map.vertex(3), Some(Vertex2::from((0.6, 0.0))));
+        assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
+    }
+
+    #[test]
+    fn split_single_dart() {
+        // before
+        //  1 -----> 2 ->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.one_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        map.split_edge(1, None);
+        // after
+        //  1 -> 3 -> 2 ->
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 2);
+        assert_eq!(map.beta::<2>(3), NULL_DART_ID);
+        assert_eq!(map.vertex(3), Some(Vertex2::from((0.5, 0.0))));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "attempt to split an edge that is not fully defined in the first place"
+    )]
+    fn split_edge_missing_vertex() {
+        //    <--2---
+        //  1         ?
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
+        // split
+        map.split_edge(1, None);
+    }
+
+    // splitn_edge
+
+    #[test]
+    fn splitn_edge_complete() {
+        // before
+        //    <--6---   <--5---   <--4---
+        //  1         2         3         4
+        //    ---1-->   ---2-->   ---3-->
+        let mut map: CMap2<f64> = CMap2::new(6);
+        map.one_link(1, 2);
+        map.one_link(2, 3);
+        map.one_link(4, 5);
+        map.one_link(5, 6);
+        map.two_link(1, 6);
+        map.two_link(2, 5);
+        map.two_link(3, 4);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        map.insert_vertex(3, (2.0, 0.0));
+        map.insert_vertex(4, (3.0, 0.0));
+        // split
+        let new_darts = map.splitn_edge(2, [0.25, 0.50, 0.75]);
+        // after
+        //    <--6---             <--4---
+        //  1         2 -7-8-9- 3         4
+        //    ---1-->             ---3-->
+        assert_eq!(&new_darts, &[7, 8, 9]);
+        assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
+        assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
+        assert_eq!(map.vertex(9), Some(Vertex2(1.75, 0.0)));
+
+        assert_eq!(map.beta::<1>(2), 7);
+        assert_eq!(map.beta::<1>(7), 8);
+        assert_eq!(map.beta::<1>(8), 9);
+        assert_eq!(map.beta::<1>(9), 3);
+
+        assert_eq!(map.beta::<1>(5), 10);
+        assert_eq!(map.beta::<1>(10), 11);
+        assert_eq!(map.beta::<1>(11), 12);
+        assert_eq!(map.beta::<1>(12), 6);
+
+        assert_eq!(map.beta::<2>(2), 12);
+        assert_eq!(map.beta::<2>(7), 11);
+        assert_eq!(map.beta::<2>(8), 10);
+        assert_eq!(map.beta::<2>(9), 5);
+    }
+
+    #[test]
+    fn splitn_edge_isolated() {
+        // before
+        //    <--2---
+        //  1         2
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+        // after
+        //    <-<-<-<
+        //  1 -3-4-5- 2
+        //    >->->->
+        assert_eq!(&new_darts, &[3, 4, 5]);
+        assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+        assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+        assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 4);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), NULL_DART_ID);
+
+        assert_eq!(map.beta::<1>(2), 6);
+        assert_eq!(map.beta::<1>(6), 7);
+        assert_eq!(map.beta::<1>(7), 8);
+        assert_eq!(map.beta::<1>(8), NULL_DART_ID);
+
+        assert_eq!(map.beta::<2>(1), 8);
+        assert_eq!(map.beta::<2>(3), 7);
+        assert_eq!(map.beta::<2>(4), 6);
+        assert_eq!(map.beta::<2>(5), 2);
+    }
+
+    #[test]
+    fn splitn_single_dart() {
+        // before
+        //  1 -----> 2 ->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.one_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+        // after
+        //  1 -> 3 -> 4 -> 5 -> 2 ->
+        assert_eq!(&new_darts, &[3, 4, 5]);
+        assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+        assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+        assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 4);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), 2);
+
+        assert_eq!(map.beta::<2>(1), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(3), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(4), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(5), NULL_DART_ID);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "attempt to split an edge that is not fully defined in the first place"
+    )]
+    fn splitn_edge_missing_vertex() {
+        //    <--2---
+        //  1         ?
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
+        // split
+        map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    }
 }
 
-#[test]
-fn split_edge_isolated() {
-    // before
-    //    <--2---
-    //  1         2
-    //    ---1-->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.two_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    // split
-    let nds = map.add_free_darts(2);
-    map.split_edge_noalloc(1, (nds, nds + 1), Some(0.6));
-    // after
-    //    <-4- <2-
-    //  1     3    2
-    //    -1-> -3>
-    assert_eq!(map.beta::<2>(1), 4);
-    assert_eq!(map.beta::<1>(1), 3);
+mod split_edge_noalloc {
+    use super::*;
 
-    assert_eq!(map.beta::<2>(2), 3);
-    assert_eq!(map.beta::<1>(2), 4);
+    #[test]
+    fn split_edge_complete() {
+        // before
+        //    <--6---   <--5---   <--4---
+        //  1         2         3         4
+        //    ---1-->   ---2-->   ---3-->
+        let mut map: CMap2<f64> = CMap2::new(6);
+        map.one_link(1, 2);
+        map.one_link(2, 3);
+        map.one_link(4, 5);
+        map.one_link(5, 6);
+        map.two_link(1, 6);
+        map.two_link(2, 5);
+        map.two_link(3, 4);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        map.insert_vertex(3, (2.0, 0.0));
+        map.insert_vertex(4, (3.0, 0.0));
+        // split
+        let nds = map.add_free_darts(2);
+        map.split_edge_noalloc(2, (nds, nds + 1), None);
+        // after
+        //    <--6---   <8- <5-   <--4---
+        //  1         2    7    3         4
+        //    ---1-->   -2> -7>   ---3-->
+        assert_eq!(map.beta::<2>(2), 8);
+        assert_eq!(map.beta::<1>(1), 2);
+        assert_eq!(map.beta::<1>(2), 7);
+        assert_eq!(map.beta::<1>(7), 3);
 
-    assert_eq!(map.vertex_id(3), 3);
-    assert_eq!(map.vertex_id(4), 3);
+        assert_eq!(map.beta::<2>(5), 7);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), 8);
+        assert_eq!(map.beta::<1>(8), 6);
 
-    assert_eq!(map.vertex(1), Some(Vertex2::from((0.0, 0.0))));
-    assert_eq!(map.vertex(3), Some(Vertex2::from((0.6, 0.0))));
-    assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
-}
+        assert_eq!(map.vertex_id(8), 7);
+        assert_eq!(map.vertex_id(7), 7);
 
-#[test]
-fn split_single_dart() {
-    // before
-    //  1 -----> 2 ->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.one_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    // split
-    let nd = map.add_free_dart(); // a single dart is enough in this case
-    map.split_edge_noalloc(1, (nd, NULL_DART_ID), None);
-    // after
-    //  1 -> 3 -> 2 ->
-    assert_eq!(map.beta::<1>(1), 3);
-    assert_eq!(map.beta::<1>(3), 2);
-    assert_eq!(map.beta::<2>(3), NULL_DART_ID);
-    assert_eq!(map.vertex(3), Some(Vertex2::from((0.5, 0.0))));
-}
+        assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
+        assert_eq!(map.vertex(7), Some(Vertex2::from((1.5, 0.0))));
+        assert_eq!(map.vertex(3), Some(Vertex2::from((2.0, 0.0))));
+    }
 
-#[test]
-#[should_panic(expected = "attempt to split an edge that is not fully defined in the first place")]
-fn split_edge_missing_vertex() {
-    //    <--2---
-    //  1         ?
-    //    ---1-->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.two_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
-    // split
-    let nds = map.add_free_darts(2);
-    map.split_edge_noalloc(1, (nds, nds + 1), None);
-}
+    #[test]
+    fn split_edge_isolated() {
+        // before
+        //    <--2---
+        //  1         2
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let nds = map.add_free_darts(2);
+        map.split_edge_noalloc(1, (nds, nds + 1), Some(0.6));
+        // after
+        //    <-4- <2-
+        //  1     3    2
+        //    -1-> -3>
+        assert_eq!(map.beta::<2>(1), 4);
+        assert_eq!(map.beta::<1>(1), 3);
 
-// splitn_edge
+        assert_eq!(map.beta::<2>(2), 3);
+        assert_eq!(map.beta::<1>(2), 4);
 
-#[test]
-fn splitn_edge_complete() {
-    // before
-    //    <--6---   <--5---   <--4---
-    //  1         2         3         4
-    //    ---1-->   ---2-->   ---3-->
-    let mut map: CMap2<f64> = CMap2::new(6);
-    map.one_link(1, 2);
-    map.one_link(2, 3);
-    map.one_link(4, 5);
-    map.one_link(5, 6);
-    map.two_link(1, 6);
-    map.two_link(2, 5);
-    map.two_link(3, 4);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    map.insert_vertex(3, (2.0, 0.0));
-    map.insert_vertex(4, (3.0, 0.0));
-    // split
-    let nds = map.add_free_darts(6);
-    let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-    map.splitn_edge_no_alloc(2, &new_darts, &[0.25, 0.50, 0.75]);
-    // after
-    //    <--6---             <--4---
-    //  1         2 -7-8-9- 3         4
-    //    ---1-->             ---3-->
-    assert_eq!(&new_darts[0..3], &[7, 8, 9]);
-    assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
-    assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
-    assert_eq!(map.vertex(9), Some(Vertex2(1.75, 0.0)));
+        assert_eq!(map.vertex_id(3), 3);
+        assert_eq!(map.vertex_id(4), 3);
 
-    assert_eq!(map.beta::<1>(2), 7);
-    assert_eq!(map.beta::<1>(7), 8);
-    assert_eq!(map.beta::<1>(8), 9);
-    assert_eq!(map.beta::<1>(9), 3);
+        assert_eq!(map.vertex(1), Some(Vertex2::from((0.0, 0.0))));
+        assert_eq!(map.vertex(3), Some(Vertex2::from((0.6, 0.0))));
+        assert_eq!(map.vertex(2), Some(Vertex2::from((1.0, 0.0))));
+    }
 
-    assert_eq!(map.beta::<1>(5), 10);
-    assert_eq!(map.beta::<1>(10), 11);
-    assert_eq!(map.beta::<1>(11), 12);
-    assert_eq!(map.beta::<1>(12), 6);
+    #[test]
+    fn split_single_dart() {
+        // before
+        //  1 -----> 2 ->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.one_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let nd = map.add_free_dart(); // a single dart is enough in this case
+        map.split_edge_noalloc(1, (nd, NULL_DART_ID), None);
+        // after
+        //  1 -> 3 -> 2 ->
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 2);
+        assert_eq!(map.beta::<2>(3), NULL_DART_ID);
+        assert_eq!(map.vertex(3), Some(Vertex2::from((0.5, 0.0))));
+    }
 
-    assert_eq!(map.beta::<2>(2), 12);
-    assert_eq!(map.beta::<2>(7), 11);
-    assert_eq!(map.beta::<2>(8), 10);
-    assert_eq!(map.beta::<2>(9), 5);
-}
+    #[test]
+    #[should_panic(
+        expected = "attempt to split an edge that is not fully defined in the first place"
+    )]
+    fn split_edge_missing_vertex() {
+        //    <--2---
+        //  1         ?
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
+        // split
+        let nds = map.add_free_darts(2);
+        map.split_edge_noalloc(1, (nds, nds + 1), None);
+    }
 
-#[test]
-fn splitn_edge_isolated() {
-    // before
-    //    <--2---
-    //  1         2
-    //    ---1-->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.two_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    // split
-    let nds = map.add_free_darts(6);
-    let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-    map.splitn_edge_no_alloc(1, &new_darts, &[0.25, 0.50, 0.75]);
-    // after
-    //    <-<-<-<
-    //  1 -3-4-5- 2
-    //    >->->->
-    assert_eq!(&new_darts[0..3], &[3, 4, 5]);
-    assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
-    assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
-    assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+    // splitn_edge
 
-    assert_eq!(map.beta::<1>(1), 3);
-    assert_eq!(map.beta::<1>(3), 4);
-    assert_eq!(map.beta::<1>(4), 5);
-    assert_eq!(map.beta::<1>(5), NULL_DART_ID);
+    #[test]
+    fn splitn_edge_complete() {
+        // before
+        //    <--6---   <--5---   <--4---
+        //  1         2         3         4
+        //    ---1-->   ---2-->   ---3-->
+        let mut map: CMap2<f64> = CMap2::new(6);
+        map.one_link(1, 2);
+        map.one_link(2, 3);
+        map.one_link(4, 5);
+        map.one_link(5, 6);
+        map.two_link(1, 6);
+        map.two_link(2, 5);
+        map.two_link(3, 4);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        map.insert_vertex(3, (2.0, 0.0));
+        map.insert_vertex(4, (3.0, 0.0));
+        // split
+        let nds = map.add_free_darts(6);
+        let new_darts = (nds..nds + 6).collect::<Vec<_>>();
+        map.splitn_edge_no_alloc(2, &new_darts, &[0.25, 0.50, 0.75]);
+        // after
+        //    <--6---             <--4---
+        //  1         2 -7-8-9- 3         4
+        //    ---1-->             ---3-->
+        assert_eq!(&new_darts[0..3], &[7, 8, 9]);
+        assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
+        assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
+        assert_eq!(map.vertex(9), Some(Vertex2(1.75, 0.0)));
 
-    assert_eq!(map.beta::<1>(2), 6);
-    assert_eq!(map.beta::<1>(6), 7);
-    assert_eq!(map.beta::<1>(7), 8);
-    assert_eq!(map.beta::<1>(8), NULL_DART_ID);
+        assert_eq!(map.beta::<1>(2), 7);
+        assert_eq!(map.beta::<1>(7), 8);
+        assert_eq!(map.beta::<1>(8), 9);
+        assert_eq!(map.beta::<1>(9), 3);
 
-    assert_eq!(map.beta::<2>(1), 8);
-    assert_eq!(map.beta::<2>(3), 7);
-    assert_eq!(map.beta::<2>(4), 6);
-    assert_eq!(map.beta::<2>(5), 2);
-}
+        assert_eq!(map.beta::<1>(5), 10);
+        assert_eq!(map.beta::<1>(10), 11);
+        assert_eq!(map.beta::<1>(11), 12);
+        assert_eq!(map.beta::<1>(12), 6);
 
-#[test]
-fn splitn_single_dart() {
-    // before
-    //  1 -----> 2 ->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.one_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    map.insert_vertex(2, (1.0, 0.0));
-    // split
-    let nds = map.add_free_darts(3);
-    map.splitn_edge_no_alloc(
-        1,
-        &[
-            nds,
-            nds + 1,
-            nds + 2,
-            NULL_DART_ID,
-            NULL_DART_ID,
-            NULL_DART_ID,
-        ],
-        &[0.25, 0.50, 0.75],
-    );
-    // after
-    //  1 -> 3 -> 4 -> 5 -> 2 ->
-    // assert_eq!(&new_darts, &[3, 4, 5]);
-    assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
-    assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
-    assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+        assert_eq!(map.beta::<2>(2), 12);
+        assert_eq!(map.beta::<2>(7), 11);
+        assert_eq!(map.beta::<2>(8), 10);
+        assert_eq!(map.beta::<2>(9), 5);
+    }
 
-    assert_eq!(map.beta::<1>(1), 3);
-    assert_eq!(map.beta::<1>(3), 4);
-    assert_eq!(map.beta::<1>(4), 5);
-    assert_eq!(map.beta::<1>(5), 2);
+    #[test]
+    fn splitn_edge_isolated() {
+        // before
+        //    <--2---
+        //  1         2
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let nds = map.add_free_darts(6);
+        let new_darts = (nds..nds + 6).collect::<Vec<_>>();
+        map.splitn_edge_no_alloc(1, &new_darts, &[0.25, 0.50, 0.75]);
+        // after
+        //    <-<-<-<
+        //  1 -3-4-5- 2
+        //    >->->->
+        assert_eq!(&new_darts[0..3], &[3, 4, 5]);
+        assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+        assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+        assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
 
-    assert_eq!(map.beta::<2>(1), NULL_DART_ID);
-    assert_eq!(map.beta::<2>(3), NULL_DART_ID);
-    assert_eq!(map.beta::<2>(4), NULL_DART_ID);
-    assert_eq!(map.beta::<2>(5), NULL_DART_ID);
-}
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 4);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), NULL_DART_ID);
 
-#[test]
-#[should_panic(expected = "attempt to split an edge that is not fully defined in the first place")]
-fn splitn_edge_missing_vertex() {
-    //    <--2---
-    //  1         ?
-    //    ---1-->
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.two_link(1, 2);
-    map.insert_vertex(1, (0.0, 0.0));
-    // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
-    // split
-    let nds = map.add_free_darts(3);
-    map.splitn_edge_no_alloc(
-        1,
-        &[
-            nds,
-            nds + 1,
-            nds + 2,
-            NULL_DART_ID,
-            NULL_DART_ID,
-            NULL_DART_ID,
-        ],
-        &[0.25, 0.50, 0.75],
-    );
+        assert_eq!(map.beta::<1>(2), 6);
+        assert_eq!(map.beta::<1>(6), 7);
+        assert_eq!(map.beta::<1>(7), 8);
+        assert_eq!(map.beta::<1>(8), NULL_DART_ID);
+
+        assert_eq!(map.beta::<2>(1), 8);
+        assert_eq!(map.beta::<2>(3), 7);
+        assert_eq!(map.beta::<2>(4), 6);
+        assert_eq!(map.beta::<2>(5), 2);
+    }
+
+    #[test]
+    fn splitn_single_dart() {
+        // before
+        //  1 -----> 2 ->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.one_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        map.insert_vertex(2, (1.0, 0.0));
+        // split
+        let nds = map.add_free_darts(3);
+        map.splitn_edge_no_alloc(
+            1,
+            &[
+                nds,
+                nds + 1,
+                nds + 2,
+                NULL_DART_ID,
+                NULL_DART_ID,
+                NULL_DART_ID,
+            ],
+            &[0.25, 0.50, 0.75],
+        );
+        // after
+        //  1 -> 3 -> 4 -> 5 -> 2 ->
+        // assert_eq!(&new_darts, &[3, 4, 5]);
+        assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
+        assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
+        assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
+
+        assert_eq!(map.beta::<1>(1), 3);
+        assert_eq!(map.beta::<1>(3), 4);
+        assert_eq!(map.beta::<1>(4), 5);
+        assert_eq!(map.beta::<1>(5), 2);
+
+        assert_eq!(map.beta::<2>(1), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(3), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(4), NULL_DART_ID);
+        assert_eq!(map.beta::<2>(5), NULL_DART_ID);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "attempt to split an edge that is not fully defined in the first place"
+    )]
+    fn splitn_edge_missing_vertex() {
+        //    <--2---
+        //  1         ?
+        //    ---1-->
+        let mut map: CMap2<f64> = CMap2::new(2);
+        map.two_link(1, 2);
+        map.insert_vertex(1, (0.0, 0.0));
+        // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
+        // split
+        let nds = map.add_free_darts(3);
+        map.splitn_edge_no_alloc(
+            1,
+            &[
+                nds,
+                nds + 1,
+                nds + 2,
+                NULL_DART_ID,
+                NULL_DART_ID,
+                NULL_DART_ID,
+            ],
+            &[0.25, 0.50, 0.75],
+        );
+    }
 }
 
 // --- IO

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -484,7 +484,7 @@ pub(super) fn insert_intersections<T: CoordsFloat>(
         #[allow(clippy::cast_possible_truncation)]
         let new_darts = (nds..nds + (n_v * 2) as DartIdentifier).collect::<Vec<_>>();
         let ts = vs.iter().map(|(_, t, _)| *t).collect::<Vec<_>>();
-        cmap.splitn_edge(*edge_id, &new_darts, &ts);
+        cmap.splitn_edge_no_alloc(*edge_id, &new_darts, &ts);
         // order should be consistent between collection because of the sort_by call
         vs.iter()
             .zip(new_darts[0..n_v].iter())
@@ -597,7 +597,7 @@ pub(super) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
             #[allow(clippy::cast_possible_truncation)]
             let new_darts =
                 (nds..nds + (intermediates.len() * 2) as DartIdentifier).collect::<Vec<_>>();
-            cmap.splitn_edge(
+            cmap.splitn_edge_no_alloc(
                 cmap.edge_id(d_new),
                 &new_darts,
                 &vec![T::from(0.5).unwrap(); intermediates.len()], // 0.5 is a dummy value

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -481,6 +481,7 @@ pub(super) fn insert_intersections<T: CoordsFloat>(
         vs.sort_by(|(_, t1, _), (_, t2, _)| t1.partial_cmp(t2).expect("E: unreachable"));
         let n_v = vs.len();
         let nds = cmap.add_free_darts(n_v * 2);
+        #[allow(clippy::cast_possible_truncation)]
         let new_darts = (nds..nds + (n_v * 2) as DartIdentifier).collect::<Vec<_>>();
         let ts = vs.iter().map(|(_, t, _)| *t).collect::<Vec<_>>();
         cmap.splitn_edge(*edge_id, &new_darts, &ts);
@@ -593,6 +594,7 @@ pub(super) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
         if !intermediates.is_empty() {
             // we can add intermediates after by using the splitn_edge method on a temporary start-to-end edge
             let nds = cmap.add_free_darts(intermediates.len() * 2);
+            #[allow(clippy::cast_possible_truncation)]
             let new_darts =
                 (nds..nds + (intermediates.len() * 2) as DartIdentifier).collect::<Vec<_>>();
             cmap.splitn_edge(

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -479,15 +479,10 @@ pub(super) fn insert_intersections<T: CoordsFloat>(
         // sort ts
         // panic unreachable because t s.t. t == NaN have been filtered previously
         vs.sort_by(|(_, t1, _), (_, t2, _)| t1.partial_cmp(t2).expect("E: unreachable"));
-        let n_v = vs.len();
-        let nds = cmap.add_free_darts(n_v * 2);
-        #[allow(clippy::cast_possible_truncation)]
-        let new_darts = (nds..nds + (n_v * 2) as DartIdentifier).collect::<Vec<_>>();
-        let ts = vs.iter().map(|(_, t, _)| *t).collect::<Vec<_>>();
-        cmap.splitn_edge_no_alloc(*edge_id, &new_darts, &ts);
+        let new_darts = cmap.splitn_edge(*edge_id, vs.iter().map(|(_, t, _)| *t));
         // order should be consistent between collection because of the sort_by call
         vs.iter()
-            .zip(new_darts[0..n_v].iter())
+            .zip(new_darts.iter())
             // chaining this directly avoids an additional `.collect()`
             .for_each(|((id, _, old_dart_id), dart_id)| {
                 // c.
@@ -593,16 +588,11 @@ pub(super) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
 
         if !intermediates.is_empty() {
             // we can add intermediates after by using the splitn_edge method on a temporary start-to-end edge
-            let nds = cmap.add_free_darts(intermediates.len() * 2);
-            #[allow(clippy::cast_possible_truncation)]
-            let new_darts =
-                (nds..nds + (intermediates.len() * 2) as DartIdentifier).collect::<Vec<_>>();
-            cmap.splitn_edge_no_alloc(
+            let darts = cmap.splitn_edge(
                 cmap.edge_id(d_new),
-                &new_darts,
-                &vec![T::from(0.5).unwrap(); intermediates.len()], // 0.5 is a dummy value
+                vec![T::from(0.5).unwrap(); intermediates.len()], // 0.5 is a dummy value
             );
-            new_darts[0..intermediates.len()]
+            darts
                 .iter()
                 .zip(intermediates.iter())
                 .for_each(|(dart_id, v)| {


### PR DESCRIPTION
both methods now take a slice of dart IDs to use as new segments components. both methods check if:
- the number of darts is consistent
- each dart is free
- each dart is non-null

## Scope

- [x] Code

## Type of change

- [x] Refactor

## Other

- [x] Breaking change
