### PR TITLE
feat(core): implement parallel variants of attribute storage traits & structs

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -293,6 +293,21 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
 
 // --- parallel items
 
+/// Custom storage structure for attributes
+///
+/// This structured is used to store user-defined attributes using a vector of `Option<T>` items.
+/// This means that valid attributes value may be separated by an arbitrary number of `None`.
+///
+/// Synchronization is implemented using `RwLock`s over items in the storage. All methods are
+/// blocking implemented are blocking.
+///
+/// # Generics
+///
+/// - `T: AttributeBind + AttributeUpdate` -- Type of the stored attributes.
+///
+/// # Example
+///
+/// **This struct is not meant to be used directly**, but used along the [`AttributeBind`] trait.
 #[derive(Debug)]
 pub struct PAttrSparseVec<A: AttributeBind + AttributeUpdate> {
     /// Inner storage.

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -294,12 +294,12 @@ impl<T: AttributeBind + AttributeUpdate + Clone> AttrCompactVec<T> {
 // --- parallel items
 
 #[derive(Debug)]
-pub struct ParSparseVec<A: AttributeBind + AttributeUpdate> {
+pub struct PAttrSparseVec<A: AttributeBind + AttributeUpdate> {
     /// Inner storage.
     data: Vec<RwLock<Option<A>>>,
 }
 
-impl<A: AttributeBind + AttributeUpdate + Copy> ParUnknownAttributeStorage for ParSparseVec<A> {
+impl<A: AttributeBind + AttributeUpdate + Copy> ParUnknownAttributeStorage for PAttrSparseVec<A> {
     fn new(length: usize) -> Self
     where
         Self: Sized,
@@ -374,7 +374,7 @@ impl<A: AttributeBind + AttributeUpdate + Copy> ParUnknownAttributeStorage for P
     }
 }
 
-impl<A: AttributeBind + AttributeUpdate + Copy> ParAttributeStorage<A> for ParSparseVec<A> {
+impl<A: AttributeBind + AttributeUpdate + Copy> ParAttributeStorage<A> for PAttrSparseVec<A> {
     fn set(&self, id: A::IdentifierType, val: A) {
         *self.data[id.to_usize().unwrap()].write().unwrap() = Some(val);
     }

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -8,9 +8,12 @@ mod collections;
 mod manager;
 mod traits;
 
-pub use collections::{AttrCompactVec, AttrSparseVec};
+pub use collections::{AttrCompactVec, AttrSparseVec, PAttrSparseVec};
 pub use manager::AttrStorageManager;
-pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
+pub use traits::{
+    AttributeBind, AttributeStorage, AttributeUpdate, ParAttributeStorage,
+    ParUnknownAttributeStorage, UnknownAttributeStorage,
+};
 
 // ------ TESTS
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -354,7 +354,7 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
 ///
 /// The documentation of this trait describe the behavior each function & method should have. "ID"
 /// and "index" are used interchangeably.
-pub trait ParAttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
+pub trait ParAttributeStorage<A: AttributeBind>: ParUnknownAttributeStorage {
     /// Setter
     ///
     /// Set the value of an element at a given index. This operation is not affected by the initial

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -456,6 +456,12 @@ pub trait ParAttributeStorage<A: AttributeBind>: ParUnknownAttributeStorage {
     fn remove(&self, id: A::IdentifierType) -> Option<A>;
 }
 
+/// Common trait implemented by generic attribute storages.
+///
+/// This trait contain attribute-specific methods.
+///
+/// The documentation of this trait describe the behavior each function & method should have. "ID"
+/// and "index" are used interchangeably.
 pub trait ParUnknownAttributeStorage: Any + Debug + Downcast {
     /// Constructor
     ///


### PR DESCRIPTION
- add `ParUnknownAttributeStorage`, with update method sigs
- add `ParAttributeStorage`, with update method sigs
- implement these for a new struct, `PAttrSparseVec`