### PR TITLE
feat(bench): add `fetch_...` methods benchmarks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/grisubal.rs"
 
 # benches
 
-## Iai-callgrind benchmarks
+## Core benchmarks
 
 [[bench]]
 name = "prof-cmap2-build"
@@ -51,6 +51,11 @@ harness = false
 [[bench]]
 name = "prof-cmap2-sewing-unsewing"
 path = "benches/core/cmap2/link_and_sew.rs"
+harness = false
+
+[[bench]]
+name = "fetch-icells"
+path = "benches/core/cmap2/fetch_icells.rs"
 harness = false
 
 ## Builder benchmarks

--- a/benches/benches/core/cmap2/fetch_icells.rs
+++ b/benches/benches/core/cmap2/fetch_icells.rs
@@ -1,0 +1,38 @@
+// ------ IMPORTS
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use honeycomb::prelude::CMap2;
+use honeycomb_benches::FloatType;
+use honeycomb_core::cmap::CMapBuilder;
+
+// ------ CONTENT
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let n_square = 512;
+    let map: CMap2<FloatType> = CMapBuilder::unit_grid(n_square).build().unwrap();
+
+    let mut group = c.benchmark_group("fetch-icells");
+
+    group.bench_with_input(BenchmarkId::new("fetch-vertices", ""), &map, |b, m| {
+        b.iter(|| {
+            let mut vertices = m.fetch_vertices();
+            black_box(&mut vertices);
+        })
+    });
+    group.bench_with_input(BenchmarkId::new("fetch-edges", ""), &map, |b, m| {
+        b.iter(|| {
+            let mut edges = m.fetch_edges();
+            black_box(&mut edges);
+        })
+    });
+    group.bench_with_input(BenchmarkId::new("fetch-faces", ""), &map, |b, m| {
+        b.iter(|| {
+            let mut faces = m.fetch_faces();
+            black_box(&mut faces);
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
add a benchmark group dedicated to the following `CMap2` methods:
- `fetch_vertices`
- `fetch_edges`
- `fetch_faces`

I'm adding those to quantify an optim I thought of. I'll implement the optim in another PR, but we're looking at a 30% decrease of exec time in sequential; & the new impl can be parallelized once #201 lands