### PR TITLE
feat(core): add `PMap2`, a parallel cmap prototype

### DIFF
--- a/honeycomb-core/src/cmap/collections.rs
+++ b/honeycomb-core/src/cmap/collections.rs
@@ -6,6 +6,7 @@
 // ------ IMPORTS
 
 use crate::geometry::CoordsFloat;
+use crate::pmap::PMap2;
 use crate::prelude::CMap2;
 
 // ------ CONTENT
@@ -15,6 +16,14 @@ macro_rules! collection_constructor {
         impl<'a, T: CoordsFloat> $coll<'a, T> {
             /// Constructor
             pub(crate) fn new(_: &'a CMap2<T>, ids: impl IntoIterator<Item = $idty>) -> Self {
+                Self {
+                    lifetime_indicator: std::marker::PhantomData::default(),
+                    identifiers: ids.into_iter().collect(),
+                }
+            }
+
+            /// Constructor
+            pub(crate) fn newp(_: &'a PMap2<T>, ids: impl IntoIterator<Item = $idty>) -> Self {
                 Self {
                     lifetime_indicator: std::marker::PhantomData::default(),
                     identifiers: ids.into_iter().collect(),
@@ -50,7 +59,7 @@ pub struct VertexCollection<'a, T: CoordsFloat> {
     ///
     /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
     /// if the original map is used in a mutable context.
-    lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    lifetime_indicator: std::marker::PhantomData<&'a T>,
     /// Collection of vertex identifiers.
     pub identifiers: Vec<VertexIdentifier>,
 }
@@ -83,7 +92,7 @@ pub struct EdgeCollection<'a, T: CoordsFloat> {
     ///
     /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
     /// if the original map is used in a mutable context.
-    lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    lifetime_indicator: std::marker::PhantomData<&'a T>,
     /// Collection of vertex identifiers.
     pub identifiers: Vec<EdgeIdentifier>,
 }
@@ -116,7 +125,7 @@ pub struct FaceCollection<'a, T: CoordsFloat> {
     ///
     /// This is used to ensure that the collection is only used while valid, i.e. it is invalidated
     /// if the original map is used in a mutable context.
-    lifetime_indicator: std::marker::PhantomData<&'a CMap2<T>>,
+    lifetime_indicator: std::marker::PhantomData<&'a T>,
     /// Collection of vertex identifiers.
     pub identifiers: Vec<FaceIdentifier>,
 }

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -146,16 +146,16 @@ use std::collections::BTreeSet;
 #[cfg_attr(feature = "utils", derive(Clone))]
 pub struct CMap2<T: CoordsFloat> {
     /// List of vertices making up the represented mesh
-    pub(super) attributes: AttrStorageManager,
+    pub(crate) attributes: AttrStorageManager,
     /// List of vertices making up the represented mesh
-    pub(super) vertices: AttrSparseVec<Vertex2<T>>,
+    pub(crate) vertices: AttrSparseVec<Vertex2<T>>,
     /// List of free darts identifiers, i.e. empty spots
     /// in the current dart list
-    pub(super) unused_darts: BTreeSet<DartIdentifier>,
+    pub(crate) unused_darts: BTreeSet<DartIdentifier>,
     /// Array representation of the beta functions
-    pub(super) betas: Vec<[DartIdentifier; CMAP2_BETA]>,
+    pub(crate) betas: Vec<[DartIdentifier; CMAP2_BETA]>,
     /// Current number of darts
-    pub(super) n_darts: usize,
+    pub(crate) n_darts: usize,
 }
 
 #[doc(hidden)]

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -37,5 +37,7 @@ pub mod cmap;
 
 pub mod geometry;
 
+pub mod pmap;
+
 /// commonly used items
 pub mod prelude;

--- a/honeycomb-core/src/pmap/common.rs
+++ b/honeycomb-core/src/pmap/common.rs
@@ -1,0 +1,16 @@
+//! Crate-level common definitions
+
+// ------ CONTENT
+
+// --- darts
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Type definition for dart identifiers
+///
+/// This is used for better control over memory usage and ID encoding.
+pub type PDartIdentifier = AtomicU32;
+
+pub fn is_null(d: &PDartIdentifier) -> bool {
+    d.load(Ordering::Relaxed) == 0 // isn't there better?
+}

--- a/honeycomb-core/src/pmap/common.rs
+++ b/honeycomb-core/src/pmap/common.rs
@@ -4,6 +4,7 @@
 
 // --- darts
 
+use crate::cmap::NULL_DART_ID;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Type definition for dart identifiers
@@ -11,6 +12,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// This is used for better control over memory usage and ID encoding.
 pub type PDartIdentifier = AtomicU32;
 
+/// Check if a given [`PDartIdentifier`] is null.
 pub fn is_null(d: &PDartIdentifier) -> bool {
-    d.load(Ordering::Relaxed) == 0 // isn't there better?
+    d.load(Ordering::Relaxed) == NULL_DART_ID // isn't there better?
 }

--- a/honeycomb-core/src/pmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/pmap/dim2/basic_ops.rs
@@ -22,7 +22,7 @@ use crate::{
 use crate::pmap::dim2::orbits::POrbit2;
 use crate::pmap::dim2::structure::PMap2;
 use std::collections::BTreeSet;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 // ------ CONTENT
 
 /// **Dart-related methods**
@@ -38,7 +38,10 @@ impl<T: CoordsFloat> PMap2<T> {
     /// Return information about the current number of unused darts.
     #[must_use = "returned value is not used, consider removing this method call"]
     pub fn n_unused_darts(&self) -> usize {
-        self.unused_darts.len()
+        self.unused_darts
+            .iter()
+            .filter(|v| v.load(Ordering::Relaxed))
+            .count()
     }
 
     // --- edit
@@ -66,6 +69,8 @@ impl<T: CoordsFloat> PMap2<T> {
                 AtomicU32::default(),
             ]
         }));
+        self.unused_darts
+            .extend((0..n_darts).map(|_| AtomicBool::new(false)));
         self.vertices.extend(n_darts);
         // self.attributes.extend_storages(n_darts);
         new_id

