### PR TITLE
refactor!: cleanup error enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ honeycomb-render = { version = "0.5.0", path = "./honeycomb-render" }
 # common
 cfg-if = "1"
 rustversion = "1.0.15"
+thiserror = "1.0.64"
 
 # core
 downcast-rs = "1.2.1"

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -22,6 +22,7 @@ utils = ["dep:dyn-clone"]
 downcast-rs.workspace = true
 dyn-clone = { workspace = true, optional = true }
 num-traits.workspace = true
+thiserror.workspace = true
 vtkio = { workspace = true, optional = true }
 
 [build-dependencies]

--- a/honeycomb-core/src/cmap/builder/grid/descriptor.rs
+++ b/honeycomb-core/src/cmap/builder/grid/descriptor.rs
@@ -129,17 +129,17 @@ impl<T: CoordsFloat> GridDescriptor<T> {
                     println!("W: All three grid parameters were specified, total lengths will be ignored");
                 }
                 #[rustfmt::skip]
-                check_parameters!(lpx, "Specified length per x cell is either null or negative");
+                check_parameters!(lpx, "length per x cell is null or negative");
                 #[rustfmt::skip]
-                check_parameters!(lpy, "Specified length per y cell is either null or negative");
+                check_parameters!(lpy, "length per y cell is null or negative");
                 Ok((self.origin, [nx, ny], [lpx, lpy]))
             }
             // from # cells and total lengths
             (Some([nx, ny, _]), None, Some([lx, ly, _])) => {
                 #[rustfmt::skip]
-                check_parameters!(lx, "Specified grid length along x is either null or negative");
+                check_parameters!(lx, "grid length along x is null or negative");
                 #[rustfmt::skip]
-                check_parameters!(ly, "Specified grid length along y is either null or negative");
+                check_parameters!(ly, "grid length along y is null or negative");
                 Ok((
                     self.origin,
                     [nx, ny],
@@ -149,13 +149,13 @@ impl<T: CoordsFloat> GridDescriptor<T> {
             // from lengths per cell and total lengths
             (None, Some([lpx, lpy, _]), Some([lx, ly, _])) => {
                 #[rustfmt::skip]
-                check_parameters!(lpx, "Specified length per x cell is either null or negative");
+                check_parameters!(lpx, "length per x cell is null or negative");
                 #[rustfmt::skip]
-                check_parameters!(lpy, "Specified length per y cell is either null or negative");
+                check_parameters!(lpy, "length per y cell is null or negative");
                 #[rustfmt::skip]
-                check_parameters!(lx, "Specified grid length along x is either null or negative");
+                check_parameters!(lx, "grid length along x is null or negative");
                 #[rustfmt::skip]
-                check_parameters!(ly, "Specified grid length along y is either null or negative");
+                check_parameters!(ly, "grid length along y is null or negative");
                 Ok((
                     self.origin,
                     [
@@ -165,9 +165,7 @@ impl<T: CoordsFloat> GridDescriptor<T> {
                     [lpx, lpy],
                 ))
             }
-            (_, _, _) => Err(BuilderError::MissingGridParameters(
-                "GridBuilder: insufficient building parameters",
-            )),
+            (_, _, _) => Err(BuilderError::MissingGridParameters),
         }
     }
 }

--- a/honeycomb-core/src/cmap/builder/grid/tests.rs
+++ b/honeycomb-core/src/cmap/builder/grid/tests.rs
@@ -63,7 +63,7 @@ fn build_incomplete() {
 }
 
 #[test]
-#[should_panic(expected = "Specified length per y cell is either null or negative")]
+#[should_panic(expected = "length per y cell is null or negative")]
 fn build_neg_lpc() {
     let tmp = GridDescriptor::default()
         .n_cells([4, 4, 0])
@@ -73,7 +73,7 @@ fn build_neg_lpc() {
 }
 
 #[test]
-#[should_panic(expected = "Specified grid length along x is either null or negative")]
+#[should_panic(expected = "grid length along x is null or negative")]
 fn build_null_l() {
     let tmp = GridDescriptor::default()
         .n_cells([4, 4, 0])
@@ -83,7 +83,7 @@ fn build_null_l() {
 }
 
 #[test]
-#[should_panic(expected = "Specified length per x cell is either null or negative")]
+#[should_panic(expected = "length per x cell is null or negative")]
 fn build_neg_lpc_neg_l() {
     // lpc are parsed first so their panic msg should be the one to pop
     // x val is parsed first so ...

--- a/honeycomb-core/src/cmap/builder/io/mod.rs
+++ b/honeycomb-core/src/cmap/builder/io/mod.rs
@@ -148,7 +148,7 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                         // build a collection of vertex lists corresponding of each cell
                         let mut cell_components: Vec<Vec<usize>> = Vec::new();
                         let mut take_next = 0;
-                        verts.iter().for_each(|vertex_id| {
+                        for vertex_id in &verts {
                             if take_next.is_zero() {
                                 // making it usize since it's a counter
                                 take_next = *vertex_id as usize;
@@ -160,7 +160,7 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                                     .push(*vertex_id as usize);
                                 take_next -= 1;
                             }
-                        });
+                        }
                         assert_eq!(num_cells as usize, cell_components.len());
 
                         let mut errs =

--- a/honeycomb-core/src/cmap/builder/io/mod.rs
+++ b/honeycomb-core/src/cmap/builder/io/mod.rs
@@ -66,9 +66,7 @@ macro_rules! build_vertices {
     ($v: ident) => {{
         if_predicate_return_err!(
             !($v.len() % 3).is_zero(),
-            BuilderError::InvalidVtkFile(
-                "failed to build vertices list - the point list contains an incomplete tuple",
-            )
+            BuilderError::BadVtkData("vertex list contains an incomplete tuple")
         );
         $v.chunks_exact(3)
             .map(|slice| {
@@ -113,16 +111,14 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
         | DataSet::RectilinearGrid { .. }
         | DataSet::PolyData { .. }
         | DataSet::Field { .. } => {
-            return Err(BuilderError::UnsupportedVtkData(
-                "dataset not supported - only UnstructuredGrid is currently supported",
-            ))
+            return Err(BuilderError::UnsupportedVtkData("dataset not supported"))
         }
         DataSet::UnstructuredGrid { pieces, .. } => {
             let mut tmp = pieces.iter().map(|piece| {
                 // assume inline data
-                let tmp = piece
-                    .load_piece_data(None)
-                    .expect("E: failed to load piece data - is it not inlined?");
+                let Ok(tmp) = piece.load_piece_data(None) else {
+                    return Err(BuilderError::UnsupportedVtkData("not inlined data piece"));
+                };
 
                 // build vertex list
                 // since we're expecting coordinates, we'll assume floating type
@@ -130,7 +126,11 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                 let vertices: Vec<Vertex2<T>> = match tmp.points {
                     IOBuffer::F64(v) => build_vertices!(v),
                     IOBuffer::F32(v) => build_vertices!(v),
-                    _ => return Err(BuilderError::UnsupportedVtkData("unsupported coordinate representation type - please use float or double")),
+                    _ => {
+                        return Err(BuilderError::UnsupportedVtkData(
+                            "unsupported coordinate type",
+                        ))
+                    }
                 };
 
                 let vtkio::model::Cells { cell_verts, types } = tmp.cells;
@@ -142,113 +142,162 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                         // check basic stuff
                         if_predicate_return_err!(
                             num_cells as usize != types.len(),
-                            BuilderError::InvalidVtkFile(
-                                "failed to build cells - inconsistent number of cell between CELLS and CELL_TYPES"
-                            )
+                            BuilderError::BadVtkData("different # of cell in CELLS and CELL_TYPES")
                         );
 
                         // build a collection of vertex lists corresponding of each cell
                         let mut cell_components: Vec<Vec<usize>> = Vec::new();
                         let mut take_next = 0;
-                        verts.iter().for_each(|vertex_id| if take_next.is_zero() {
-                            // making it usize since it's a counter
-                            take_next = *vertex_id as usize;
-                            cell_components.push(Vec::with_capacity(take_next));
-                        } else {
-                            cell_components.last_mut().expect("E: unreachable").push(*vertex_id as usize);
-                            take_next -= 1;
+                        verts.iter().for_each(|vertex_id| {
+                            if take_next.is_zero() {
+                                // making it usize since it's a counter
+                                take_next = *vertex_id as usize;
+                                cell_components.push(Vec::with_capacity(take_next));
+                            } else {
+                                cell_components
+                                    .last_mut()
+                                    .expect("E: unreachable")
+                                    .push(*vertex_id as usize);
+                                take_next -= 1;
+                            }
                         });
                         assert_eq!(num_cells as usize, cell_components.len());
 
-                        let mut errs = types.iter().zip(cell_components.iter()).map(|(cell_type, vids)| match cell_type {
-                            CellType::Vertex => {
-                                if_predicate_return_err!(
-                                    vids.len() != 1,
-                                    BuilderError::InvalidVtkFile("failed to build cell - `Vertex` cell has incorrect # of vertices (!=1)")
-                                );
-                                // silent ignore
-                                Ok(())
-                            }
-                            CellType::PolyVertex => Err(BuilderError::UnsupportedVtkData("failed to build cell - `PolyVertex` cell type is not supported because for consistency")),
-                            CellType::Line => {
-                                if_predicate_return_err!(
-                                    vids.len() != 2,
-                                    BuilderError::InvalidVtkFile("failed to build cell - `Line` cell has incorrect # of vertices (!=2)")
-                                );
-                                // silent ignore
-                                Ok(())
-                            }
-                            CellType::PolyLine => Err(BuilderError::UnsupportedVtkData("failed to build cell - `PolyLine` cell type is not supported because for consistency")),
-                            CellType::Triangle => {
-                                // check validity
-                                if_predicate_return_err!(
-                                    vids.len() != 3,
-                                    BuilderError::InvalidVtkFile("failed to build cell - `Triangle` cell has incorrect # of vertices (!=3)")
-                                );
-                                // build the triangle
-                                let d0 = cmap.add_free_darts(3);
-                                let (d1, d2) = (d0 + 1, d0 + 2);
-                                cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
-                                cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
-                                cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
-                                cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                                cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                                cmap.one_link(d2, d0); // edge d2 links vertices vids[2] & vids[0]
-                                // record a trace of the built cell for future 2-sew
-                                sew_buffer.insert((vids[0], vids[1]), d0);
-                                sew_buffer.insert((vids[1], vids[2]), d1);
-                                sew_buffer.insert((vids[2], vids[0]), d2);
-                                Ok(())
-                            }
-                            CellType::TriangleStrip => Err(BuilderError::UnsupportedVtkData("failed to build cell - `TriangleStrip` cell type is not supported because of orientation requirements")),
-                            CellType::Polygon => {
-                                let n_vertices = vids.len();
-                                let d0 = cmap.add_free_darts(n_vertices);
-                                (0..n_vertices).for_each(|i| {
-                                    let di = d0 + i as DartIdentifier;
-                                    let dip1 = if i == n_vertices - 1 {
-                                        d0
-                                    } else {
-                                        di + 1
-                                    };
-                                    cmap.insert_vertex(di as VertexIdentifier, vertices[vids[i]]);
-                                    cmap.one_link(di, dip1);
-                                    sew_buffer.insert((vids[i], vids[(i + 1) % n_vertices]), di);
+                        let mut errs =
+                            types
+                                .iter()
+                                .zip(cell_components.iter())
+                                .map(|(cell_type, vids)| match cell_type {
+                                    CellType::Vertex => {
+                                        if_predicate_return_err!(
+                                            vids.len() != 1,
+                                            BuilderError::BadVtkData(
+                                                "`Vertex` with incorrect # of vertices (!=1)"
+                                            )
+                                        );
+                                        // silent ignore
+                                        Ok(())
+                                    }
+                                    CellType::PolyVertex => Err(BuilderError::UnsupportedVtkData(
+                                        "`PolyVertex` cell type",
+                                    )),
+                                    CellType::Line => {
+                                        if_predicate_return_err!(
+                                            vids.len() != 2,
+                                            BuilderError::BadVtkData(
+                                                "`Line` with incorrect # of vertices (!=2)"
+                                            )
+                                        );
+                                        // silent ignore
+                                        Ok(())
+                                    }
+                                    CellType::PolyLine => Err(BuilderError::UnsupportedVtkData(
+                                        "`PolyLine` cell type",
+                                    )),
+                                    CellType::Triangle => {
+                                        // check validity
+                                        if_predicate_return_err!(
+                                            vids.len() != 3,
+                                            BuilderError::BadVtkData(
+                                                "`Triangle` with incorrect # of vertices (!=3)"
+                                            )
+                                        );
+                                        // build the triangle
+                                        let d0 = cmap.add_free_darts(3);
+                                        let (d1, d2) = (d0 + 1, d0 + 2);
+                                        cmap.insert_vertex(
+                                            d0 as VertexIdentifier,
+                                            vertices[vids[0]],
+                                        );
+                                        cmap.insert_vertex(
+                                            d1 as VertexIdentifier,
+                                            vertices[vids[1]],
+                                        );
+                                        cmap.insert_vertex(
+                                            d2 as VertexIdentifier,
+                                            vertices[vids[2]],
+                                        );
+                                        cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
+                                        cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
+                                        cmap.one_link(d2, d0); // edge d2 links vertices vids[2] & vids[0]
+                                                               // record a trace of the built cell for future 2-sew
+                                        sew_buffer.insert((vids[0], vids[1]), d0);
+                                        sew_buffer.insert((vids[1], vids[2]), d1);
+                                        sew_buffer.insert((vids[2], vids[0]), d2);
+                                        Ok(())
+                                    }
+                                    CellType::TriangleStrip => {
+                                        Err(BuilderError::UnsupportedVtkData(
+                                            "`TriangleStrip` cell type",
+                                        ))
+                                    }
+                                    CellType::Polygon => {
+                                        let n_vertices = vids.len();
+                                        let d0 = cmap.add_free_darts(n_vertices);
+                                        (0..n_vertices).for_each(|i| {
+                                            let di = d0 + i as DartIdentifier;
+                                            let dip1 =
+                                                if i == n_vertices - 1 { d0 } else { di + 1 };
+                                            cmap.insert_vertex(
+                                                di as VertexIdentifier,
+                                                vertices[vids[i]],
+                                            );
+                                            cmap.one_link(di, dip1);
+                                            sew_buffer
+                                                .insert((vids[i], vids[(i + 1) % n_vertices]), di);
+                                        });
+                                        Ok(())
+                                    }
+                                    CellType::Pixel => {
+                                        Err(BuilderError::UnsupportedVtkData("`Pixel` cell type"))
+                                    }
+                                    CellType::Quad => {
+                                        if_predicate_return_err!(
+                                            vids.len() != 4,
+                                            BuilderError::BadVtkData(
+                                                "`Quad` with incorrect # of vertices (!=4)"
+                                            )
+                                        );
+                                        // build the quad
+                                        let d0 = cmap.add_free_darts(4);
+                                        let (d1, d2, d3) = (d0 + 1, d0 + 2, d0 + 3);
+                                        cmap.insert_vertex(
+                                            d0 as VertexIdentifier,
+                                            vertices[vids[0]],
+                                        );
+                                        cmap.insert_vertex(
+                                            d1 as VertexIdentifier,
+                                            vertices[vids[1]],
+                                        );
+                                        cmap.insert_vertex(
+                                            d2 as VertexIdentifier,
+                                            vertices[vids[2]],
+                                        );
+                                        cmap.insert_vertex(
+                                            d3 as VertexIdentifier,
+                                            vertices[vids[3]],
+                                        );
+                                        cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
+                                        cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
+                                        cmap.one_link(d2, d3); // edge d2 links vertices vids[2] & vids[3]
+                                        cmap.one_link(d3, d0); // edge d3 links vertices vids[3] & vids[0]
+                                                               // record a trace of the built cell for future 2-sew
+                                        sew_buffer.insert((vids[0], vids[1]), d0);
+                                        sew_buffer.insert((vids[1], vids[2]), d1);
+                                        sew_buffer.insert((vids[2], vids[3]), d2);
+                                        sew_buffer.insert((vids[3], vids[0]), d3);
+                                        Ok(())
+                                    }
+                                    _ => Err(BuilderError::UnsupportedVtkData(
+                                        "CellType not supported in 2-maps",
+                                    )),
                                 });
-                                Ok(())
-                            }
-                            CellType::Pixel => Err(BuilderError::UnsupportedVtkData("failed to build cell - `Pixel` cell type is not supported because of orientation requirements")),
-                            CellType::Quad => {
-                                if_predicate_return_err!(
-                                    vids.len() != 4,
-                                    BuilderError::InvalidVtkFile("failed to build cell - `Quad` cell has incorrect # of vertices (!=4)")
-                                );
-                                // build the quad
-                                let d0 = cmap.add_free_darts(4);
-                                let (d1, d2, d3) = (d0 + 1, d0 + 2, d0 + 3);
-                                cmap.insert_vertex(d0 as VertexIdentifier, vertices[vids[0]]);
-                                cmap.insert_vertex(d1 as VertexIdentifier, vertices[vids[1]]);
-                                cmap.insert_vertex(d2 as VertexIdentifier, vertices[vids[2]]);
-                                cmap.insert_vertex(d3 as VertexIdentifier, vertices[vids[3]]);
-                                cmap.one_link(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                                cmap.one_link(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                                cmap.one_link(d2, d3); // edge d2 links vertices vids[2] & vids[3]
-                                cmap.one_link(d3, d0); // edge d3 links vertices vids[3] & vids[0]
-                                // record a trace of the built cell for future 2-sew
-                                sew_buffer.insert((vids[0], vids[1]), d0);
-                                sew_buffer.insert((vids[1], vids[2]), d1);
-                                sew_buffer.insert((vids[2], vids[3]), d2);
-                                sew_buffer.insert((vids[3], vids[0]), d3);
-                                Ok(())
-                            }
-                            _ => Err(BuilderError::UnsupportedVtkData("failed to build cell - found a CellType that is not supported in 2-maps")),
-                        });
                         if let Some(is_err) = errs.find(Result::is_err) {
                             return Err(is_err.unwrap_err()); // unwrap & wrap because type inference is clunky
                         }
                     }
                     VertexNumbers::XML { .. } => {
-                        return Err(BuilderError::UnsupportedVtkData("XML Vtk files are not supported"));
+                        return Err(BuilderError::UnsupportedVtkData("XML format"));
                     }
                 }
                 Ok(())

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -10,6 +10,7 @@
 use super::GridDescriptor;
 use crate::prelude::{AttributeBind, CMap2};
 use crate::{attributes::AttrStorageManager, geometry::CoordsFloat};
+use thiserror::Error;
 #[cfg(feature = "io")]
 use vtkio::Vtk;
 
@@ -21,19 +22,21 @@ use vtkio::Vtk;
 ///
 /// This enum is used to describe all non-panic errors that can occur when using a builder
 /// structure.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum BuilderError {
     // grid-related variants
     /// One or multiple of the specified grid characteristics are invalid.
+    #[error("invalid grid parameters - {0}")]
     InvalidGridParameters(&'static str),
     /// The builder is missing one or multiple parameters to generate the grid.
-    MissingGridParameters(&'static str),
+    #[error("insufficient parameters - please specifiy at least 2")]
+    MissingGridParameters,
     // vtk-related variants
     /// Specified VTK file contains inconsistent data.
-    InvalidVtkFile(&'static str),
-    /// Specified VTK file could not be found.
-    MissingVtkFile(&'static str),
+    #[error("invalid/corrupted data in the vtk file - {0}")]
+    BadVtkData(&'static str),
     /// Specified VTK file contains unsupported data.
+    #[error("unsupported data in the vtk file - {0}")]
     UnsupportedVtkData(&'static str),
 }
 

--- a/honeycomb-core/src/geometry/mod.rs
+++ b/honeycomb-core/src/geometry/mod.rs
@@ -12,6 +12,7 @@ mod vertex;
 
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+use thiserror::Error;
 
 // ------ CONTENT
 
@@ -23,15 +24,17 @@ pub use vertex::Vertex2;
 // --- error enum
 
 /// Coordinates-level error enum
-#[derive(Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum CoordsError {
     /// Error during the computation of the unit direction vector.
     ///
     /// This is returned when trying to compute the unit vector of a null [`Vector2`].
+    #[error("cannot compute unit direction of a null vector")]
     InvalidUnitDir,
     /// Error during the computation of the normal direction vector.
     ///
     /// This is returned when trying to compute the normal to a null [`Vector2`].
+    #[error("cannot compute normal direction to a null vector")]
     InvalidNormDir,
 }
 

--- a/honeycomb-kernels/Cargo.toml
+++ b/honeycomb-kernels/Cargo.toml
@@ -14,8 +14,9 @@ publish = true
 
 [dependencies]
 honeycomb-core = { workspace = true, features = ["io", "utils"] }
-vtkio.workspace = true
 num-traits.workspace = true
+thiserror.workspace = true
+vtkio.workspace = true
 
 [features]
 profiling = []

--- a/honeycomb-kernels/src/grisubal/clip.rs
+++ b/honeycomb-kernels/src/grisubal/clip.rs
@@ -57,7 +57,7 @@ fn mark_faces<T: CoordsFloat>(
             let mut darts = Orbit2::new(cmap, OrbitPolicy::Face, face_id as DartIdentifier);
             if darts.any(|did| cmap.get_attribute::<Boundary>(did) == Some(other)) {
                 return Err(GrisubalError::InconsistentOrientation(
-                    "reached other side of the boundary without crossing it".to_string(),
+                    "between-boundary inconsistency",
                 ));
             }
             // find neighbor faces where entry darts aren't tagged

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -68,23 +68,28 @@ use crate::grisubal::model::{
     compute_overlapping_grid, detect_orientation_issue, remove_redundant_poi, Boundary, Geometry2,
 };
 use honeycomb_core::prelude::{CMap2, CoordsFloat};
+use thiserror::Error;
 use vtkio::Vtk;
 
 // ------ CONTENT
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 /// Enum used to model potential errors of the `grisubal` kernel.
 ///
 /// Each variant has an associated message that details more precisely what was detected.
 pub enum GrisubalError {
     /// An orientation issue has been detected in the input geometry.
-    InconsistentOrientation(String),
+    #[error("boundary isn't consistently oriented - {0}")]
+    InconsistentOrientation(&'static str),
     /// The specified geometry does not match one (or more) requirements of the algorithm.
-    InvalidInput(String),
+    #[error("input shape isn't conform to requirements - {0}")]
+    InvalidShape(&'static str),
     /// The VTK file used to try to build a `Geometry2` object contains invalid data
     /// (per VTK's specification).
+    #[error("invalid/corrupted data in the vtk file - {0}")]
     BadVtkData(&'static str),
     /// The VTK file used to try to build a `Geometry2` object contains valid but unsupported data.
+    #[error("unsupported data in the vtk file - {0}")]
     UnsupportedVtkData(&'static str),
 }
 

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -73,6 +73,7 @@ macro_rules! build_vertices {
 impl<T: CoordsFloat> TryFrom<Vtk> for Geometry2<T> {
     type Error = GrisubalError;
 
+    #[allow(clippy::too_many_lines)]
     fn try_from(value: Vtk) -> Result<Self, Self::Error> {
         // What we are reading / how we construct the geometry:
         // The input VTK file should describe boundaries (e.g. edges in 2D) & key vertices (e.g. sharp corners)
@@ -126,7 +127,7 @@ impl<T: CoordsFloat> TryFrom<Vtk> for Geometry2<T> {
                             // build a collection of vertex lists corresponding of each cell
                             let mut cell_components: Vec<Vec<usize>> = Vec::new();
                             let mut take_next = 0;
-                            verts.iter().for_each(|vertex_id| {
+                            for vertex_id in &verts {
                                 if take_next == 0 {
                                     // making it usize since it's a counter
                                     take_next = *vertex_id as usize;
@@ -138,7 +139,7 @@ impl<T: CoordsFloat> TryFrom<Vtk> for Geometry2<T> {
                                         .push(*vertex_id as usize);
                                     take_next -= 1;
                                 }
-                            });
+                            }
                             assert_eq!(num_cells as usize, cell_components.len());
 
                             if let Some(err) = types.iter().zip(cell_components.iter()).find_map(

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -64,7 +64,7 @@ pub fn process_cell<T: CoordsFloat>(
     let mut n = darts.len();
 
     // early checks - check # of darts & face size
-    check_requirements(n, new_darts.len(), face_id)?;
+    check_requirements(n, new_darts.len())?;
 
     // get associated vertices - check for undefined vertices
     let mut vertices = fetch_face_vertices(cmap, &darts, face_id)?;

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -67,7 +67,7 @@ pub fn process_cell<T: CoordsFloat>(
     check_requirements(n, new_darts.len())?;
 
     // get associated vertices - check for undefined vertices
-    let mut vertices = fetch_face_vertices(cmap, &darts, face_id)?;
+    let mut vertices = fetch_face_vertices(cmap, &darts)?;
 
     let mut ndart_id = new_darts[0];
     while n > 3 {

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -52,10 +52,10 @@ pub fn process_cell<T: CoordsFloat>(
     let n = darts.len();
 
     // early checks - check # of darts & face size
-    check_requirements(n, new_darts.len(), face_id)?;
+    check_requirements(n, new_darts.len())?;
 
     // get associated vertices - check for undefined vertices
-    let vertices = fetch_face_vertices(cmap, &darts, face_id)?;
+    let vertices = fetch_face_vertices(cmap, &darts)?;
 
     // iterating by ref so that we can still access the list
     let star = darts

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -152,7 +152,7 @@ pub fn process_convex_cell<T: CoordsFloat>(
     let n = Orbit2::new(cmap, OrbitPolicy::Custom(&[1]), face_id as DartIdentifier).count();
 
     // early rets
-    check_requirements(n, new_darts.len(), face_id)?;
+    check_requirements(n, new_darts.len())?;
 
     // we assume the polygon is convex (== starrable from any vertex)
     let sdart = face_id as DartIdentifier;

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -24,7 +24,7 @@ pub use fan::process_convex_cell as fan_convex_cell;
 
 // ------ CONTENT
 
-use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
+use honeycomb_core::cmap::{CMap2, DartIdentifier};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
 use thiserror::Error;
 
@@ -114,7 +114,6 @@ pub fn check_requirements(
 fn fetch_face_vertices<T: CoordsFloat>(
     cmap: &CMap2<T>,
     darts: &[DartIdentifier],
-    face_id: FaceIdentifier,
 ) -> Result<Vec<Vertex2<T>>, TriangulateError> {
     let tmp = darts
         .iter()

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -26,24 +26,31 @@ pub use fan::process_convex_cell as fan_convex_cell;
 
 use honeycomb_core::cmap::{CMap2, DartIdentifier, FaceIdentifier};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
+use thiserror::Error;
 
 /// Error-modeling enum for triangulation routines.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum TriangulateError {
     /// The face to triangulate is already a triangle.
+    #[error("face is already a triangle")]
     AlreadyTriangulated,
     /// The face has no ear to use for triangulation using the ear clipping method.
+    #[error("no ear found in the polygon to triangulate")]
     NoEar,
     /// The face is not fannable, i.e. there is no "star" vertex.
+    #[error("no star in the polygon to triangulate")]
     NonFannable,
     /// The number of darts passed to create the new segments is too low. The `usize` value
     /// is the number of missing darts.
+    #[error("not enough darts were passed to the triangulation function - missing `{0}`")]
     NotEnoughDarts(usize),
     /// The number of darts passed to create the new segments is too high. The `usize` value
     /// is the number of excess darts.
+    #[error("too many darts were passed to the triangulation function - missing `{0}`")]
     TooManyDarts(usize),
     /// The face is not fit for triangulation. The `String` contains information about the reason.
-    UndefinedFace(String),
+    #[error("face {0} isn't defined correctly - {1}")]
+    UndefinedFace(FaceIdentifier, &'static str),
 }
 
 #[allow(clippy::missing_errors_doc)]
@@ -83,9 +90,10 @@ pub fn check_requirements(
 ) -> Result<(), TriangulateError> {
     match n_darts_face {
         1 | 2 => {
-            return Err(TriangulateError::UndefinedFace(format!(
-                "face {face_id} has less than three vertices"
-            )));
+            return Err(TriangulateError::UndefinedFace(
+                face_id,
+                "less than 3 vertices",
+            ));
         }
         3 => {
             return Err(TriangulateError::AlreadyTriangulated);
@@ -116,9 +124,10 @@ fn fetch_face_vertices<T: CoordsFloat>(
         .iter()
         .map(|dart_id| cmap.vertex(cmap.vertex_id(*dart_id)));
     if tmp.clone().any(|v| v.is_none()) {
-        Err(TriangulateError::UndefinedFace(format!(
-            "face {face_id} has one or more undefined vertices"
-        )))
+        Err(TriangulateError::UndefinedFace(
+            face_id,
+            "one or more undefined vertices",
+        ))
     } else {
         Ok(tmp.map(Option::unwrap).collect()) // safe unwrap due to if
     }

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -49,8 +49,8 @@ pub enum TriangulateError {
     #[error("too many darts were passed to the triangulation function - missing `{0}`")]
     TooManyDarts(usize),
     /// The face is not fit for triangulation. The `String` contains information about the reason.
-    #[error("face {0} isn't defined correctly - {1}")]
-    UndefinedFace(FaceIdentifier, &'static str),
+    #[error("face isn't defined correctly - {0}")]
+    UndefinedFace(&'static str),
 }
 
 #[allow(clippy::missing_errors_doc)]
@@ -86,14 +86,10 @@ pub enum TriangulateError {
 pub fn check_requirements(
     n_darts_face: usize,
     n_darts_allocated: usize,
-    face_id: FaceIdentifier,
 ) -> Result<(), TriangulateError> {
     match n_darts_face {
         1 | 2 => {
-            return Err(TriangulateError::UndefinedFace(
-                face_id,
-                "less than 3 vertices",
-            ));
+            return Err(TriangulateError::UndefinedFace("less than 3 vertices"));
         }
         3 => {
             return Err(TriangulateError::AlreadyTriangulated);
@@ -125,7 +121,6 @@ fn fetch_face_vertices<T: CoordsFloat>(
         .map(|dart_id| cmap.vertex(cmap.vertex_id(*dart_id)));
     if tmp.clone().any(|v| v.is_none()) {
         Err(TriangulateError::UndefinedFace(
-            face_id,
             "one or more undefined vertices",
         ))
     } else {


### PR DESCRIPTION
- add `thiserror` as a dependency, and use it for `BuilderError`, `GrisubalError` and `TriangulateError`
- rename some variants for consistency 
- shorten a bunch of error messages
- replace most (all?) `String`contained in enum variants by `&'static str`

I think this, along with #188, closes #175 