### PR TITLE
refactor: replace regular prints with prints to stderr for warnings

### DIFF
--- a/benches/src/grisubal.rs
+++ b/benches/src/grisubal.rs
@@ -11,7 +11,7 @@ fn main() {
             "left" => grisubal::Clip::Left,
             "right" => grisubal::Clip::Right,
             _ => {
-                println!("W: unrecognised clip argument - running kernel without clipping");
+                eprintln!("W: unrecognised clip argument - running kernel without clipping");
                 grisubal::Clip::None
             }
         })

--- a/examples/examples/kernels/grisubal.rs
+++ b/examples/examples/kernels/grisubal.rs
@@ -12,7 +12,7 @@ fn main() {
                 "left" => Clip::Left,
                 "right" => Clip::Right,
                 _ => {
-                    println!("W: unrecognised clip argument - running kernel without clipping");
+                    eprintln!("W: unrecognised clip argument - running kernel without clipping");
                     Clip::None
                 }
             }

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -60,8 +60,8 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
                 if let Some(v) = AttributeUpdate::merge_from_none() {
                     self.set(out.into(), v);
                 } else {
-                    println!("W: cannot merge two null attribute value");
-                    println!("   setting new target value to `None`");
+                    eprintln!("W: cannot merge two null attribute value");
+                    eprintln!("   setting new target value to `None`");
                     let _ = self.remove(out.into());
                 }
             }
@@ -75,8 +75,8 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
             self.set(lhs_out.into(), lhs_val);
             self.set(rhs_out.into(), rhs_val);
         } else {
-            println!("W: cannot split attribute value (not found in storage)");
-            println!("   setting both new values to `None`");
+            eprintln!("W: cannot split attribute value (not found in storage)");
+            eprintln!("   setting both new values to `None`");
             let _ = self.remove(lhs_out.into());
             let _ = self.remove(rhs_out.into());
         }
@@ -188,8 +188,8 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
                 if let Some(v) = AttributeUpdate::merge_from_none() {
                     self.set(out.into(), v);
                 } else {
-                    println!("W: cannot merge two null attribute value");
-                    println!("   setting new target value to `None`");
+                    eprintln!("W: cannot merge two null attribute value");
+                    eprintln!("   setting new target value to `None`");
                     let _ = self.remove(out.into());
                 }
             }
@@ -203,8 +203,8 @@ impl<A: AttributeBind + AttributeUpdate + Copy> UnknownAttributeStorage for Attr
             self.set(lhs_out.into(), lhs_val);
             self.set(rhs_out.into(), rhs_val);
         } else {
-            println!("W: cannot split attribute value (not found in storage)");
-            println!("   setting both new values to `None`");
+            eprintln!("W: cannot split attribute value (not found in storage)");
+            eprintln!("   setting both new values to `None`");
             let _ = self.remove(lhs_out.into());
             let _ = self.remove(rhs_out.into());
         }

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -366,11 +366,11 @@ impl AttrStorageManager {
         }
         .is_some()
         {
-            println!(
+            eprintln!(
                 "W: Storage of attribute `{}` already exists in the attribute storage manager",
                 std::any::type_name::<A>()
             );
-            println!("   Continuing...");
+            eprintln!("   Continuing...");
         }
     }
 
@@ -388,7 +388,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.extend(length);
         } else {
-            println!(
+            eprintln!(
                 "W: could not extend storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -457,7 +457,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.set(id, val);
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -487,7 +487,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.insert(id, val);
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -521,7 +521,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.get(id)
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -561,7 +561,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.replace(id, val)
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -596,7 +596,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.remove(id)
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -621,7 +621,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.merge(id_out, id_in_lhs, id_in_rhs);
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
@@ -645,7 +645,7 @@ impl AttrStorageManager {
         if let Some(st) = storage {
             st.split(id_out_lhs, id_out_rhs, id_in);
         } else {
-            println!(
+            eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );

--- a/honeycomb-core/src/cmap/builder/grid/descriptor.rs
+++ b/honeycomb-core/src/cmap/builder/grid/descriptor.rs
@@ -126,7 +126,7 @@ impl<T: CoordsFloat> GridDescriptor<T> {
             // from # cells and lengths per cell
             (Some([nx, ny, _]), Some([lpx, lpy, _]), lens) => {
                 if lens.is_some() {
-                    println!("W: All three grid parameters were specified, total lengths will be ignored");
+                    eprintln!("W: All three grid parameters were specified, total lengths will be ignored");
                 }
                 #[rustfmt::skip]
                 check_parameters!(lpx, "length per x cell is null or negative");

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -274,7 +274,9 @@ pub fn compute_overlapping_grid<T: CoordsFloat>(
     let mut i = 1;
 
     while on_corner | reflect {
-        println!("W: land on corner: {on_corner} - reflect on an axis: {reflect}, shifting origin");
+        eprintln!(
+            "W: land on corner: {on_corner} - reflect on an axis: {reflect}, shifting origin"
+        );
         og_x += len_cell_x * T::from(1. / (2_i32.pow(i + 1) as f32)).unwrap();
         og_y += len_cell_y * T::from(1. / (2_i32.pow(i + 1) as f32)).unwrap();
         (on_corner, reflect) =


### PR DESCRIPTION
I'll replace those of `split_edge` methods in another PR