--- a/honeycomb-core/src/pmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/pmap/dim2/basic_ops.rs
@@ -10,8 +10,7 @@
 // ------ IMPORTS
 
 use crate::prelude::{
-    DartIdentifier, EdgeIdentifier, FaceIdentifier, Orbit2, OrbitPolicy, VertexIdentifier,
-    NULL_DART_ID,
+    DartIdentifier, EdgeIdentifier, FaceIdentifier, OrbitPolicy, VertexIdentifier, NULL_DART_ID,
 };
 use crate::{
     attributes::UnknownAttributeStorage,

--- a/honeycomb-core/src/pmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/pmap/dim2/basic_ops.rs
@@ -1,0 +1,434 @@
+//! Basic operations implementation
+//!
+//! This module contains code used to implement basic operations of combinatorial maps, such as
+//! (but not limited to):
+//!
+//! - Dart addition / insertion / removal
+//! - Beta function interfaces
+//! - i-cell computations
+
+// ------ IMPORTS
+
+use crate::prelude::{
+    DartIdentifier, EdgeIdentifier, FaceIdentifier, Orbit2, OrbitPolicy, VertexIdentifier,
+    NULL_DART_ID,
+};
+use crate::{
+    attributes::UnknownAttributeStorage,
+    cmap::{EdgeCollection, FaceCollection, VertexCollection},
+    geometry::CoordsFloat,
+};
+
+use crate::pmap::dim2::structure::PMap2;
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicU32, Ordering};
+// ------ CONTENT
+
+/// **Dart-related methods**
+impl<T: CoordsFloat> PMap2<T> {
+    // --- read
+
+    /// Return information about the current number of darts.
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_darts(&self) -> usize {
+        self.n_darts
+    }
+
+    /// Return information about the current number of unused darts.
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_unused_darts(&self) -> usize {
+        self.unused_darts.len()
+    }
+
+    // --- edit
+
+    /// Add multiple new free darts to the combinatorial map.
+    ///
+    /// All darts are i-free for all i and are pushed to the end of the list of existing darts.
+    ///
+    /// # Arguments
+    ///
+    /// - `n_darts: usize` -- Number of darts to have.
+    ///
+    /// # Return
+    ///
+    /// Return the `ID` of the first created dart to allow for direct operations. Darts are
+    /// positioned on range `ID..ID+n_darts`.
+    ///
+    pub fn add_free_darts(&mut self, n_darts: usize) -> DartIdentifier {
+        let new_id = self.n_darts as DartIdentifier;
+        self.n_darts += n_darts;
+        self.betas.extend((0..n_darts).map(|_| {
+            [
+                AtomicU32::default(),
+                AtomicU32::default(),
+                AtomicU32::default(),
+            ]
+        }));
+        self.vertices.extend(n_darts);
+        // self.attributes.extend_storages(n_darts);
+        new_id
+    }
+
+    /// Remove a free dart from the combinatorial map.
+    ///
+    /// The removed dart identifier is added to the list of free dart. This way of proceeding is
+    /// necessary as the structure relies on darts indexing for encoding data, making reordering of
+    /// any sort extremely costly.
+    ///
+    /// By keeping track of free spots in the dart arrays, we can prevent too much memory waste,
+    /// although at the cost of locality of reference.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of the dart to remove.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if:
+    ///
+    /// - The dart is not *i*-free for all *i*.
+    /// - The dart is already marked as unused (Refer to [`Self::remove_vertex`] documentation for
+    ///   a detailed breakdown of this choice).
+    ///
+    pub fn remove_free_dart(&mut self, dart_id: DartIdentifier) {
+        assert!(self.is_free(dart_id));
+        assert!(self.unused_darts[dart_id as usize]
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok());
+        // this should not be required if the map is not corrupt
+        // or in the middle of a more complex operation
+        let b0d = self.beta::<0>(dart_id);
+        let b1d = self.beta::<1>(dart_id);
+        let b2d = self.beta::<2>(dart_id);
+        self.betas[b0d as usize][1] = AtomicU32::default();
+        self.betas[b1d as usize][0] = AtomicU32::default();
+        self.betas[b2d as usize][2] = AtomicU32::default();
+    }
+}
+
+/// **Beta-related methods**
+impl<T: CoordsFloat> PMap2<T> {
+    // --- read
+
+    /// Compute the value of the i-th beta function of a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// ## Generics
+    ///
+    /// - `const I: u8` -- Index of the beta function. *I* should be 0, 1 or 2 for a 2D map.
+    ///
+    /// # Return
+    ///
+    /// Return the identifier of the dart *d* such that *d = β<sub>i</sub>(dart)*. If the returned
+    /// value is the null dart (i.e. a dart ID equal to 0), this means that the dart is i-free.
+    ///
+    /// # Panics
+    ///
+    /// The method will panic if *I* is not 0, 1 or 2.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn beta<const I: u8>(&self, dart_id: DartIdentifier) -> DartIdentifier {
+        assert!(I < 3);
+        self.betas[dart_id as usize][I as usize].load(Ordering::Relaxed)
+    }
+
+    /// Compute the value of the i-th beta function of a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    /// - `i: u8` -- Index of the beta function. *i* should be 0, 1 or 2 for a 2D map.
+    ///
+    /// # Return
+    ///
+    /// Return the identifier of the dart *d* such that *d = β<sub>i</sub>(dart)*. If the returned
+    /// value is the null dart (i.e. a dart ID equal to 0), this means that the dart is i-free.
+    ///
+    /// # Panics
+    ///
+    /// The method will panic if *i* is not 0, 1 or 2.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn beta_runtime(&self, i: u8, dart_id: DartIdentifier) -> DartIdentifier {
+        assert!(i < 3);
+        match i {
+            0 => self.beta::<0>(dart_id),
+            1 => self.beta::<1>(dart_id),
+            2 => self.beta::<2>(dart_id),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Check if a given dart is i-free.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// ## Generics
+    ///
+    /// - `const I: u8` -- Index of the beta function. *I* should be 0, 1 or 2 for a 2D map.
+    ///
+    /// # Return
+    ///
+    /// Return a boolean indicating if the dart is i-free, i.e.
+    /// *β<sub>i</sub>(dart) = `NULL_DART_ID`*.
+    ///
+    /// # Panics
+    ///
+    /// The function will panic if *I* is not 0, 1 or 2.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn is_i_free<const I: u8>(&self, dart_id: DartIdentifier) -> bool {
+        self.beta::<I>(dart_id) == NULL_DART_ID
+    }
+
+    /// Check if a given dart is i-free, for all i.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// # Return
+    ///
+    /// Return a boolean indicating if the dart is 0-free, 1-free **and** 2-free.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn is_free(&self, dart_id: DartIdentifier) -> bool {
+        self.beta::<0>(dart_id) == NULL_DART_ID
+            && self.beta::<1>(dart_id) == NULL_DART_ID
+            && self.beta::<2>(dart_id) == NULL_DART_ID
+    }
+}
+
+/// **I-cell-related methods**
+impl<T: CoordsFloat> PMap2<T> {
+    #[allow(clippy::missing_panics_doc)]
+    /// Fetch vertex identifier associated to a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// # Return
+    ///
+    /// Return the identifier of the associated vertex.
+    ///
+    /// ## Note on cell identifiers
+    ///
+    /// Cells identifiers are defined as the smallest identifier among the darts that make up the
+    /// cell. This definition has three interesting properties:
+    ///
+    /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
+    ///   associated cell ID.
+    /// - Cell IDs are not affected by the order of traversal of the map.
+    /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
+    ///   that the storage is consistent / up to date.
+    ///
+    /// These properties come at the literal cost of the computation routine, which is:
+    /// 1. a BFS to compute a given orbit
+    /// 2. a minimum computation on the IDs composing the orbit
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn vertex_id(&self, dart_id: DartIdentifier) -> VertexIdentifier {
+        // unwraping the result is safe because the orbit is always non empty
+        Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id)
+            .min()
+            .expect("E: unreachable") as VertexIdentifier
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    /// Fetch edge associated to a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// # Return
+    ///
+    /// Return the identifier of the associated edge.
+    ///
+    /// ## Note on cell identifiers
+    ///
+    /// Cells identifiers are defined as the smallest identifier among the darts that make up the
+    /// cell. This definition has three interesting properties:
+    ///
+    /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
+    ///   associated cell ID.
+    /// - Cell IDs are not affected by the order of traversal of the map.
+    /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
+    ///   that the storage is consistent / up to date.
+    ///
+    /// These properties come at the literal cost of the computation routine, which is:
+    /// 1. a BFS to compute a given orbit
+    /// 2. a minimum computation on the IDs composing the orbit
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn edge_id(&self, dart_id: DartIdentifier) -> EdgeIdentifier {
+        // unwraping the result is safe because the orbit is always non empty
+        Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id)
+            .min()
+            .expect("E: unreachable") as EdgeIdentifier
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    /// Fetch face associated to a given dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// # Return
+    ///
+    /// Return the identifier of the associated face.
+    ///
+    /// ## Note on cell identifiers
+    ///
+    /// Cells identifiers are defined as the smallest identifier among the darts that make up the
+    /// cell. This definition has three interesting properties:
+    ///
+    /// - A given cell ID can be computed from any dart of the cell, i.e. all darts have an
+    ///   associated cell ID.
+    /// - Cell IDs are not affected by the order of traversal of the map.
+    /// - Because the ID is computed in real time, there is no need to store cell IDs and ensure
+    ///   that the storage is consistent / up to date.
+    ///
+    /// These properties come at the literal cost of the computation routine, which is:
+    /// 1. a BFS to compute a given orbit
+    /// 2. a minimum computation on the IDs composing the orbit
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn face_id(&self, dart_id: DartIdentifier) -> FaceIdentifier {
+        // unwraping the result is safe because the orbit is always non empty
+        Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id)
+            .min()
+            .expect("E: unreachable") as FaceIdentifier
+    }
+
+    /// Return an [`Orbit2`] object that can be used to iterate over darts of an i-cell.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- Identifier of a given dart.
+    ///
+    /// ## Generics
+    ///
+    /// - `const I: u8` -- Dimension of the cell of interest. *I* should be 0 (vertex), 1 (edge) or
+    ///   2 (face) for a 2D map.
+    ///
+    /// # Return
+    ///
+    /// Returns an [`Orbit2`] that can be iterated upon to retrieve all dart member of the cell. Note
+    /// that **the dart passed as an argument is included as the first element of the returned
+    /// orbit**.
+    ///
+    /// # Panics
+    ///
+    /// The method will panic if *I* is not 0, 1 or 2.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn i_cell<const I: u8>(&self, dart_id: DartIdentifier) -> Orbit2<T> {
+        assert!(I < 3);
+        match I {
+            0 => Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id),
+            1 => Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id),
+            2 => Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Return a collection of all the map's vertices.
+    ///
+    /// # Return
+    ///
+    /// Return a [`VertexCollection`] object containing a list of vertex identifiers, whose validity
+    /// is ensured through an implicit lifetime condition on the structure and original map.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn fetch_vertices(&self) -> VertexCollection<T> {
+        let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
+        // using a set for cells & converting it later to avoid duplicated values
+        // from incomplete cells until they are correctly supported by Orbit2
+        let mut vertex_ids: BTreeSet<DartIdentifier> = BTreeSet::new();
+        (1..self.n_darts as DartIdentifier)
+            .filter(|dart_id| !self.unused_darts[*dart_id as usize].load(Ordering::Relaxed)) // only used darts
+            .for_each(|dart_id| {
+                // if we haven't seen this dart yet
+                if marked.insert(dart_id) {
+                    // because we iterate from dart 1 to n_darts,
+                    // the first dart we encounter is the min of its orbit
+                    vertex_ids.insert(dart_id as VertexIdentifier);
+                    // mark its orbit
+                    Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id).for_each(|did| {
+                        marked.insert(did);
+                    });
+                }
+            });
+        VertexCollection::<'_, T>::new(self, vertex_ids)
+    }
+
+    /// Return a collection of all the map's edges.
+    ///
+    /// # Return
+    ///
+    /// Return an [`EdgeCollection`] object containing a list of edge identifiers, whose validity
+    /// is ensured through an implicit lifetime condition on the structure and original map.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn fetch_edges(&self) -> EdgeCollection<T> {
+        let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
+        marked.insert(NULL_DART_ID);
+        // using a set for cells & converting it later to avoid duplicated values
+        // from incomplete cells until they are correctly supported by Orbit2
+        let mut edge_ids: BTreeSet<EdgeIdentifier> = BTreeSet::new();
+        (1..self.n_darts as DartIdentifier)
+            .filter(|dart_id| !self.unused_darts[*dart_id as usize].load(Ordering::Relaxed)) // only used darts
+            .for_each(|dart_id| {
+                // if we haven't seen this dart yet
+                if marked.insert(dart_id) {
+                    // because we iterate from dart 1 to n_darts,
+                    // the first dart we encounter is the min of its orbit
+                    edge_ids.insert(dart_id as EdgeIdentifier);
+                    // mark its orbit
+                    Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id).for_each(|did| {
+                        marked.insert(did);
+                    });
+                }
+            });
+        EdgeCollection::<'_, T>::new(self, edge_ids)
+    }
+
+    /// Return a collection of all the map's faces.
+    ///
+    /// # Return
+    ///
+    /// Return a [`FaceCollection`] object containing a list of face identifiers, whose validity
+    /// is ensured through an implicit lifetime condition on the structure and original map.
+    ///
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn fetch_faces(&self) -> FaceCollection<T> {
+        let mut marked: BTreeSet<DartIdentifier> = BTreeSet::new();
+        // using a set for cells & converting it later to avoid duplicated values
+        // from incomplete cells until they are correctly supported by Orbit2
+        let mut face_ids: BTreeSet<FaceIdentifier> = BTreeSet::new();
+        (1..self.n_darts as DartIdentifier)
+            .filter(|dart_id| !self.unused_darts[*dart_id as usize].load(Ordering::Relaxed)) // only used darts
+            .for_each(|dart_id| {
+                // if we haven't seen this dart yet
+                if marked.insert(dart_id) {
+                    // because we iterate from dart 1 to n_darts,
+                    // the first dart we encounter is the min of its orbit
+                    face_ids.insert(dart_id as FaceIdentifier);
+                    // mark its orbit
+                    Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id).for_each(|did| {
+                        marked.insert(did);
+                    });
+                }
+            });
+        FaceCollection::<'_, T>::new(self, face_ids)
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/pmap/dim2/basic_ops.rs
@@ -19,6 +19,7 @@ use crate::{
     geometry::CoordsFloat,
 };
 
+use crate::pmap::dim2::orbits::POrbit2;
 use crate::pmap::dim2::structure::PMap2;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -236,7 +237,7 @@ impl<T: CoordsFloat> PMap2<T> {
     #[must_use = "returned value is not used, consider removing this method call"]
     pub fn vertex_id(&self, dart_id: DartIdentifier) -> VertexIdentifier {
         // unwraping the result is safe because the orbit is always non empty
-        Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id)
+        POrbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id)
             .min()
             .expect("E: unreachable") as VertexIdentifier
     }
@@ -270,7 +271,7 @@ impl<T: CoordsFloat> PMap2<T> {
     #[must_use = "returned value is not used, consider removing this method call"]
     pub fn edge_id(&self, dart_id: DartIdentifier) -> EdgeIdentifier {
         // unwraping the result is safe because the orbit is always non empty
-        Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id)
+        POrbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id)
             .min()
             .expect("E: unreachable") as EdgeIdentifier
     }
@@ -304,7 +305,7 @@ impl<T: CoordsFloat> PMap2<T> {
     #[must_use = "returned value is not used, consider removing this method call"]
     pub fn face_id(&self, dart_id: DartIdentifier) -> FaceIdentifier {
         // unwraping the result is safe because the orbit is always non empty
-        Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id)
+        POrbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id)
             .min()
             .expect("E: unreachable") as FaceIdentifier
     }
@@ -331,12 +332,12 @@ impl<T: CoordsFloat> PMap2<T> {
     /// The method will panic if *I* is not 0, 1 or 2.
     ///
     #[must_use = "returned value is not used, consider removing this method call"]
-    pub fn i_cell<const I: u8>(&self, dart_id: DartIdentifier) -> Orbit2<T> {
+    pub fn i_cell<const I: u8>(&self, dart_id: DartIdentifier) -> POrbit2<T> {
         assert!(I < 3);
         match I {
-            0 => Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id),
-            1 => Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id),
-            2 => Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id),
+            0 => POrbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id),
+            1 => POrbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id),
+            2 => POrbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id),
             _ => unreachable!(),
         }
     }
@@ -363,12 +364,12 @@ impl<T: CoordsFloat> PMap2<T> {
                     // the first dart we encounter is the min of its orbit
                     vertex_ids.insert(dart_id as VertexIdentifier);
                     // mark its orbit
-                    Orbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id).for_each(|did| {
+                    POrbit2::<'_, T>::new(self, OrbitPolicy::Vertex, dart_id).for_each(|did| {
                         marked.insert(did);
                     });
                 }
             });
-        VertexCollection::<'_, T>::new(self, vertex_ids)
+        VertexCollection::<'_, T>::newp(self, vertex_ids)
     }
 
     /// Return a collection of all the map's edges.
@@ -394,12 +395,12 @@ impl<T: CoordsFloat> PMap2<T> {
                     // the first dart we encounter is the min of its orbit
                     edge_ids.insert(dart_id as EdgeIdentifier);
                     // mark its orbit
-                    Orbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id).for_each(|did| {
+                    POrbit2::<'_, T>::new(self, OrbitPolicy::Edge, dart_id).for_each(|did| {
                         marked.insert(did);
                     });
                 }
             });
-        EdgeCollection::<'_, T>::new(self, edge_ids)
+        EdgeCollection::<'_, T>::newp(self, edge_ids)
     }
 
     /// Return a collection of all the map's faces.
@@ -424,11 +425,11 @@ impl<T: CoordsFloat> PMap2<T> {
                     // the first dart we encounter is the min of its orbit
                     face_ids.insert(dart_id as FaceIdentifier);
                     // mark its orbit
-                    Orbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id).for_each(|did| {
+                    POrbit2::<'_, T>::new(self, OrbitPolicy::Face, dart_id).for_each(|did| {
                         marked.insert(did);
                     });
                 }
             });
-        FaceCollection::<'_, T>::new(self, face_ids)
+        FaceCollection::<'_, T>::newp(self, face_ids)
     }
 }

