### PR TITLE
refactor!(core): unify edge splits method error policy

### DIFF
--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -97,11 +97,16 @@ impl<T: CoordsFloat> CMap2<T> {
     /// map.insert_vertex(1, (0.0, 0.0));
     /// map.insert_vertex(2, (1.0, 0.0));
     /// // split
-    /// let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+    /// assert!(map.splitn_edge(1, [0.25, 0.50, 0.75]));
     /// // after
     /// //    <-<-<-<
     /// //  1 -3-4-5- 2
     /// //    >->->->
+    /// let new_darts = [
+    ///     map.beta::<1>(1),
+    ///     map.beta::<1>(map.beta::<1>(1)),
+    ///     map.beta::<1>(map.beta::<1>(map.beta::<1>(1))),
+    /// ];
     /// assert_eq!(&new_darts, &[3, 4, 5]);
     /// assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
     /// assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -323,12 +323,22 @@ fn inner_split<T: CoordsFloat>(
     if base_dart2 == NULL_DART_ID {
         let b1d1_old = cmap.beta::<1>(base_dart1);
         let b1d1_new = new_darts.0;
-        let v1 = cmap // (*)
+        let (Some(v1), Some(v2)) = (
+            cmap.vertex(cmap.vertex_id(base_dart1)),
+            cmap.vertex(cmap.vertex_id(b1d1_old)),
+        ) else {
+            println!("W: attempt to split an edge that is not fully defined in the first place");
+            println!("   skipping split...");
+            return;
+        };
+        /*
+        let v1 = cmap
             .vertex(cmap.vertex_id(base_dart1))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
         let v2 = cmap // (*)
             .vertex(cmap.vertex_id(b1d1_old))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
+        */
         // unsew current dart
         // self.one_unlink(base_dart1);
         cmap.betas[base_dart1 as usize][1] = 0;
@@ -346,12 +356,22 @@ fn inner_split<T: CoordsFloat>(
         let b1d1_old = cmap.beta::<1>(base_dart1);
         let b1d2_old = cmap.beta::<1>(base_dart2);
         let (b1d1_new, b1d2_new) = new_darts;
+        let (Some(v1), Some(v2)) = (
+            cmap.vertex(cmap.vertex_id(base_dart1)),
+            cmap.vertex(cmap.vertex_id(base_dart2)),
+        ) else {
+            println!("W: attempt to split an edge that is not fully defined in the first place");
+            println!("   skipping split...");
+            return;
+        };
+        /*
         let v1 = cmap // (*)
             .vertex(cmap.vertex_id(base_dart1))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
         let v2 = cmap // (*)
             .vertex(cmap.vertex_id(base_dart2))
             .expect("E: attempt to split an edge that is not fully defined in the first place");
+        */
         // unsew current darts
         // self.one_unlink(base_dart1);
         cmap.betas[base_dart1 as usize][1] = 0;
@@ -392,6 +412,19 @@ fn inner_splitn<T: CoordsFloat>(
 
     // (*): unwrapping is ok since splitting an edge that does not have both its vertices
     //      defined is undefined behavior, therefore panic
+    let (Some(v1), Some(v2)) = (
+        cmap.vertex(cmap.vertex_id(base_dart1)),
+        cmap.vertex(cmap.vertex_id(if base_dart2 == NULL_DART_ID {
+            b1d1_old
+        } else {
+            base_dart2
+        })),
+    ) else {
+        println!("W: attempt to split an edge that is not fully defined in the first place");
+        println!("   skipping split...");
+        return;
+    };
+    /*
     let v1 = cmap // (*)
         .vertex(cmap.vertex_id(base_dart1))
         .expect("E: attempt to split an edge that is not fully defined in the first place");
@@ -402,6 +435,7 @@ fn inner_splitn<T: CoordsFloat>(
             base_dart2
         }))
         .expect("E: attempt to split an edge that is not fully defined in the first place");
+    */
     let seg = v2 - v1;
 
     // unsew current dart

--- a/honeycomb-core/src/cmap/dim2/advanced_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/advanced_ops.rs
@@ -33,6 +33,13 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - `midpoint_vertex: Option<T>` -- Relative position of the new vertex, starting from the
     ///   vertex of the dart sharing `edge_id` as its identifier.
     ///
+    /// # Return
+    ///
+    /// This method will return:
+    /// - `true` if the operation is successful & the edge was split
+    /// - `false` if the operation fails & the edge is left unchanged. It can fail if:
+    ///   - one or both vertices of the edge is undefined
+    ///
     /// # Example
     ///
     /// Given an edge made of darts `1` and `2`, these darts respectively encoding vertices
@@ -80,6 +87,13 @@ impl<T: CoordsFloat> CMap2<T> {
     /// ## Generics
     ///
     /// - `I: Iterator<Item = T>` -- Iterator over `T` values. These should be in the `]0; 1[` open range.
+    ///
+    /// # Return
+    ///
+    /// This method will return:
+    /// - `true` if the operation is successful & the edge was split
+    /// - `false` if the operation fails & the edge is left unchanged. It can fail if:
+    ///   - one or both vertices of the edge is undefined
     ///
     /// # Example
     ///
@@ -189,6 +203,14 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - the second dart of the tuple will only be used if the original edge is made of two darts;
     ///   if that is not the case, the second dart ID can be `NULL_DART_ID`.
     /// - both of these darts should be free
+    ///
+    /// # Return
+    ///
+    /// This method will return:
+    /// - `true` if the operation is successful & the edge was split
+    /// - `false` if the operation fails & the edge is left unchanged. It can fail if:
+    ///   - one or both vertices of the edge is undefined
+    ///   - if darts passed as argument do not match the above requirements
     pub fn split_edge_noalloc(
         &mut self,
         edge_id: EdgeIdentifier,
@@ -251,6 +273,14 @@ impl<T: CoordsFloat> CMap2<T> {
     /// - the second half of the slice will only be used if the original edge is made of two darts;
     ///   if that is not the case, the second half IDs can all be `NULL_DART_ID`s.
     /// - all of these darts should be free
+    ///
+    /// # Return
+    ///
+    /// This method will return:
+    /// - `true` if the operation is successful & the edge was split
+    /// - `false` if the operation fails & the edge is left unchanged. It can fail if:
+    ///   - one or both vertices of the edge is undefined
+    ///   - if darts passed as argument do not match the above requirements
     pub fn splitn_edge_no_alloc(
         &mut self,
         edge_id: EdgeIdentifier,

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -271,7 +271,7 @@ mod split_edge_standard {
         map.insert_vertex(3, (2.0, 0.0));
         map.insert_vertex(4, (3.0, 0.0));
         // split
-        map.split_edge(2, None);
+        assert!(map.split_edge(2, None));
         // after
         //    <--6---   <8- <5-   <--4---
         //  1         2    7    3         4
@@ -305,7 +305,7 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         map.insert_vertex(2, (1.0, 0.0));
         // split
-        map.split_edge(1, Some(0.6));
+        assert!(map.split_edge(1, Some(0.6)));
         // after
         //    <-4- <2-
         //  1     3    2
@@ -333,7 +333,7 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         map.insert_vertex(2, (1.0, 0.0));
         // split
-        map.split_edge(1, None);
+        assert!(map.split_edge(1, None));
         // after
         //  1 -> 3 -> 2 ->
         assert_eq!(map.beta::<1>(1), 3);
@@ -343,9 +343,6 @@ mod split_edge_standard {
     }
 
     #[test]
-    #[should_panic(
-        expected = "attempt to split an edge that is not fully defined in the first place"
-    )]
     fn split_edge_missing_vertex() {
         //    <--2---
         //  1         ?
@@ -355,7 +352,7 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
         // split
-        map.split_edge(1, None);
+        assert!(!map.split_edge(1, None));
     }
 
     // splitn_edge
@@ -379,11 +376,16 @@ mod split_edge_standard {
         map.insert_vertex(3, (2.0, 0.0));
         map.insert_vertex(4, (3.0, 0.0));
         // split
-        let new_darts = map.splitn_edge(2, [0.25, 0.50, 0.75]);
+        assert!(map.splitn_edge(1, [0.25, 0.50, 0.75]));
         // after
         //    <--6---             <--4---
         //  1         2 -7-8-9- 3         4
         //    ---1-->             ---3-->
+        let new_darts = [
+            map.beta::<1>(1),
+            map.beta::<1>(map.beta::<1>(1)),
+            map.beta::<1>(map.beta::<1>(map.beta::<1>(1))),
+        ];
         assert_eq!(&new_darts, &[7, 8, 9]);
         assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
         assert_eq!(map.vertex(8), Some(Vertex2(1.50, 0.0)));
@@ -416,15 +418,17 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         map.insert_vertex(2, (1.0, 0.0));
         // split
-        let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+        assert!(map.splitn_edge(1, [0.25, 0.50, 0.75]));
         // after
         //    <-<-<-<
         //  1 -3-4-5- 2
         //    >->->->
+        let new_darts = [
+            map.beta::<1>(1),
+            map.beta::<1>(map.beta::<1>(1)),
+            map.beta::<1>(map.beta::<1>(map.beta::<1>(1))),
+        ];
         assert_eq!(&new_darts, &[3, 4, 5]);
-        assert_eq!(map.vertex(3), Some(Vertex2(0.25, 0.0)));
-        assert_eq!(map.vertex(4), Some(Vertex2(0.50, 0.0)));
-        assert_eq!(map.vertex(5), Some(Vertex2(0.75, 0.0)));
 
         assert_eq!(map.beta::<1>(1), 3);
         assert_eq!(map.beta::<1>(3), 4);
@@ -451,7 +455,12 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         map.insert_vertex(2, (1.0, 0.0));
         // split
-        let new_darts = map.splitn_edge(1, [0.25, 0.50, 0.75]);
+        assert!(map.splitn_edge(1, [0.25, 0.50, 0.75]));
+        let new_darts = [
+            map.beta::<1>(1),
+            map.beta::<1>(map.beta::<1>(1)),
+            map.beta::<1>(map.beta::<1>(map.beta::<1>(1))),
+        ];
         // after
         //  1 -> 3 -> 4 -> 5 -> 2 ->
         assert_eq!(&new_darts, &[3, 4, 5]);
@@ -483,7 +492,7 @@ mod split_edge_standard {
         map.insert_vertex(1, (0.0, 0.0));
         // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
         // split
-        map.splitn_edge(1, [0.25, 0.50, 0.75]);
+        assert!(!map.splitn_edge(1, [0.25, 0.50, 0.75]));
     }
 }
 
@@ -510,7 +519,7 @@ mod split_edge_noalloc {
         map.insert_vertex(4, (3.0, 0.0));
         // split
         let nds = map.add_free_darts(2);
-        map.split_edge_noalloc(2, (nds, nds + 1), None);
+        assert!(map.split_edge_noalloc(2, (nds, nds + 1), None));
         // after
         //    <--6---   <8- <5-   <--4---
         //  1         2    7    3         4
@@ -545,7 +554,7 @@ mod split_edge_noalloc {
         map.insert_vertex(2, (1.0, 0.0));
         // split
         let nds = map.add_free_darts(2);
-        map.split_edge_noalloc(1, (nds, nds + 1), Some(0.6));
+        assert!(map.split_edge_noalloc(1, (nds, nds + 1), Some(0.6)));
         // after
         //    <-4- <2-
         //  1     3    2
@@ -574,7 +583,7 @@ mod split_edge_noalloc {
         map.insert_vertex(2, (1.0, 0.0));
         // split
         let nd = map.add_free_dart(); // a single dart is enough in this case
-        map.split_edge_noalloc(1, (nd, NULL_DART_ID), None);
+        assert!(map.split_edge_noalloc(1, (nd, NULL_DART_ID), None));
         // after
         //  1 -> 3 -> 2 ->
         assert_eq!(map.beta::<1>(1), 3);
@@ -584,9 +593,6 @@ mod split_edge_noalloc {
     }
 
     #[test]
-    #[should_panic(
-        expected = "attempt to split an edge that is not fully defined in the first place"
-    )]
     fn split_edge_missing_vertex() {
         //    <--2---
         //  1         ?
@@ -597,7 +603,7 @@ mod split_edge_noalloc {
         // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
         // split
         let nds = map.add_free_darts(2);
-        map.split_edge_noalloc(1, (nds, nds + 1), None);
+        assert!(!map.split_edge_noalloc(1, (nds, nds + 1), None));
     }
 
     // splitn_edge
@@ -623,7 +629,7 @@ mod split_edge_noalloc {
         // split
         let nds = map.add_free_darts(6);
         let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-        map.splitn_edge_no_alloc(2, &new_darts, &[0.25, 0.50, 0.75]);
+        assert!(map.splitn_edge_no_alloc(2, &new_darts, &[0.25, 0.50, 0.75]));
         // after
         //    <--6---             <--4---
         //  1         2 -7-8-9- 3         4
@@ -662,7 +668,7 @@ mod split_edge_noalloc {
         // split
         let nds = map.add_free_darts(6);
         let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-        map.splitn_edge_no_alloc(1, &new_darts, &[0.25, 0.50, 0.75]);
+        assert!(map.splitn_edge_no_alloc(1, &new_darts, &[0.25, 0.50, 0.75]));
         // after
         //    <-<-<-<
         //  1 -3-4-5- 2
@@ -698,7 +704,7 @@ mod split_edge_noalloc {
         map.insert_vertex(2, (1.0, 0.0));
         // split
         let nds = map.add_free_darts(3);
-        map.splitn_edge_no_alloc(
+        assert!(map.splitn_edge_no_alloc(
             1,
             &[
                 nds,
@@ -709,7 +715,7 @@ mod split_edge_noalloc {
                 NULL_DART_ID,
             ],
             &[0.25, 0.50, 0.75],
-        );
+        ));
         // after
         //  1 -> 3 -> 4 -> 5 -> 2 ->
         // assert_eq!(&new_darts, &[3, 4, 5]);
@@ -729,9 +735,6 @@ mod split_edge_noalloc {
     }
 
     #[test]
-    #[should_panic(
-        expected = "attempt to split an edge that is not fully defined in the first place"
-    )]
     fn splitn_edge_missing_vertex() {
         //    <--2---
         //  1         ?
@@ -742,11 +745,11 @@ mod split_edge_noalloc {
         // map.insert_vertex(2, (1.0, 0.0)); missing vertex!
         // split
         let nds = map.add_free_darts(6);
-        map.splitn_edge_no_alloc(
+        assert!(!map.splitn_edge_no_alloc(
             1,
             &[nds, nds + 1, nds + 2, nds + 3, nds + 4, nds + 5],
             &[0.25, 0.50, 0.75],
-        );
+        ));
     }
 }
 

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -376,15 +376,15 @@ mod split_edge_standard {
         map.insert_vertex(3, (2.0, 0.0));
         map.insert_vertex(4, (3.0, 0.0));
         // split
-        assert!(map.splitn_edge(1, [0.25, 0.50, 0.75]));
+        assert!(map.splitn_edge(2, [0.25, 0.50, 0.75]));
         // after
         //    <--6---             <--4---
         //  1         2 -7-8-9- 3         4
         //    ---1-->             ---3-->
         let new_darts = [
-            map.beta::<1>(1),
-            map.beta::<1>(map.beta::<1>(1)),
-            map.beta::<1>(map.beta::<1>(map.beta::<1>(1))),
+            map.beta::<1>(2),
+            map.beta::<1>(map.beta::<1>(2)),
+            map.beta::<1>(map.beta::<1>(map.beta::<1>(2))),
         ];
         assert_eq!(&new_darts, &[7, 8, 9]);
         assert_eq!(map.vertex(7), Some(Vertex2(1.25, 0.0)));
@@ -480,9 +480,6 @@ mod split_edge_standard {
     }
 
     #[test]
-    #[should_panic(
-        expected = "attempt to split an edge that is not fully defined in the first place"
-    )]
     fn splitn_edge_missing_vertex() {
         //    <--2---
         //  1         ?


### PR DESCRIPTION
All variants of the edge-splitting op now return a boolean:

- `true` if the edge was correctly split
- `false` if it could not be split, and is left unchanged

Note that:
- the `splitn_edge` did not need to return a vector of dart identifiers, we can find those after the op by using beta 1
- the returned boolean gives an actual information to the user about the completion of the op. the user can then choose to retry or abort as needed
