### PR TITLE
feat(bench): add benchmarking tools for the grid building routines

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -27,6 +27,10 @@ rand = { workspace = true, features = ["small_rng"] }
 # binaries
 
 [[bin]]
+name = "builder"
+path = "src/builder.rs"
+
+[[bin]]
 name = "grisubal"
 path = "src/grisubal.rs"
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -81,6 +81,17 @@ name = "splitsquaremap-shift"
 path = "benches/splitsquaremap/shift.rs"
 harness = false
 
+
+[[bench]]
+name = "builder"
+path = "benches/builder/time.rs"
+harness = false
+
+[[bench]]
+name = "builder-grid-size"
+path = "benches/builder/grid_size.rs"
+harness = false
+
 ## Kernels benchmarks
 
 [[bench]]

--- a/benches/benches/builder/grid_size.rs
+++ b/benches/benches/builder/grid_size.rs
@@ -1,0 +1,34 @@
+// ------ IMPORTS
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use honeycomb::prelude::CMap2;
+use honeycomb_benches::FloatType;
+use honeycomb_core::cmap::CMapBuilder;
+// ------ CONTENT
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("builder-grid-size");
+
+    for multiplier in 7..13 {
+        let size = 2_u64.pow(multiplier);
+        group.throughput(Throughput::Elements(size.pow(2))); // throughoutput = number of cells
+        group.bench_with_input(BenchmarkId::new("unit-squares", ""), &size, |b, size| {
+            b.iter(|| {
+                let mut map: CMap2<FloatType> =
+                    CMapBuilder::unit_grid(*size as usize).build().unwrap();
+                black_box(&mut map);
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("unit-triangles", ""), &size, |b, size| {
+            b.iter(|| {
+                let mut map: CMap2<FloatType> =
+                    CMapBuilder::unit_triangles(*size as usize).build().unwrap();
+                black_box(&mut map);
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/benches/builder/time.rs
+++ b/benches/benches/builder/time.rs
@@ -1,0 +1,35 @@
+// ------ IMPORTS
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use honeycomb::prelude::CMap2;
+use honeycomb_benches::FloatType;
+use honeycomb_core::cmap::CMapBuilder;
+// ------ CONTENT
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // passing args to cargo bench filters bench instead of actually reading args;
+    // the path to the file needs to be hardcoded (I think?)
+    //let path = "./examples/shape.vtk";
+
+    let mut group = c.benchmark_group("builder-time");
+
+    let n_square = 128;
+
+    group.bench_with_input(BenchmarkId::new("unit-squares", ""), &(), |b, _| {
+        b.iter(|| {
+            let mut map: CMap2<FloatType> = CMapBuilder::unit_grid(n_square).build().unwrap();
+            black_box(&mut map);
+        })
+    });
+    group.bench_with_input(BenchmarkId::new("unit-triangles", ""), &(), |b, _| {
+        b.iter(|| {
+            let mut map: CMap2<FloatType> = CMapBuilder::unit_triangles(n_square).build().unwrap();
+            black_box(&mut map);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/builder.py
+++ b/benches/builder.py
@@ -1,0 +1,90 @@
+import subprocess
+import sys
+
+# Definitions
+
+BUILDER_PROF = "./target/profiling/builder"
+
+FIXED_SIZE = "128"
+SIZE_RANGE = [2 ** n for n in range(7, 13)]  # 128*128 to 8192*8192
+
+PERF_FREQ = "997"
+
+
+# Benchmarks suite
+
+def fixed():
+    # avg runtime using criterion
+    subprocess.run(["mkdir", "fixed"])
+    subprocess.run(["cargo", "bench", "--bench", "builder"], stdout=open("fixed/criterion.txt", "w"))
+    subprocess.run(["cargo", "build", "--profile=profiling", "--bin=builder"])
+    # perf + flamegraph
+    subprocess.run(
+        ["perf", "record", "-o", "fixed/perf.data", "-F", PERF_FREQ, "--call-graph", "dwarf", BUILDER_PROF,
+         FIXED_SIZE, FIXED_SIZE])
+    subprocess.run(["flamegraph", "--flamechart", "--perfdata", "fixed/perf.data", "-o", "fixed/fg.svg"])
+    # heaptrack
+    subprocess.run(["heaptrack", "-o", "fixed/ht", BUILDER_PROF, FIXED_SIZE, FIXED_SIZE])
+    return
+
+
+def size():
+    # avg runtimes using criterion
+    subprocess.run(["mkdir", "size"])
+    subprocess.run(["cargo", "bench", "--bench", "builder-grid-size"], stdout=open("size/criterion.txt", "w"))
+    subprocess.run(["cargo", "build", "--profile=profiling", "--bin=builder"])
+    for i in SIZE_RANGE:
+        # perf + flamegraph
+        subprocess.run(
+            ["perf", "record", "-o", f"size/{i}.perf.data", "-F", PERF_FREQ, "--call-graph", "dwarf", BUILDER_PROF,
+             FIXED_SIZE, FIXED_SIZE])
+        subprocess.run(
+            ["flamegraph", "--flamechart", "--perfdata", f"size/{i}.perf.data", "-o", f"size/{i:.1f}.svg"])
+        # heaptrack
+        subprocess.run(["heaptrack", "-o", f"size/{i}", BUILDER_PROF, str(i), str(i)])
+    return
+
+
+def thread():
+    print("Not yet implemented")
+    return
+
+
+# Main
+
+def main():
+    print("Run:")
+    print("(0) all")
+    print("(1) fixed-size profiling")
+    print("(2) grid size scaling")
+    print("(3) thread number scaling")
+    print("(q) quit")
+
+    choice = input("Enter your choice (0-3): ")
+
+    if choice == "0":
+        print("Running all benchmarks")
+        fixed()
+        size()
+        thread()
+    elif choice == "1":
+        print("Running fixed-size benchmarks")
+        fixed()
+    elif choice == "2":
+        print("Running grid size scaling benchmarks")
+        size()
+    elif choice == "3":
+        print("Running thread number scaling benchmarks")
+        subprocess.run(["df", "-h"])
+    elif choice == "q":
+        print("Quitting")
+        sys.exit(0)
+    else:
+        print("Invalid option; Exiting.")
+        sys.exit(1)
+    print("Finished")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/src/builder.rs
+++ b/benches/src/builder.rs
@@ -1,0 +1,26 @@
+use honeycomb::prelude::{CMapBuilder, GridDescriptor};
+
+fn main() {
+    // ./binary nx ny split
+    let grid = {
+        let args: Vec<String> = std::env::args().collect();
+        match (args.get(1), args.get(2), args.get(3)) {
+            (Some(nx), Some(ny), split) => {
+                let nx = nx.parse().unwrap();
+                let ny = ny.parse().unwrap();
+                GridDescriptor::default()
+                    .n_cells([nx, ny, 0])
+                    .lens([1.0, 1.0, 1.0])
+                    .split_quads(split.is_some())
+            }
+            _ => panic!("E: specifify at least the number of cells along X and Y axes"),
+        }
+    };
+
+    let map = CMapBuilder::default()
+        .grid_descriptor(grid)
+        .build()
+        .unwrap();
+
+    std::hint::black_box(map);
+}


### PR DESCRIPTION
add:
- a python script
- two benchmarks, one fixed size, one ver a range of grid sizes
- a binary to profile using perf / heaptrack / ...