--- a/honeycomb-core/src/pmap/dim2/embed.rs
+++ b/honeycomb-core/src/pmap/dim2/embed.rs
@@ -1,0 +1,279 @@
+//! Attribute operations implementation
+//!
+//! This module contains code used to implement operations on the embedded data associated to the
+//! map. This includes operations regarding vertices as well as (in the future) user-defined
+//! generic attributes
+
+// ------ IMPORT
+
+use crate::pmap::dim2::structure::PMap2;
+use crate::prelude::{Vertex2, VertexIdentifier};
+use crate::{
+    attributes::{AttributeStorage, UnknownAttributeStorage},
+    geometry::CoordsFloat,
+};
+// ------ CONTENT
+
+/// **Built-in vertex-related methods**
+impl<T: CoordsFloat> PMap2<T> {
+    /// Return the current number of vertices.
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn n_vertices(&self) -> usize {
+        self.vertices.n_attributes()
+    }
+
+    /// Fetch vertex value associated to a given identifier.
+    ///
+    /// # Arguments
+    ///
+    /// - `vertex_id: VertexIdentifier` -- Identifier of the given vertex.
+    ///
+    /// # Return
+    ///
+    /// This method return a `Option` taking the following values:
+    /// - `Some(v: Vertex2)` if there is a vertex associated to this ID.
+    /// - `None` -- otherwise
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    #[must_use = "returned value is not used, consider removing this method call"]
+    pub fn vertex(&self, vertex_id: VertexIdentifier) -> Option<Vertex2<T>> {
+        self.vertices.get(vertex_id)
+    }
+
+    /// Insert a vertex in the combinatorial map.
+    ///
+    /// This method can be interpreted as giving a value to the vertex of a specific ID. Vertices
+    /// implicitly exist through topology, but their spatial representation is not automatically
+    /// created at first.
+    ///
+    /// # Arguments
+    ///
+    /// - `vertex_id: VertexIdentifier` -- Vertex identifier to attribute a value to.
+    /// - `vertex: impl Into<Vertex2>` -- Value used to create a [Vertex2] value.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - **there is already a vertex associated to the specified index**
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    pub fn insert_vertex(&mut self, vertex_id: VertexIdentifier, vertex: impl Into<Vertex2<T>>) {
+        self.vertices.insert(vertex_id, vertex.into());
+    }
+
+    /// Remove a vertex from the combinatorial map.
+    ///
+    /// # Arguments
+    ///
+    /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to remove.
+    ///
+    /// # Return
+    ///
+    /// This method return a `Option` taking the following values:
+    /// - `Some(v: Vertex2)` -- The vertex was successfully removed & its value was returned
+    /// - `None` -- The vertex was not found in the internal storage
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    pub fn remove_vertex(&mut self, vertex_id: VertexIdentifier) -> Option<Vertex2<T>> {
+        self.vertices.remove(vertex_id)
+    }
+
+    /// Try to overwrite the given vertex with a new value.
+    ///
+    /// # Arguments
+    ///
+    /// - `vertex_id: VertexIdentifier` -- Identifier of the vertex to replace.
+    /// - `vertex: impl<Into<Vertex2>>` -- New value for the vertex.
+    ///
+    /// # Return
+    ///
+    /// This method return an `Option` taking the following values:
+    /// - `Some(v: Vertex2)` -- The vertex was successfully overwritten & its previous value was
+    ///   returned
+    /// - `None` -- The vertex was set, but no value were overwritten
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the index lands out of bounds
+    /// - the index cannot be converted to `usize`
+    pub fn replace_vertex(
+        &mut self,
+        vertex_id: VertexIdentifier,
+        vertex: impl Into<Vertex2<T>>,
+    ) -> Option<Vertex2<T>> {
+        self.vertices.replace(vertex_id, vertex.into())
+    }
+}
+
+/*
+/// **Generic attribute-related methods**
+impl<T: CoordsFloat> CMap2<T> {
+    /// Setter
+    ///
+    /// Set the value of an attribute for a given index. This operation is not affected by
+    /// the initial state of the edited entry.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: A::IdentifierType` -- Cell index.
+    /// - `val: A` -- Attribute value.
+    ///
+    /// ## Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute kind to edit.
+    ///
+    /// # Panics
+    ///
+    /// The method:
+    /// - should panic if the index lands out of bounds
+    /// - may panic if the index cannot be converted to `usize`
+    pub fn set_attribute<A: AttributeBind + AttributeUpdate>(
+        &mut self,
+        id: A::IdentifierType,
+        val: A,
+    ) {
+        self.attributes.set_attribute::<A>(id, val);
+    }
+
+    /// Setter
+    ///
+    /// Insert an attribute value at a given undefined index. See the panics section information
+    /// on behavior if the value is already defined.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: A::IdentifierType` -- Cell index.
+    /// - `val: A` -- Attribute value.
+    ///
+    /// ## Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute kind to edit.
+    ///
+    /// # Panics
+    ///
+    /// The method:
+    /// - **should panic if there is already a value associated to the specified index**
+    /// - should panic if the index lands out of bounds
+    /// - may panic if the index cannot be converted to `usize`
+    pub fn insert_attribute<A: AttributeBind + AttributeUpdate>(
+        &mut self,
+        id: A::IdentifierType,
+        val: A,
+    ) {
+        self.attributes.insert_attribute::<A>(id, val);
+    }
+
+    /// Getter
+    ///
+    /// # Arguments
+    ///
+    /// - `index: A::IdentifierType` -- Cell index.
+    ///
+    /// ## Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute kind to edit.
+    ///
+    /// # Return
+    ///
+    /// The method should return:
+    /// - `Some(val: A)` if there is an attribute associated with the specified index,
+    /// - `None` if there is not.
+    ///
+    /// # Panics
+    ///
+    /// The method:
+    /// - should panic if the index lands out of bounds
+    /// - may panic if the index cannot be converted to `usize`
+    pub fn get_attribute<A: AttributeBind + AttributeUpdate>(
+        &self,
+        id: A::IdentifierType,
+    ) -> Option<A> {
+        self.attributes.get_attribute::<A>(id)
+    }
+
+    /// Setter
+    ///
+    /// Replace the value of the attribute for a given index.
+    ///
+    /// # Arguments
+    ///
+    /// - `index: A::IdentifierType` -- Cell index.
+    /// - `val: A` -- Attribute value.
+    ///
+    /// ## Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute kind to edit.
+    ///
+    /// # Return
+    ///
+    /// The method should return:
+    /// - `Some(val_old: A)` if there was an attribute associated with the specified index,
+    /// - `None` if there is not.
+    ///
+    /// In both cases, the new value should be set to the one specified as argument.
+    ///
+    /// # Panics
+    ///
+    /// The method:
+    /// - should panic if the index lands out of bounds
+    /// - may panic if the index cannot be converted to `usize`
+    pub fn replace_attribute<A: AttributeBind + AttributeUpdate>(
+        &mut self,
+        id: A::IdentifierType,
+        val: A,
+    ) -> Option<A> {
+        self.attributes.replace_attribute::<A>(id, val)
+    }
+
+    /// Remove an attribute value from the storage and return it
+    ///
+    /// # Arguments
+    ///
+    /// - `index: A::IdentifierType` -- Cell index.
+    ///
+    /// ## Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute kind to edit.
+    ///
+    /// # Return
+    ///
+    /// The method should return:
+    /// - `Some(val: A)` if there was an attribute associated with the specified index,
+    /// - `None` if there is not.
+    ///
+    /// # Panics
+    ///
+    /// The method:
+    /// - may panic if the index lands out of bounds
+    /// - may panic if the index cannot be converted to `usize`
+    pub fn remove_attribute<A: AttributeBind + AttributeUpdate>(
+        &mut self,
+        id: A::IdentifierType,
+    ) -> Option<A> {
+        self.attributes.remove_attribute::<A>(id)
+    }
+
+    // --- big guns
+
+    /// Remove an entire attribute storage from the map.
+    ///
+    /// This method is useful when implementing routines that uses attributes to run; Those can then be removed
+    /// before the final result is returned.
+    ///
+    /// # Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute stored by the fetched storage.
+    pub fn remove_attribute_storage<A: AttributeBind + AttributeUpdate>(&mut self) {
+        self.attributes.remove_storage::<A>();
+    }
+}
+*/

--- a/honeycomb-core/src/pmap/dim2/io.rs
+++ b/honeycomb-core/src/pmap/dim2/io.rs
@@ -1,0 +1,187 @@
+//! Input/Output features implementation
+//!
+//! The support for I/O is currently very restricted since this is not the focus of this project.
+//! Maps can be built from and serialized to VTK legacy files (both binary and ASCII). The
+//! `DATASET` of the VTK file should be `UNSTRUCTURED_GRID`, and only a given set of `CELL_TYPES`
+//! are supported, because of orientation and dimension restriction.
+
+// ------ IMPORTS
+
+use crate::geometry::CoordsFloat;
+use crate::prelude::{DartIdentifier, OrbitPolicy, VertexIdentifier, NULL_DART_ID};
+
+use std::{any::TypeId, collections::BTreeMap};
+
+use crate::pmap::dim2::orbits::POrbit2;
+use crate::pmap::dim2::structure::PMap2;
+use vtkio::{
+    model::{
+        ByteOrder, CellType, DataSet, Piece, UnstructuredGridPiece, Version, VertexNumbers, Vtk,
+    },
+    IOBuffer,
+};
+// ------ CONTENT
+
+/// **Serializing methods**
+impl<T: CoordsFloat + 'static> PMap2<T> {
+    /// Generate a legacy VTK file from the map.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if the internal writing routine fails, i.e.:
+    ///     - Vertex coordinates cannot be cast to `f32` or `f64`
+    ///     - A vertex cannot be found
+    pub fn to_vtk_binary(&self, writer: impl std::io::Write) {
+        // build a Vtk structure
+        let vtk_struct = Vtk {
+            version: Version::Legacy { major: 2, minor: 0 },
+            title: "cmap".to_string(),
+            byte_order: ByteOrder::BigEndian,
+            data: DataSet::UnstructuredGrid {
+                meta: None,
+                pieces: vec![Piece::Inline(Box::new(build_unstructured_piece(self)))],
+            },
+            file_path: None,
+        };
+
+        // write data to the created file
+        vtk_struct
+            .write_legacy(writer)
+            .expect("E: could not write data to writer");
+    }
+
+    /// Generate a legacy VTK file from the map.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if the internal writing routine fails, i.e.:
+    ///     - Vertex coordinates cannot be cast to `f32` or `f64`
+    ///     - A vertex cannot be found
+    pub fn to_vtk_ascii(&self, writer: impl std::fmt::Write) {
+        // build a Vtk structure
+        let vtk_struct = Vtk {
+            version: Version::Legacy { major: 2, minor: 0 },
+            title: "cmap".to_string(),
+            byte_order: ByteOrder::BigEndian,
+            data: DataSet::UnstructuredGrid {
+                meta: None,
+                pieces: vec![Piece::Inline(Box::new(build_unstructured_piece(self)))],
+            },
+            file_path: None,
+        };
+
+        // write data to the created file
+        vtk_struct
+            .write_legacy_ascii(writer)
+            .expect("E: could not write data to writer");
+    }
+}
+
+// --- internals
+
+/// Internal building routine for [`CMap2::to_vtk_file`].
+fn build_unstructured_piece<T>(map: &PMap2<T>) -> UnstructuredGridPiece
+where
+    T: CoordsFloat + 'static,
+{
+    // common data
+    let vertex_ids: Vec<VertexIdentifier> = map.fetch_vertices().identifiers;
+    let mut id_map: BTreeMap<VertexIdentifier, usize> = BTreeMap::new();
+    vertex_ids.iter().enumerate().for_each(|(id, vid)| {
+        id_map.insert(*vid, id);
+    });
+    // ------ points data
+    let vertices = vertex_ids
+        .iter()
+        .map(|vid| {
+            map.vertex(*vid)
+                .expect("E: found a topological vertex with no associated coordinates")
+        })
+        .flat_map(|v| [v.x(), v.y(), T::zero()].into_iter());
+    // ------ cells data
+    let mut n_cells = 0;
+    // --- faces
+    let face_ids = map.fetch_faces().identifiers;
+    let face_data = face_ids.into_iter().map(|id| {
+        let mut count: u32 = 0;
+        // VecDeque will be useful later
+        let orbit: Vec<u32> = POrbit2::new(map, OrbitPolicy::Custom(&[1]), id as DartIdentifier)
+            .map(|dart_id| {
+                count += 1;
+                id_map[&map.vertex_id(dart_id)] as u32
+            })
+            .collect();
+        (count, orbit)
+    });
+
+    // --- borders
+    let edge_ids = map.fetch_edges().identifiers;
+    // because we do not model boundaries, we can get edges
+    // from filtering isolated darts making up edges
+    let edge_data = edge_ids
+        .into_iter()
+        .filter(|id| map.beta::<2>(*id as DartIdentifier) == NULL_DART_ID)
+        .map(|id| {
+            let dart_id = id as DartIdentifier;
+            let ndart_id = map.beta::<1>(dart_id);
+            (
+                id_map[&map.vertex_id(dart_id)] as u32,
+                id_map[&map.vertex_id(ndart_id)] as u32,
+            )
+        });
+
+    // --- corners
+
+    // ------ build VTK data
+    let mut cell_vertices: Vec<u32> = Vec::new();
+    let mut cell_types: Vec<CellType> = Vec::new();
+
+    edge_data.for_each(|(v1, v2)| {
+        cell_types.push(CellType::Line);
+        cell_vertices.extend([2_u32, v1, v2]);
+        n_cells += 1;
+    });
+
+    face_data.for_each(|(count, mut elements)| {
+        cell_types.push(match count {
+            0..=2 => return, // silent ignore
+            3 => CellType::Triangle,
+            4 => CellType::Quad,
+            5.. => CellType::Polygon,
+        });
+        cell_vertices.push(count);
+        cell_vertices.append(&mut elements);
+        n_cells += 1;
+    });
+
+    UnstructuredGridPiece {
+        points: if TypeId::of::<T>() == TypeId::of::<f32>() {
+            IOBuffer::F32(
+                vertices
+                    .map(|t| t.to_f32().expect("E: unreachable"))
+                    .collect(),
+            )
+        } else if TypeId::of::<T>() == TypeId::of::<f64>() {
+            IOBuffer::F64(
+                vertices
+                    .map(|t| t.to_f64().expect("E: unreachable"))
+                    .collect(),
+            )
+        } else {
+            println!("W: unrecognized coordinate type -- cast to f64 might fail");
+            IOBuffer::F64(
+                vertices
+                    .map(|t| t.to_f64().expect("E: unreachable"))
+                    .collect(),
+            )
+        },
+        cells: vtkio::model::Cells {
+            cell_verts: VertexNumbers::Legacy {
+                num_cells: n_cells,
+                vertices: cell_vertices,
+            },
+            types: cell_types,
+        },
+        data: vtkio::model::Attributes::default(),
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/link_and_sew.rs
+++ b/honeycomb-core/src/pmap/dim2/link_and_sew.rs
@@ -1,0 +1,493 @@
+//! (Un)sew and (un)link implementations
+//!
+//! This module contains code used to implement sew, unsew, link and unlink operations in all
+//! dimensions for which they are defined (1, 2) for a [`CMap2`].
+
+// ------ IMPORTS
+
+use crate::pmap::dim2::structure::PMap2;
+use crate::prelude::{DartIdentifier, NULL_DART_ID};
+use crate::{
+    attributes::{AttributeStorage, UnknownAttributeStorage},
+    geometry::CoordsFloat,
+};
+use std::sync::atomic::Ordering;
+// ------ CONTENT
+
+/// **Sew and unsew operations**
+impl<T: CoordsFloat> PMap2<T> {
+    /// 1-sew operation.
+    ///
+    /// This operation corresponds to *coherently linking* two darts via the *β<sub>1</sub>*
+    /// function. For a thorough explanation of this operation (and implied hypothesis &
+    /// consequences), refer to the [user guide][UG].
+    ///
+    /// [UG]: https://lihpc-computational-geometry.github.io/honeycomb/
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
+    /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
+    /// - `policy: SewPolicy` -- Geometrical sewing policy to follow.
+    ///
+    /// After the sewing operation, these darts will verify
+    /// *β<sub>1</sub>(`lhs_dart`) = `rhs_dart`*. The *β<sub>0</sub>* function is also updated.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if the two darts are not 1-sewable.
+    ///
+    pub fn one_sew(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+        // this operation only makes sense if lhs_dart is associated to a fully defined edge, i.e.
+        // its image through beta2 is defined & has a valid associated vertex (we assume the second
+        // condition is valid if the first one is)
+        // if that is not the case, the sewing operation becomes a linking operation
+        let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
+        if b2lhs_dart_id == NULL_DART_ID {
+            self.one_link(lhs_dart_id, rhs_dart_id);
+        } else {
+            // fetch vertices ID before topology update
+            let b2lhs_vid_old = self.vertex_id(b2lhs_dart_id);
+            let rhs_vid_old = self.vertex_id(rhs_dart_id);
+            // update the topology
+            self.one_link(lhs_dart_id, rhs_dart_id);
+            // merge vertices & attributes from the old IDs to the new one
+            // FIXME: VertexIdentifier should be cast to DartIdentifier
+            self.vertices
+                .merge(self.vertex_id(rhs_dart_id), b2lhs_vid_old, rhs_vid_old);
+            /*self.attributes.merge_vertex_attributes(
+                self.vertex_id(rhs_dart_id),
+                b2lhs_vid_old,
+                rhs_vid_old,
+            );
+             */
+        }
+    }
+
+    /// 2-sew operation.
+    ///
+    /// This operation corresponds to *coherently linking* two darts via the *β<sub>2</sub>*
+    /// function. For a thorough explanation of this operation (and implied hypothesis &
+    /// consequences), refer to the [user guide][UG].
+    ///
+    /// [UG]: https://lihpc-computational-geometry.github.io/honeycomb/
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
+    /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
+    /// - `policy: SewPolicy` -- Geometrical sewing policy to follow.
+    ///
+    /// After the sewing operation, these darts will verify
+    /// *β<sub>2</sub>(`lhs_dart`) = `rhs_dart`* and *β<sub>2</sub>(`rhs_dart`) = `lhs_dart`*.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if:
+    /// - the two darts are not 2-sewable,
+    /// - the method cannot resolve orientation issues.
+    ///
+    pub fn two_sew(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+        let b1lhs_dart_id = self.beta::<1>(lhs_dart_id);
+        let b1rhs_dart_id = self.beta::<1>(rhs_dart_id);
+        // match (is lhs 1-free, is rhs 1-free)
+        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+            // trivial case, no update needed
+            (true, true) => {
+                self.two_link(lhs_dart_id, rhs_dart_id);
+            }
+            // update vertex associated to b1rhs/lhs
+            (true, false) => {
+                // fetch vertices ID before topology update
+                /*
+                let lhs_eid_old = self.edge_id(lhs_dart_id);
+                let rhs_eid_old = self.edge_id(b1rhs_dart_id);
+                 */
+                let lhs_vid_old = self.vertex_id(lhs_dart_id);
+                let b1rhs_vid_old = self.vertex_id(b1rhs_dart_id);
+                // update the topology
+                self.two_link(lhs_dart_id, rhs_dart_id);
+                // merge vertices & attributes from the old IDs to the new one
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices
+                    .merge(self.vertex_id(lhs_dart_id), lhs_vid_old, b1rhs_vid_old);
+                /*
+                self.attributes.merge_vertex_attributes(
+                    self.vertex_id(lhs_dart_id),
+                    lhs_vid_old,
+                    b1rhs_vid_old,
+                );
+                self.attributes.merge_edge_attributes(
+                    self.edge_id(lhs_dart_id),
+                    lhs_eid_old,
+                    rhs_eid_old,
+                );
+                 */
+            }
+            // update vertex associated to b1lhs/rhs
+            (false, true) => {
+                // fetch vertices ID before topology update
+                /*
+                let lhs_eid_old = self.edge_id(lhs_dart_id);
+                let rhs_eid_old = self.edge_id(b1rhs_dart_id);
+                 */
+                let b1lhs_vid_old = self.vertex_id(b1lhs_dart_id);
+                let rhs_vid_old = self.vertex_id(rhs_dart_id);
+                // update the topology
+                self.two_link(lhs_dart_id, rhs_dart_id);
+                // merge vertices & attributes from the old IDs to the new one
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices
+                    .merge(self.vertex_id(rhs_dart_id), b1lhs_vid_old, rhs_vid_old);
+                /*self.attributes.merge_vertex_attributes(
+                    self.vertex_id(rhs_dart_id),
+                    b1lhs_vid_old,
+                    rhs_vid_old,
+                );
+                self.attributes.merge_edge_attributes(
+                    self.edge_id(lhs_dart_id),
+                    lhs_eid_old,
+                    rhs_eid_old,
+                );
+                 */
+            }
+            // update both vertices making up the edge
+            (false, false) => {
+                // fetch vertices ID before topology update
+                /*
+                let lhs_eid_old = self.edge_id(lhs_dart_id);
+                let rhs_eid_old = self.edge_id(b1rhs_dart_id);
+                 */
+                // (lhs/b1rhs) vertex
+                let lhs_vid_old = self.vertex_id(lhs_dart_id);
+                let b1rhs_vid_old = self.vertex_id(b1rhs_dart_id);
+                // (b1lhs/rhs) vertex
+                let b1lhs_vid_old = self.vertex_id(b1lhs_dart_id);
+                let rhs_vid_old = self.vertex_id(rhs_dart_id);
+
+                // check orientation
+                // FIXME: using `get` is suboptimal because read ops imply a copy in our collections
+                // FIXME: maybe we should directly read into the storage instead of using its API
+                #[rustfmt::skip]
+                if let (
+                    Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
+                    Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
+                ) = (
+                    self.vertices.get(lhs_vid_old), self.vertices.get(b1rhs_vid_old),// (lhs/b1rhs)
+                    self.vertices.get(b1lhs_vid_old), self.vertices.get(rhs_vid_old) // (b1lhs/rhs)
+                )
+                {
+                    let lhs_vector = b1l_vertex - l_vertex;
+                    let rhs_vector = b1r_vertex - r_vertex;
+                    // dot product should be negative if the two darts have opposite direction
+                    // we could also put restriction on the angle made by the two darts to prevent
+                    // drastic deformation
+                    // FIXME: should we crash in case of inconsistent orientation?
+                    assert!(
+                        lhs_vector.dot(&rhs_vector) < T::zero(),
+                        "{}",
+                        format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
+                    );
+                };
+
+                // update the topology
+                self.two_link(lhs_dart_id, rhs_dart_id);
+                // merge vertices & attributes from the old IDs to the new one
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices
+                    .merge(self.vertex_id(lhs_dart_id), lhs_vid_old, b1rhs_vid_old);
+                self.vertices
+                    .merge(self.vertex_id(rhs_dart_id), b1lhs_vid_old, rhs_vid_old);
+                /*
+                self.attributes.merge_vertex_attributes(
+                    self.vertex_id(rhs_dart_id),
+                    b1lhs_vid_old,
+                    rhs_vid_old,
+                );
+                self.attributes.merge_edge_attributes(
+                    self.edge_id(lhs_dart_id),
+                    lhs_eid_old,
+                    rhs_eid_old,
+                );
+                 */
+            }
+        }
+    }
+
+    /// 1-unsew operation.
+    ///
+    /// This operation corresponds to *coherently separating* two darts linked via the
+    /// *β<sub>1</sub>* function. For a thorough explanation of this operation (and implied
+    /// hypothesis & consequences), refer to the [user guide][UG].
+    ///
+    /// [UG]: https://lihpc-computational-geometry.github.io/honeycomb/
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the dart to separate.
+    /// - `policy: UnsewPolicy` -- Geometrical unsewing policy to follow.
+    ///
+    /// Note that we do not need to take two darts as arguments since the second dart can be
+    /// obtained through the *β<sub>1</sub>* function. The *β<sub>0</sub>* function is also updated.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if there's a missing attribute at the splitting step. While the
+    /// implementation could fall back to a simple unlink operation, it probably should have been
+    /// called by the user, instead of unsew, in the first place.
+    pub fn one_unsew(&mut self, lhs_dart_id: DartIdentifier) {
+        let b2lhs_dart_id = self.beta::<2>(lhs_dart_id);
+        if b2lhs_dart_id == NULL_DART_ID {
+            self.one_unlink(lhs_dart_id);
+        } else {
+            // fetch IDs before topology update
+            let rhs_dart_id = self.beta::<1>(lhs_dart_id);
+            let vid_old = self.vertex_id(rhs_dart_id);
+            // update the topology
+            self.one_unlink(lhs_dart_id);
+            // split vertices & attributes from the old ID to the new ones
+            // FIXME: VertexIdentifier should be cast to DartIdentifier
+            self.vertices.split(
+                self.vertex_id(b2lhs_dart_id),
+                self.vertex_id(rhs_dart_id),
+                vid_old,
+            );
+            /*
+            self.attributes.split_vertex_attributes(
+                self.vertex_id(b2lhs_dart_id),
+                self.vertex_id(rhs_dart_id),
+                vid_old,
+            );
+             */
+        }
+    }
+
+    /// 2-unsew operation.
+    ///
+    /// This operation corresponds to *coherently separating* two darts linked via the
+    /// *β<sub>2</sub>* function. For a thorough explanation of this operation (and implied
+    /// hypothesis & consequences), refer to the [user guide][UG].
+    ///
+    /// [UG]: https://lihpc-computational-geometry.github.io/honeycomb/
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the dart to separate.
+    /// - `policy: UnsewPolicy` -- Geometrical unsewing policy to follow.
+    ///
+    /// Note that we do not need to take two darts as arguments since the second dart can be
+    /// obtained through the *β<sub>2</sub>* function.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if there's a missing attribute at the splitting step. While the
+    /// implementation could fall back to a simple unlink operation, it probably should have been
+    /// called by the user, instead of unsew, in the first place.
+    pub fn two_unsew(&mut self, lhs_dart_id: DartIdentifier) {
+        let rhs_dart_id = self.beta::<2>(lhs_dart_id);
+        let b1lhs_dart_id = self.beta::<1>(lhs_dart_id);
+        let b1rhs_dart_id = self.beta::<1>(rhs_dart_id);
+        // match (is lhs 1-free, is rhs 1-free)
+        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+            (true, true) => {
+                // fetch IDs before topology update
+                /*
+                let eid_old = self.edge_id(lhs_dart_id);
+                */
+                // update the topology
+                self.two_unlink(lhs_dart_id);
+                // split attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                /*
+                self.attributes
+                   .split_edge_attributes(lhs_dart_id, rhs_dart_id, eid_old);
+                */
+            }
+            (true, false) => {
+                // fetch IDs before topology update
+                /*
+                let eid_old = self.edge_id(lhs_dart_id);
+                */
+                let rhs_vid_old = self.vertex_id(rhs_dart_id);
+                // update the topology
+                self.two_unlink(lhs_dart_id);
+                // split vertex & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices.split(
+                    self.vertex_id(b1lhs_dart_id),
+                    self.vertex_id(rhs_dart_id),
+                    rhs_vid_old,
+                );
+                /*
+                self.attributes
+                    .split_edge_attributes(lhs_dart_id, rhs_dart_id, eid_old);
+                self.attributes.split_vertex_attributes(
+                    self.vertex_id(b1lhs_dart_id),
+                    self.vertex_id(rhs_dart_id),
+                    rhs_vid_old,
+                );
+                 */
+            }
+            (false, true) => {
+                // fetch IDs before topology update
+                /*
+                let eid_old = self.edge_id(lhs_dart_id);
+                */
+                let lhs_vid_old = self.vertex_id(lhs_dart_id);
+                // update the topology
+                self.two_unlink(lhs_dart_id);
+                // split vertex & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices.split(
+                    self.vertex_id(lhs_dart_id),
+                    self.vertex_id(b1rhs_dart_id),
+                    lhs_vid_old,
+                );
+                /*
+                self.attributes
+                    .split_edge_attributes(lhs_dart_id, rhs_dart_id, eid_old);
+                self.attributes.split_vertex_attributes(
+                    self.vertex_id(lhs_dart_id),
+                    self.vertex_id(b1rhs_dart_id),
+                    lhs_vid_old,
+                );
+                 */
+            }
+            (false, false) => {
+                // fetch IDs before topology update
+                /*
+                let eid_old = self.edge_id(lhs_dart_id);
+                */
+                let lhs_vid_old = self.vertex_id(lhs_dart_id);
+                let rhs_vid_old = self.vertex_id(rhs_dart_id);
+                // update the topology
+                self.two_unlink(lhs_dart_id);
+                // split vertices & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                self.vertices.split(
+                    self.vertex_id(b1lhs_dart_id),
+                    self.vertex_id(rhs_dart_id),
+                    rhs_vid_old,
+                );
+                self.vertices.split(
+                    self.vertex_id(lhs_dart_id),
+                    self.vertex_id(b1rhs_dart_id),
+                    lhs_vid_old,
+                );
+                /*
+                self.attributes
+                    .split_edge_attributes(lhs_dart_id, rhs_dart_id, eid_old);
+                self.attributes.split_vertex_attributes(
+                    self.vertex_id(b1lhs_dart_id),
+                    self.vertex_id(rhs_dart_id),
+                    rhs_vid_old,
+                );
+                self.attributes.split_vertex_attributes(
+                    self.vertex_id(lhs_dart_id),
+                    self.vertex_id(b1rhs_dart_id),
+                    lhs_vid_old,
+                );
+                 */
+            }
+        }
+    }
+}
+
+/// **Link and unlink operations**
+impl<T: CoordsFloat> PMap2<T> {
+    /// 1-link operation.
+    ///
+    /// This operation corresponds to linking two darts via the *β<sub>1</sub>* function. Unlike
+    /// its sewing counterpart, this method does not contain any code to update the attributes or
+    /// geometrical data of the affected cell(s). The *β<sub>0</sub>* function is also updated.
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
+    /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if `lhs_dart_id` isn't 1-free or `rhs_dart_id` isn't 0-free.
+    ///
+    pub fn one_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+        // we could technically overwrite the value, but these assertions
+        // makes it easier to assert algorithm correctness
+        assert!(self.is_i_free::<1>(lhs_dart_id));
+        assert!(self.is_i_free::<0>(rhs_dart_id));
+        // set beta_1(lhs_dart) to rhs_dart
+        self.betas[lhs_dart_id as usize][1].store(rhs_dart_id, Ordering::Relaxed);
+        // set beta_0(rhs_dart) to lhs_dart
+        self.betas[rhs_dart_id as usize][0].store(lhs_dart_id, Ordering::Relaxed);
+    }
+
+    /// 2-link operation.
+    ///
+    /// This operation corresponds to linking two darts via the *β<sub>2</sub>* function. Unlike
+    /// its sewing counterpart, this method does not contain any code to update the attributes or
+    /// geometrical data of the affected cell(s).
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the first dart to be linked.
+    /// - `rhs_dart_id: DartIdentifier` -- ID of the second dart to be linked.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if one of `lhs_dart_id` or `rhs_dart_id` isn't 2-free.
+    pub fn two_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+        // we could technically overwrite the value, but these assertions
+        // make it easier to assert algorithm correctness
+        assert!(self.is_i_free::<2>(lhs_dart_id));
+        assert!(self.is_i_free::<2>(rhs_dart_id));
+        // set beta_2(lhs_dart) to rhs_dart
+        self.betas[lhs_dart_id as usize][2].store(rhs_dart_id, Ordering::Relaxed);
+        // set beta_2(rhs_dart) to lhs_dart
+        self.betas[rhs_dart_id as usize][2].store(lhs_dart_id, Ordering::Relaxed);
+    }
+
+    /// 1-unlink operation.
+    ///
+    /// This operation corresponds to unlinking two darts that are linked via the *β<sub>1</sub>*
+    /// function. Unlike its sewing counterpart, this method does not contain any code to update
+    /// the attributes or geometrical data of the affected cell(s). The *β<sub>0</sub>* function is
+    /// also updated.
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the dart to unlink.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if one of `lhs_dart_id` is already 1-free.
+    pub fn one_unlink(&mut self, lhs_dart_id: DartIdentifier) {
+        let rhs_dart_id = self.beta::<1>(lhs_dart_id); // fetch id of beta_1(lhs_dart)
+        assert_ne!(rhs_dart_id, NULL_DART_ID);
+        // set beta_1(lhs_dart) to NullDart
+        self.betas[lhs_dart_id as usize][1].store(NULL_DART_ID, Ordering::Relaxed);
+        // set beta_0(rhs_dart) to NullDart
+        self.betas[rhs_dart_id as usize][0].store(NULL_DART_ID, Ordering::Relaxed);
+    }
+
+    /// 2-unlink operation.
+    ///
+    /// This operation corresponds to unlinking two darts that are linked via the *β<sub>2</sub>*
+    /// function. Unlike its sewing counterpart, this method does not contain any code to update
+    /// the attributes or geometrical data of the affected cell(s).
+    ///
+    /// # Arguments
+    ///
+    /// - `lhs_dart_id: DartIdentifier` -- ID of the dart to unlink.
+    ///
+    /// # Panics
+    ///
+    /// This method may panic if one of `lhs_dart_id` is already 2-free.
+    pub fn two_unlink(&mut self, lhs_dart_id: DartIdentifier) {
+        let rhs_dart_id = self.beta::<2>(lhs_dart_id); // fetch id of beta_2(lhs_dart)
+        assert_ne!(rhs_dart_id, NULL_DART_ID);
+        // set beta_2(dart) to NullDart
+        self.betas[lhs_dart_id as usize][2].store(NULL_DART_ID, Ordering::Relaxed);
+        // set beta_2(beta_2(dart)) to NullDart
+        self.betas[rhs_dart_id as usize][2].store(NULL_DART_ID, Ordering::Relaxed);
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/link_and_sew.rs
+++ b/honeycomb-core/src/pmap/dim2/link_and_sew.rs
@@ -410,7 +410,7 @@ impl<T: CoordsFloat> PMap2<T> {
     ///
     /// This method may panic if `lhs_dart_id` isn't 1-free or `rhs_dart_id` isn't 0-free.
     ///
-    pub fn one_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+    pub fn one_link(&self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
         // we could technically overwrite the value, but these assertions
         // makes it easier to assert algorithm correctness
         assert!(self.is_i_free::<1>(lhs_dart_id));
@@ -435,7 +435,7 @@ impl<T: CoordsFloat> PMap2<T> {
     /// # Panics
     ///
     /// This method may panic if one of `lhs_dart_id` or `rhs_dart_id` isn't 2-free.
-    pub fn two_link(&mut self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
+    pub fn two_link(&self, lhs_dart_id: DartIdentifier, rhs_dart_id: DartIdentifier) {
         // we could technically overwrite the value, but these assertions
         // make it easier to assert algorithm correctness
         assert!(self.is_i_free::<2>(lhs_dart_id));
@@ -460,7 +460,7 @@ impl<T: CoordsFloat> PMap2<T> {
     /// # Panics
     ///
     /// This method may panic if one of `lhs_dart_id` is already 1-free.
-    pub fn one_unlink(&mut self, lhs_dart_id: DartIdentifier) {
+    pub fn one_unlink(&self, lhs_dart_id: DartIdentifier) {
         let rhs_dart_id = self.beta::<1>(lhs_dart_id); // fetch id of beta_1(lhs_dart)
         assert_ne!(rhs_dart_id, NULL_DART_ID);
         // set beta_1(lhs_dart) to NullDart
@@ -482,7 +482,7 @@ impl<T: CoordsFloat> PMap2<T> {
     /// # Panics
     ///
     /// This method may panic if one of `lhs_dart_id` is already 2-free.
-    pub fn two_unlink(&mut self, lhs_dart_id: DartIdentifier) {
+    pub fn two_unlink(&self, lhs_dart_id: DartIdentifier) {
         let rhs_dart_id = self.beta::<2>(lhs_dart_id); // fetch id of beta_2(lhs_dart)
         assert_ne!(rhs_dart_id, NULL_DART_ID);
         // set beta_2(dart) to NullDart

--- a/honeycomb-core/src/pmap/dim2/mod.rs
+++ b/honeycomb-core/src/pmap/dim2/mod.rs
@@ -1,0 +1,1 @@
+mod structure;

--- a/honeycomb-core/src/pmap/dim2/mod.rs
+++ b/honeycomb-core/src/pmap/dim2/mod.rs
@@ -18,3 +18,6 @@ pub mod io;
 pub mod utils;
 
 const PMAP2_BETA: usize = 3;
+
+#[cfg(test)]
+mod tests;

--- a/honeycomb-core/src/pmap/dim2/mod.rs
+++ b/honeycomb-core/src/pmap/dim2/mod.rs
@@ -1,6 +1,20 @@
+//! [`PMap2`] code
+//!
+//! This module contains code for the 2D implementation of combinatorial maps: [`PMap2`].
+//!
+//! The definitions are re-exported, direct interaction with this module
+//! should be minimal, if existing at all.
+
 mod basic_ops;
+mod embed;
 mod link_and_sew;
 mod orbits;
 mod structure;
+
+#[cfg(feature = "io")]
+mod io;
+
+#[cfg(feature = "utils")]
+mod utils;
 
 const PMAP2_BETA: usize = 3;

--- a/honeycomb-core/src/pmap/dim2/mod.rs
+++ b/honeycomb-core/src/pmap/dim2/mod.rs
@@ -1,1 +1,6 @@
+mod basic_ops;
+mod link_and_sew;
+mod orbits;
 mod structure;
+
+const PMAP2_BETA: usize = 3;

--- a/honeycomb-core/src/pmap/dim2/mod.rs
+++ b/honeycomb-core/src/pmap/dim2/mod.rs
@@ -5,16 +5,16 @@
 //! The definitions are re-exported, direct interaction with this module
 //! should be minimal, if existing at all.
 
-mod basic_ops;
-mod embed;
-mod link_and_sew;
-mod orbits;
-mod structure;
+pub mod basic_ops;
+pub mod embed;
+pub mod link_and_sew;
+pub mod orbits;
+pub mod structure;
 
 #[cfg(feature = "io")]
-mod io;
+pub mod io;
 
 #[cfg(feature = "utils")]
-mod utils;
+pub mod utils;
 
 const PMAP2_BETA: usize = 3;

--- a/honeycomb-core/src/pmap/dim2/orbits.rs
+++ b/honeycomb-core/src/pmap/dim2/orbits.rs
@@ -11,6 +11,7 @@ use crate::prelude::{DartIdentifier, NULL_DART_ID};
 use crate::cmap::OrbitPolicy;
 use crate::pmap::dim2::structure::PMap2;
 use std::collections::{BTreeSet, VecDeque};
+
 // ------ CONTENT
 
 /// Generic 2D orbit implementation

--- a/honeycomb-core/src/pmap/dim2/orbits.rs
+++ b/honeycomb-core/src/pmap/dim2/orbits.rs
@@ -1,0 +1,249 @@
+//! Orbit implementation
+//!
+//! This module contains all code used to model orbits, a notion defined
+//! along the structure of combinatorial maps.
+
+// ------ IMPORTS
+
+use crate::geometry::CoordsFloat;
+use crate::prelude::{DartIdentifier, NULL_DART_ID};
+
+use crate::cmap::OrbitPolicy;
+use crate::pmap::dim2::structure::PMap2;
+use std::collections::{BTreeSet, VecDeque};
+// ------ CONTENT
+
+/// Generic 2D orbit implementation
+///
+/// This structure only contains meta-data about the orbit in its initial state. All the darts
+/// making up the orbit are computed when using the methods that come with the [Iterator]
+/// implementation.
+///
+/// It is not currently possible to iterate over references, the orbit has to be consumed for its
+/// result to be used. This is most likely the best behavior since orbits should be consumed upon
+/// traversal to avoid inconsistencies created by a later mutable operation on the map.
+///
+/// # Generics
+///
+/// - `'a` -- Lifetime of the reference to the map
+/// - `T: CoordsFloat` -- Generic parameter of the referenced map.
+///
+/// # The search algorithm
+///
+/// The search algorithm used to establish the list of dart included in the orbit is a
+/// [Breadth-First Search algorithm][WIKIBFS]. This means that:
+///
+/// - we look at the images of the current dart through all beta functions,
+///   adding those to a queue, before moving on to the next dart.
+/// - we apply the beta functions in their specified order (in the case of a
+///   custom [`OrbitPolicy`]); This guarantees a consistent and predictable result.
+///
+/// Both of these points allow orbitd to be used for sewing operations at the cost of some
+/// performance (non-trivial parallelization & sequential consistency requirements).
+///
+/// [WIKIBFS]: https://en.wikipedia.org/wiki/Breadth-first_search
+///
+/// # Example
+///
+/// See [`CMap2`] example.
+///
+pub struct POrbit2<'a, T: CoordsFloat> {
+    /// Reference to the map containing the beta functions used in the BFS.
+    map_handle: &'a PMap2<T>,
+    /// Policy used by the orbit for the BFS. It can be predetermined or custom.
+    orbit_policy: OrbitPolicy,
+    /// Set used to identify which dart is marked during the BFS.
+    marked: BTreeSet<DartIdentifier>,
+    /// Queue used to store which dart must be visited next during the BFS.
+    pending: VecDeque<DartIdentifier>,
+}
+
+impl<'a, T: CoordsFloat> POrbit2<'a, T> {
+    /// Constructor
+    ///
+    /// # Arguments
+    ///
+    /// - `map_handle: &'a CMap2<T>` -- Reference to the map containing the beta
+    ///   functions used in the BFS.
+    /// - `orbit_policy: OrbitPolicy<'a>` -- Policy used by the orbit for the BFS.
+    /// - `dart: DartIdentifier` -- Dart of which the structure will compute the orbit.
+    ///
+    /// # Return
+    ///
+    /// Return an [Orbit2] structure that can be iterated upon to retrieve the orbit's darts.
+    ///
+    /// # Panics
+    ///
+    /// The method may panic if no beta index is passed along the custom policy. Additionally,
+    /// if an invalid beta index is passed through the custom policy (e.g. `3` for a 2D map),
+    /// a panic will occur on iteration
+    ///
+    /// # Example
+    ///
+    /// See [`CMap2`] example.
+    ///
+    #[must_use = "orbits are lazy and do nothing unless consumed"]
+    pub fn new(map_handle: &'a PMap2<T>, orbit_policy: OrbitPolicy, dart: DartIdentifier) -> Self {
+        let mut marked = BTreeSet::<DartIdentifier>::new();
+        marked.insert(NULL_DART_ID); // we don't want to include the null dart in the orbit
+        marked.insert(dart); // we're starting here, so we mark it beforehand
+        let pending = VecDeque::from([dart]);
+        /*
+        if let OrbitPolicy::Custom(slice) = orbit_policy {
+            assert!(!slice.len().is_zero());
+        }
+        */
+        Self {
+            map_handle,
+            orbit_policy,
+            marked,
+            pending,
+        }
+    }
+}
+
+impl<'a, T: CoordsFloat> Iterator for POrbit2<'a, T> {
+    type Item = DartIdentifier;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(d) = self.pending.pop_front() {
+            match self.orbit_policy {
+                OrbitPolicy::Vertex => {
+                    // THIS CODE IS ONLY VALID IN 2D
+
+                    let image1 = self.map_handle.beta::<1>(self.map_handle.beta::<2>(d));
+                    if self.marked.insert(image1) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image1);
+                    }
+                    let image2 = self.map_handle.beta::<2>(self.map_handle.beta::<0>(d));
+                    if self.marked.insert(image2) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image2);
+                    }
+                }
+                OrbitPolicy::Edge => {
+                    // THIS CODE IS ONLY VALID IN 2D
+                    let image = self.map_handle.beta::<2>(d);
+                    if self.marked.insert(image) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image);
+                    }
+                }
+                OrbitPolicy::Face => {
+                    // THIS CODE IS ONLY VALID IN 2D
+                    // WE ASSUME THAT THE FACE IS COMPLETE
+                    let image = self.map_handle.beta::<1>(d);
+                    if self.marked.insert(image) {
+                        // if true, we did not see this dart yet
+                        // i.e. we need to visit it later
+                        self.pending.push_back(image);
+                    }
+                }
+                OrbitPolicy::Custom(beta_slice) => {
+                    for beta_id in beta_slice {
+                        let image = self.map_handle.beta_runtime(*beta_id, d);
+                        if self.marked.insert(image) {
+                            // if true, we did not see this dart yet
+                            // i.e. we need to visit it later
+                            self.pending.push_back(image);
+                        }
+                    }
+                }
+            }
+            Some(d)
+        } else {
+            None
+        }
+    }
+}
+
+// ------ TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn simple_map() -> PMap2<f64> {
+        let mut map: PMap2<f64> = PMap2::new(6);
+        map.one_link(1, 2);
+        map.one_link(2, 3);
+        map.one_link(3, 1);
+        map.one_link(4, 5);
+        map.one_link(5, 6);
+        map.one_link(6, 4);
+        map.two_link(2, 4);
+        /*
+        assert!(map.replace_vertex(1, (0.0, 0.0)).is_none());
+        assert!(map.replace_vertex(2, (1.0, 0.0)).is_none());
+        assert!(map.replace_vertex(6, (1.0, 1.0)).is_none());
+        assert!(map.replace_vertex(3, (0.0, 1.0)).is_none());
+
+         */
+        map
+    }
+
+    #[test]
+    fn full_map_from_orbit() {
+        let map = simple_map();
+        let orbit = POrbit2::new(&map, OrbitPolicy::Custom(&[1, 2]), 3);
+        let darts: Vec<DartIdentifier> = orbit.collect();
+        assert_eq!(darts.len(), 6);
+        // because the algorithm is consistent, we can predict the exact layout
+        assert_eq!(&darts, &[3, 1, 2, 4, 5, 6]);
+    }
+
+    #[test]
+    fn face_from_orbit() {
+        let map = simple_map();
+        let face_orbit = POrbit2::new(&map, OrbitPolicy::Face, 1);
+        let darts: Vec<DartIdentifier> = face_orbit.collect();
+        assert_eq!(darts.len(), 3);
+        assert_eq!(&darts, &[1, 2, 3]);
+        let other_face_orbit = POrbit2::new(&map, OrbitPolicy::Custom(&[1]), 5);
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.collect();
+        assert_eq!(other_darts.len(), 3);
+        assert_eq!(&other_darts, &[5, 6, 4]);
+    }
+
+    #[test]
+    fn edge_from_orbit() {
+        let map = simple_map();
+        let face_orbit = POrbit2::new(&map, OrbitPolicy::Edge, 1);
+        let darts: Vec<DartIdentifier> = face_orbit.collect();
+        assert_eq!(darts.len(), 1);
+        assert_eq!(&darts, &[1]); // dart 1 is on the boundary
+        let other_face_orbit = POrbit2::new(&map, OrbitPolicy::Custom(&[2]), 4);
+        let other_darts: Vec<DartIdentifier> = other_face_orbit.collect();
+        assert_eq!(other_darts.len(), 2);
+        assert_eq!(&other_darts, &[4, 2]);
+    }
+
+    #[test]
+    fn vertex_from_orbit() {
+        let map = simple_map();
+        let orbit = POrbit2::new(&map, OrbitPolicy::Vertex, 4);
+        let darts: Vec<DartIdentifier> = orbit.collect();
+        // note that this one fails if we start at 3, because the vertex is not complete
+        assert_eq!(darts.len(), 2);
+        assert_eq!(&darts, &[4, 3]);
+    }
+
+    #[test]
+    fn empty_orbit_policy() {
+        let map = simple_map();
+        let darts: Vec<DartIdentifier> = POrbit2::new(&map, OrbitPolicy::Custom(&[]), 3).collect();
+        assert_eq!(&darts, &[3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: i < 3")]
+    fn invalid_orbit_policy() {
+        let map = simple_map();
+        let orbit = POrbit2::new(&map, OrbitPolicy::Custom(&[6]), 3);
+        let _: Vec<DartIdentifier> = orbit.collect();
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/orbits.rs
+++ b/honeycomb-core/src/pmap/dim2/orbits.rs
@@ -176,13 +176,12 @@ mod tests {
         map.one_link(5, 6);
         map.one_link(6, 4);
         map.two_link(2, 4);
-        /*
+
         assert!(map.replace_vertex(1, (0.0, 0.0)).is_none());
         assert!(map.replace_vertex(2, (1.0, 0.0)).is_none());
         assert!(map.replace_vertex(6, (1.0, 1.0)).is_none());
         assert!(map.replace_vertex(3, (0.0, 1.0)).is_none());
 
-         */
         map
     }
 

--- a/honeycomb-core/src/pmap/dim2/structure.rs
+++ b/honeycomb-core/src/pmap/dim2/structure.rs
@@ -67,14 +67,14 @@ impl<T: CoordsFloat> From<CMap2<T>> for PMap2<T> {
             vertices,
             unused_darts,
             betas,
-            n_darts,
+            n_darts, // THIS ALREADY COUNTS THE NULL DART; NO INCLUSIVE RANGE NEEDED LATER
         } = cmap;
         Self {
             vertices,
-            unused_darts: (0..=n_darts as DartIdentifier) // n_darts + 1
+            unused_darts: (0..n_darts as DartIdentifier)
                 .map(|id| AtomicBool::new(unused_darts.contains(&id)))
                 .collect(),
-            betas: (0..=n_darts) // n_darts + 1
+            betas: (0..n_darts)
                 .map(|i| {
                     let [b0, b1, b2] = betas[i];
                     [AtomicU32::new(b0), AtomicU32::new(b1), AtomicU32::new(b2)]

--- a/honeycomb-core/src/pmap/dim2/structure.rs
+++ b/honeycomb-core/src/pmap/dim2/structure.rs
@@ -5,7 +5,20 @@ use crate::pmap::common::PDartIdentifier;
 use crate::pmap::dim2::PMAP2_BETA;
 use std::sync::atomic::{AtomicBool, AtomicU32};
 
-// #[cfg_attr(feature = "utils", derive(Clone))]
+/// Main map object.
+///
+/// Structure used to model 2D combinatorial map. This is a parallel-friendly variant of [`CMap2`].
+///
+/// **Note that Undefined Behavior resulting from different execution path are currently not
+/// accounted for.**
+///
+/// # Generics
+///
+/// - `T: CoordsFloat` -- Generic type for coordinates representation.
+///
+/// # Example
+///
+/// TODO
 pub struct PMap2<T: CoordsFloat> {
     // /// List of vertices making up the represented mesh
     // pub(super) attributes: AttrStorageManager,

--- a/honeycomb-core/src/pmap/dim2/structure.rs
+++ b/honeycomb-core/src/pmap/dim2/structure.rs
@@ -1,10 +1,8 @@
 use crate::attributes::{AttrSparseVec, UnknownAttributeStorage};
 use crate::geometry::{CoordsFloat, Vertex2};
 use crate::pmap::common::PDartIdentifier;
-use std::collections::BTreeSet;
-use std::sync::atomic::AtomicU32;
-
-const PMAP2_BETA: usize = 3;
+use crate::pmap::dim2::PMAP2_BETA;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 
 // #[cfg_attr(feature = "utils", derive(Clone))]
 pub struct PMap2<T: CoordsFloat> {
@@ -14,7 +12,7 @@ pub struct PMap2<T: CoordsFloat> {
     pub(super) vertices: AttrSparseVec<Vertex2<T>>,
     /// List of free darts identifiers, i.e. empty spots
     /// in the current dart list
-    pub(super) unused_darts: BTreeSet<PDartIdentifier>,
+    pub(super) unused_darts: Vec<AtomicBool>,
     /// Array representation of the beta functions
     pub(super) betas: Vec<[PDartIdentifier; PMAP2_BETA]>,
     /// Current number of darts
@@ -44,7 +42,9 @@ impl<T: CoordsFloat> PMap2<T> {
         Self {
             // attributes: AttrStorageManager::default(),
             vertices: AttrSparseVec::new(n_darts + 1),
-            unused_darts: BTreeSet::new(),
+            unused_darts: (0..=n_darts) // n_darts + 1
+                .map(|_| AtomicBool::new(false))
+                .collect(),
             betas: (0..=n_darts) // n_darts + 1
                 .map(|_| {
                     [

--- a/honeycomb-core/src/pmap/dim2/structure.rs
+++ b/honeycomb-core/src/pmap/dim2/structure.rs
@@ -1,0 +1,60 @@
+use crate::attributes::{AttrSparseVec, UnknownAttributeStorage};
+use crate::geometry::{CoordsFloat, Vertex2};
+use crate::pmap::common::PDartIdentifier;
+use std::collections::BTreeSet;
+use std::sync::atomic::AtomicU32;
+
+const PMAP2_BETA: usize = 3;
+
+// #[cfg_attr(feature = "utils", derive(Clone))]
+pub struct PMap2<T: CoordsFloat> {
+    // /// List of vertices making up the represented mesh
+    // pub(super) attributes: AttrStorageManager,
+    /// List of vertices making up the represented mesh
+    pub(super) vertices: AttrSparseVec<Vertex2<T>>,
+    /// List of free darts identifiers, i.e. empty spots
+    /// in the current dart list
+    pub(super) unused_darts: BTreeSet<PDartIdentifier>,
+    /// Array representation of the beta functions
+    pub(super) betas: Vec<[PDartIdentifier; PMAP2_BETA]>,
+    /// Current number of darts
+    pub(super) n_darts: usize,
+}
+
+#[doc(hidden)]
+/// **Constructor convenience implementations**
+impl<T: CoordsFloat> PMap2<T> {
+    /// Creates a new 2D combinatorial map.
+    ///
+    /// # Arguments
+    ///
+    /// - `n_darts: usize` -- Number of darts composing the new combinatorial map.
+    ///
+    /// # Return
+    ///
+    /// Returns a combinatorial map containing `n_darts + 1` darts, the amount of darts wanted plus
+    /// the null dart (at index `NULL_DART_ID` i.e. `0`).
+    ///
+    /// # Example
+    ///
+    /// See [`PMap2`] example.
+    #[allow(unused)]
+    #[must_use = "constructed object is not used, consider removing this function call"]
+    pub(crate) fn new(n_darts: usize) -> Self {
+        Self {
+            // attributes: AttrStorageManager::default(),
+            vertices: AttrSparseVec::new(n_darts + 1),
+            unused_darts: BTreeSet::new(),
+            betas: (0..=n_darts) // n_darts + 1
+                .map(|_| {
+                    [
+                        AtomicU32::default(),
+                        AtomicU32::default(),
+                        AtomicU32::default(),
+                    ]
+                })
+                .collect(),
+            n_darts: n_darts + 1,
+        }
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/structure.rs
+++ b/honeycomb-core/src/pmap/dim2/structure.rs
@@ -1,4 +1,5 @@
 use crate::attributes::{AttrSparseVec, UnknownAttributeStorage};
+use crate::cmap::{CMap2, DartIdentifier};
 use crate::geometry::{CoordsFloat, Vertex2};
 use crate::pmap::common::PDartIdentifier;
 use crate::pmap::dim2::PMAP2_BETA;
@@ -55,6 +56,31 @@ impl<T: CoordsFloat> PMap2<T> {
                 })
                 .collect(),
             n_darts: n_darts + 1,
+        }
+    }
+}
+
+impl<T: CoordsFloat> From<CMap2<T>> for PMap2<T> {
+    fn from(cmap: CMap2<T>) -> Self {
+        let CMap2 {
+            attributes: _, // ignore attributes for now
+            vertices,
+            unused_darts,
+            betas,
+            n_darts,
+        } = cmap;
+        Self {
+            vertices,
+            unused_darts: (0..=n_darts as DartIdentifier) // n_darts + 1
+                .map(|id| AtomicBool::new(unused_darts.contains(&id)))
+                .collect(),
+            betas: (0..=n_darts) // n_darts + 1
+                .map(|i| {
+                    let [b0, b1, b2] = betas[i];
+                    [AtomicU32::new(b0), AtomicU32::new(b1), AtomicU32::new(b2)]
+                })
+                .collect(),
+            n_darts,
         }
     }
 }

--- a/honeycomb-core/src/pmap/dim2/tests.rs
+++ b/honeycomb-core/src/pmap/dim2/tests.rs
@@ -1,0 +1,327 @@
+// ------ IMPORTS
+
+use crate::pmap::dim2::orbits::POrbit2;
+use crate::pmap::PMap2;
+use crate::prelude::{CMapBuilder, OrbitPolicy, Vertex2};
+
+// ------ CONTENT
+
+// --- GENERAL
+
+#[test]
+fn example_test() {
+    // build a triangle
+    let mut map: PMap2<f64> = CMapBuilder::default().n_darts(3).build().unwrap().into();
+    map.one_link(1, 2);
+    map.one_link(2, 3);
+    map.one_link(3, 1);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (1.0, 0.0));
+    map.insert_vertex(3, (0.0, 1.0));
+
+    // checks
+    let faces = map.fetch_faces();
+    assert_eq!(faces.identifiers.len(), 1);
+    assert_eq!(faces.identifiers[0], 1);
+    let mut face = POrbit2::new(&map, OrbitPolicy::Face, 1);
+    assert_eq!(face.next(), Some(1));
+    assert_eq!(face.next(), Some(2));
+    assert_eq!(face.next(), Some(3));
+    assert_eq!(face.next(), None);
+
+    // build a second triangle
+    map.add_free_darts(3);
+    map.one_link(4, 5);
+    map.one_link(5, 6);
+    map.one_link(6, 4);
+    map.insert_vertex(4, (0.0, 2.0));
+    map.insert_vertex(5, (2.0, 0.0));
+    map.insert_vertex(6, (1.0, 1.0));
+
+    // checks
+    let faces = map.fetch_faces();
+    assert_eq!(&faces.identifiers, &[1, 4]);
+    let mut face = POrbit2::new(&map, OrbitPolicy::Face, 4);
+    assert_eq!(face.next(), Some(4));
+    assert_eq!(face.next(), Some(5));
+    assert_eq!(face.next(), Some(6));
+    assert_eq!(face.next(), None);
+
+    // sew both triangles
+    map.two_sew(2, 4);
+
+    // checks
+    assert_eq!(map.beta::<2>(2), 4);
+    assert_eq!(map.vertex_id(2), 2);
+    assert_eq!(map.vertex_id(5), 2);
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.5, 0.0)));
+    assert_eq!(map.vertex_id(3), 3);
+    assert_eq!(map.vertex_id(4), 3);
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.5)));
+    let edges = map.fetch_edges();
+    assert_eq!(&edges.identifiers, &[1, 2, 3, 5, 6]);
+
+    // adjust bottom-right & top-left vertex position
+    assert_eq!(
+        map.replace_vertex(2, Vertex2::from((1.0, 0.0))),
+        Some(Vertex2::from((1.5, 0.0)))
+    );
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.0, 0.0)));
+    assert_eq!(
+        map.replace_vertex(3, Vertex2::from((0.0, 1.0))),
+        Some(Vertex2::from((0.0, 1.5)))
+    );
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
+
+    // separate the diagonal from the rest
+    map.one_unsew(1);
+    map.one_unsew(2);
+    map.one_unsew(6);
+    map.one_unsew(4);
+    // break up & remove the diagonal
+    map.two_unsew(2); // this makes dart 2 and 4 free
+    map.remove_free_dart(2);
+    map.remove_free_dart(4);
+    // sew the square back up
+    map.one_sew(1, 5);
+    map.one_sew(6, 3);
+
+    // i-cells
+    let faces = map.fetch_faces();
+    assert_eq!(&faces.identifiers, &[1]);
+    let edges = map.fetch_edges();
+    assert_eq!(&edges.identifiers, &[1, 3, 5, 6]);
+    let vertices = map.fetch_vertices();
+    assert_eq!(&vertices.identifiers, &[1, 3, 5, 6]);
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(5).unwrap(), Vertex2::from((1.0, 0.0)));
+    assert_eq!(map.vertex(6).unwrap(), Vertex2::from((1.0, 1.0)));
+    assert_eq!(map.vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
+    // darts
+    assert_eq!(map.n_unused_darts(), 2); // there are unused darts since we removed the diagonal
+    assert_eq!(map.beta_runtime(1, 1), 5);
+    assert_eq!(map.beta_runtime(1, 5), 6);
+    assert_eq!(map.beta_runtime(1, 6), 3);
+    assert_eq!(map.beta_runtime(1, 3), 1);
+}
+
+#[test]
+#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
+fn remove_vertex_twice() {
+    // in its default state, all darts/vertices of a map are considered to be used
+    let mut map: PMap2<f64> = PMap2::new(4);
+    // set vertex 1 as unused
+    map.remove_vertex(1).unwrap();
+    // set vertex 1 as unused, again
+    map.remove_vertex(1).unwrap(); // this should panic
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: ")]
+fn remove_dart_twice() {
+    // in its default state, all darts/vertices of a map are considered to be used
+    // darts are also free
+    let mut map: PMap2<f64> = PMap2::new(4);
+    // set dart 1 as unused
+    map.remove_free_dart(1);
+    // set dart 1 as unused, again
+    map.remove_free_dart(1); // this should panic
+}
+
+// --- (UN)SEW
+
+#[test]
+fn two_sew_complete() {
+    let mut map: PMap2<f64> = PMap2::new(4);
+    map.one_link(1, 2);
+    map.one_link(3, 4);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0));
+    map.insert_vertex(3, (1.0, 1.0));
+    map.insert_vertex(4, (1.0, 0.0));
+    map.two_sew(1, 3);
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.5, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
+}
+
+#[test]
+fn two_sew_incomplete() {
+    let mut map: PMap2<f64> = PMap2::new(3);
+    map.one_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0));
+    map.insert_vertex(3, (1.0, 1.0));
+    map.two_sew(1, 3);
+    // missing beta1 image for dart 3
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
+    map.two_unsew(1);
+    assert_eq!(map.add_free_darts(1), 4);
+    map.one_link(3, 4);
+    map.two_sew(1, 3);
+    // missing vertex for dart 4
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
+}
+
+#[test]
+fn two_sew_no_b1() {
+    let mut map: PMap2<f64> = PMap2::new(2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (1.0, 1.0));
+    map.two_sew(1, 2);
+    assert_eq!(map.vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((1.0, 1.0)));
+}
+
+#[test]
+// #[should_panic] // FIXME: find a way to test what's printed?
+fn two_sew_no_attributes() {
+    let mut map: PMap2<f64> = PMap2::new(2);
+    map.two_sew(1, 2); // should panic
+}
+
+#[test]
+// #[should_panic] // FIXME: find a way to test what's printed?
+fn two_sew_no_attributes_bis() {
+    let mut map: PMap2<f64> = PMap2::new(4);
+    map.one_link(1, 2);
+    map.one_link(3, 4);
+    map.two_sew(1, 3); // panic
+}
+
+#[test]
+#[should_panic(expected = "Dart 1 and 3 do not have consistent orientation for 2-sewing")]
+fn two_sew_bad_orientation() {
+    let mut map: PMap2<f64> = PMap2::new(4);
+    map.one_link(1, 2);
+    map.one_link(3, 4);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0)); // 1->2 goes up
+    map.insert_vertex(3, (1.0, 0.0));
+    map.insert_vertex(4, (1.0, 1.0)); // 3->4 also goes up
+    map.two_sew(1, 3); // panic
+}
+
+#[test]
+fn one_sew_complete() {
+    let mut map: PMap2<f64> = PMap2::new(3);
+    map.two_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0));
+    map.insert_vertex(3, (0.0, 2.0));
+    map.one_sew(1, 3);
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.5)));
+}
+
+#[test]
+fn one_sew_incomplete_attributes() {
+    let mut map: PMap2<f64> = PMap2::new(3);
+    map.two_link(1, 2);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0));
+    map.one_sew(1, 3);
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
+}
+
+#[test]
+fn one_sew_incomplete_beta() {
+    let mut map: PMap2<f64> = PMap2::new(3);
+    map.insert_vertex(1, (0.0, 0.0));
+    map.insert_vertex(2, (0.0, 1.0));
+    map.one_sew(1, 2);
+    assert_eq!(map.vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
+}
+#[test]
+// #[should_panic] // FIXME: find a way to test what's printed?
+fn one_sew_no_attributes() {
+    let mut map: PMap2<f64> = PMap2::new(2);
+    map.one_sew(1, 2); // should panic
+}
+
+#[test]
+// #[should_panic] // FIXME: find a way to test what's printed?
+fn one_sew_no_attributes_bis() {
+    let mut map: PMap2<f64> = PMap2::new(3);
+    map.two_link(1, 2);
+    map.one_sew(1, 3); // panic
+}
+
+// --- IO
+
+#[cfg(feature = "io")]
+#[test]
+fn io_write() {
+    // build a map looking like this:
+    //      15
+    //     / \
+    //    /   \
+    //   /     \
+    //  16      14
+    //  |       |
+    //  4---3---7
+    //  |   |  /|
+    //  |   | / |
+    //  |   |/  |
+    //  1---2---6
+    let mut cmap: PMap2<f32> = PMap2::new(16);
+    // bottom left square
+    cmap.one_link(1, 2);
+    cmap.one_link(2, 3);
+    cmap.one_link(3, 4);
+    cmap.one_link(4, 1);
+    // bottom right triangles
+    cmap.one_link(5, 6);
+    cmap.one_link(6, 7);
+    cmap.one_link(7, 5);
+    cmap.two_link(7, 8);
+    cmap.one_link(8, 9);
+    cmap.one_link(9, 10);
+    cmap.one_link(10, 8);
+    // top polygon
+    cmap.one_link(11, 12);
+    cmap.one_link(12, 13);
+    cmap.one_link(13, 14);
+    cmap.one_link(14, 15);
+    cmap.one_link(15, 16);
+    cmap.one_link(16, 11);
+    // assemble
+    cmap.two_link(2, 10);
+    cmap.two_link(3, 11);
+    cmap.two_link(9, 12);
+
+    // insert vertices
+    cmap.insert_vertex(1, (0.0, 0.0));
+    cmap.insert_vertex(2, (1.0, 0.0));
+    cmap.insert_vertex(6, (2.0, 0.0));
+    cmap.insert_vertex(4, (0.0, 1.0));
+    cmap.insert_vertex(3, (1.0, 1.0));
+    cmap.insert_vertex(7, (2.0, 1.0));
+    cmap.insert_vertex(16, (0.0, 2.0));
+    cmap.insert_vertex(15, (1.0, 3.0));
+    cmap.insert_vertex(14, (2.0, 2.0));
+
+    // generate VTK data
+    let mut res = String::new();
+    cmap.to_vtk_ascii(&mut res);
+    println!("{res}");
+
+    // check result
+    assert!(res.contains("POINTS 9 float"));
+    assert!(res.contains("CELLS 12 44"));
+    assert!(res.contains("CELL_TYPES 12"));
+    // faces
+    assert!(res.contains("4 0 1 2 3"));
+    assert!(res.contains("3 1 4 5"));
+    assert!(res.contains("4 0 1 2 3"));
+    assert!(res.contains("4 0 1 2 3"));
+    // edges
+    assert!(res.contains("2 0 1"));
+    assert!(res.contains("2 3 0"));
+    assert!(res.contains("2 1 4"));
+    assert!(res.contains("2 4 5"));
+    assert!(res.contains("2 5 6"));
+    assert!(res.contains("2 6 7"));
+    assert!(res.contains("2 7 8"));
+    assert!(res.contains("2 8 3"));
+}

--- a/honeycomb-core/src/pmap/dim2/utils.rs
+++ b/honeycomb-core/src/pmap/dim2/utils.rs
@@ -1,0 +1,59 @@
+//! [`PMap2`] utilities implementations
+//!
+//! <div class="warning">
+//!
+//! **This code is only compiled if the `utils` feature is enabled.**
+//!
+//! </div>
+//!
+//! This module contains utility code for the [`PMap2`] structure that is gated behind the `utils`
+//! feature.
+
+// ------ IMPORTS
+
+use super::PMAP2_BETA;
+use crate::geometry::CoordsFloat;
+use crate::pmap::common::PDartIdentifier;
+use crate::pmap::dim2::structure::PMap2;
+use crate::prelude::DartIdentifier;
+use std::sync::atomic::Ordering;
+
+// ------ CONTENT
+
+/// **Utilities**
+impl<T: CoordsFloat> PMap2<T> {
+    /// Set the value of the specified beta function of a dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- ID of the dart of interest.
+    /// - `val: DartIdentifier` -- Value of the image of `dart_id` through the beta `I` function.
+    ///
+    /// ## Generic
+    ///
+    /// - `const I: u8` -- Beta function to edit.
+    ///
+    pub fn set_beta<const I: u8>(&mut self, dart_id: DartIdentifier, val: DartIdentifier) {
+        self.betas[dart_id as usize][I as usize].store(val, Ordering::Relaxed);
+    }
+
+    /// Set the values of the beta functions of a dart.
+    ///
+    /// # Arguments
+    ///
+    /// - `dart_id: DartIdentifier` -- ID of the dart of interest.
+    /// - `[b0, b1, b2]: [DartIdentifier; 3]` -- Value of the images as
+    ///   *[β<sub>0</sub>(dart), β<sub>1</sub>(dart), β<sub>2</sub>(dart)]*
+    ///
+    pub fn set_betas(
+        &mut self,
+        dart_id: DartIdentifier,
+        [b0, b1, b2]: [DartIdentifier; PMAP2_BETA],
+    ) {
+        self.betas[dart_id as usize] = [
+            PDartIdentifier::new(b0),
+            PDartIdentifier::new(b1),
+            PDartIdentifier::new(b2),
+        ];
+    }
+}

--- a/honeycomb-core/src/pmap/dim2/utils.rs
+++ b/honeycomb-core/src/pmap/dim2/utils.rs
@@ -13,7 +13,6 @@
 
 use super::PMAP2_BETA;
 use crate::geometry::CoordsFloat;
-use crate::pmap::common::PDartIdentifier;
 use crate::pmap::dim2::structure::PMap2;
 use crate::prelude::DartIdentifier;
 use std::sync::atomic::Ordering;
@@ -33,7 +32,7 @@ impl<T: CoordsFloat> PMap2<T> {
     ///
     /// - `const I: u8` -- Beta function to edit.
     ///
-    pub fn set_beta<const I: u8>(&mut self, dart_id: DartIdentifier, val: DartIdentifier) {
+    pub fn set_beta<const I: u8>(&self, dart_id: DartIdentifier, val: DartIdentifier) {
         self.betas[dart_id as usize][I as usize].store(val, Ordering::Relaxed);
     }
 
@@ -45,15 +44,10 @@ impl<T: CoordsFloat> PMap2<T> {
     /// - `[b0, b1, b2]: [DartIdentifier; 3]` -- Value of the images as
     ///   *[β<sub>0</sub>(dart), β<sub>1</sub>(dart), β<sub>2</sub>(dart)]*
     ///
-    pub fn set_betas(
-        &mut self,
-        dart_id: DartIdentifier,
-        [b0, b1, b2]: [DartIdentifier; PMAP2_BETA],
-    ) {
-        self.betas[dart_id as usize] = [
-            PDartIdentifier::new(b0),
-            PDartIdentifier::new(b1),
-            PDartIdentifier::new(b2),
-        ];
+    pub fn set_betas(&self, dart_id: DartIdentifier, [b0, b1, b2]: [DartIdentifier; PMAP2_BETA]) {
+        // using individual stores to keep a non-mutable sig
+        self.betas[dart_id as usize][0].store(b0, Ordering::Relaxed);
+        self.betas[dart_id as usize][1].store(b1, Ordering::Relaxed);
+        self.betas[dart_id as usize][2].store(b2, Ordering::Relaxed);
     }
 }

--- a/honeycomb-core/src/pmap/mod.rs
+++ b/honeycomb-core/src/pmap/mod.rs
@@ -2,3 +2,5 @@
 
 mod common;
 mod dim2;
+
+pub use dim2::structure::PMap2;

--- a/honeycomb-core/src/pmap/mod.rs
+++ b/honeycomb-core/src/pmap/mod.rs
@@ -3,4 +3,5 @@
 mod common;
 mod dim2;
 
-pub use dim2::structure::PMap2;
+pub use common::{is_null, PDartIdentifier};
+pub use dim2::{orbits::POrbit2, structure::PMap2};

--- a/honeycomb-core/src/pmap/mod.rs
+++ b/honeycomb-core/src/pmap/mod.rs
@@ -1,0 +1,4 @@
+//! parallel-friendly combinatorial maps implementations
+
+mod common;
+mod dim2;


### PR DESCRIPTION
Implemented:
- vertex / sews are unchanged
- orbits (as `POrbit2`), this should eventualy be common code with `CMap2`
- the rest is implemented using new, non-mutable internals
- a `From<CMap2>` impl for `PMap2`

Skipped:
- generic attributes
- "side" structures such as the builder

part of #197 

## Necessary follow-up

- [x] Needs documentation
- [x] Other:
    - figure out vertex management
    - extract common code between the sequential & parallel impls
    - cleanup
