### PR TITLE
refactor(kernels::grisubal): add intermediate compute before step 2

### DIFF
--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -542,18 +542,21 @@ pub(super) fn insert_intersections<T: CoordsFloat>(
             &vs.iter().map(|(_, t, _)| *t).collect::<Vec<_>>(),
         );
         // order should be consistent between collection because of the sort_by call
-        let mut dart_id = cmap.beta::<1>(*edge_id as DartIdentifier);
+        let hl = new_darts.len() / 2; // half-length; also equal to n_intermediate
+        let fh = &new_darts[..hl];
+        let sh = &new_darts[hl..];
+
         // chaining this directly avoids an additional `.collect()`
-        for (id, _, old_dart_id) in vs {
+        for (i, (id, _, old_dart_id)) in vs.iter().enumerate() {
             // c.
             // reajust according to intersection side
             res[*id] = if *old_dart_id == *edge_id {
-                dart_id
+                fh[i]
             } else {
                 // ! not sure how generalized this operation can be !
-                cmap.beta::<1>(cmap.beta::<2>(dart_id))
+                sh[hl - 1 - i]
             };
-            dart_id = cmap.beta::<1>(dart_id);
+            //dart_id = cmap.beta::<1>(dart_id);
         }
     }
 

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -571,8 +571,8 @@ pub(super) fn compute_intersection_ids<T: CoordsFloat>(
     for ((edge_id, vs), new_darts) in edge_intersec.iter().zip(dart_slices.iter()) {
         // order should be consistent between collection because of the sort_by call
         let hl = new_darts.len() / 2; // half-length; also equal to n_intermediate
-        let fh = &new_darts[..hl];
-        let sh = &new_darts[hl..];
+        let fh = &new_darts[..hl]; // first half;  used for the side of edge id
+        let sh = &new_darts[hl..]; // second half; used for the opposite side
         for (i, (id, _, old_dart_id)) in vs.iter().enumerate() {
             // readjust according to intersection side
             res[*id] = if *old_dart_id == *edge_id {

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -1,7 +1,8 @@
 // ------ IMPORTS
 
 use crate::grisubal::kernel::{
-    generate_edge_data, generate_intersection_data, insert_edges_in_map, insert_intersections,
+    compute_intersection_ids, generate_edge_data, generate_intersection_data,
+    group_intersections_per_edge, insert_edges_in_map, insert_intersections,
 };
 use crate::grisubal::model::{Boundary, Geometry2, GeometryVertex};
 use honeycomb_core::prelude::{CMapBuilder, GridDescriptor, Orbit2, OrbitPolicy, Vertex2};
@@ -186,9 +187,13 @@ fn regular_intersections() {
         GeometryVertex::PoI(0)
     );
 
-    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+    let n_intersec = intersection_metadata.len();
+    let (edge_intersec, dart_slices) =
+        group_intersections_per_edge(&mut cmap, intersection_metadata);
+    let intersection_darts = compute_intersection_ids(n_intersec, &edge_intersec, &dart_slices);
+    insert_intersections(&mut cmap, &edge_intersec, &dart_slices);
 
-    assert_eq!(intersection_darts.len(), 4);
+    assert_eq!(n_intersec, 4);
     // check new vertices at intersection
     assert_eq!(
         cmap.vertex(cmap.vertex_id(cmap.beta::<1>(2))),
@@ -314,8 +319,11 @@ fn corner_intersection() {
         GeometryVertex::PoI(0)
     );
 
-    // same as the one of the `regular_intersections`, so we won't repeat the assertions
-    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+    let n_intersec = intersection_metadata.len();
+    let (edge_intersec, dart_slices) =
+        group_intersections_per_edge(&mut cmap, intersection_metadata);
+    let intersection_darts = compute_intersection_ids(n_intersec, &edge_intersec, &dart_slices);
+    insert_intersections(&mut cmap, &edge_intersec, &dart_slices);
 
     let mut edges = generate_edge_data(&cmap, &geometry, &segments, &intersection_darts);
 
@@ -401,8 +409,11 @@ pub fn successive_straight_intersections() {
     let (segments, intersection_metadata) =
         generate_intersection_data(&cmap, &geometry, [3, 3], [1.0, 1.0], Vertex2::default());
 
-    // same as the one of the `regular_intersections`, so we won't repeat the assertions
-    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+    let n_intersec = intersection_metadata.len();
+    let (edge_intersec, dart_slices) =
+        group_intersections_per_edge(&mut cmap, intersection_metadata);
+    let intersection_darts = compute_intersection_ids(n_intersec, &edge_intersec, &dart_slices);
+    insert_intersections(&mut cmap, &edge_intersec, &dart_slices);
 
     let edges = generate_edge_data(&cmap, &geometry, &segments, &intersection_darts);
 
@@ -625,8 +636,11 @@ pub fn successive_diag_intersections() {
     let (segments, intersection_metadata) =
         generate_intersection_data(&cmap, &geometry, [3, 3], [1.0, 1.0], Vertex2::default());
 
-    // same as the one of the `regular_intersections`, so we won't repeat the assertions
-    let intersection_darts = insert_intersections(&mut cmap, intersection_metadata);
+    let n_intersec = intersection_metadata.len();
+    let (edge_intersec, dart_slices) =
+        group_intersections_per_edge(&mut cmap, intersection_metadata);
+    let intersection_darts = compute_intersection_ids(n_intersec, &edge_intersec, &dart_slices);
+    insert_intersections(&mut cmap, &edge_intersec, &dart_slices);
 
     let edges = generate_edge_data(&cmap, &geometry, &segments, &intersection_darts);
 


### PR DESCRIPTION
- convert step 2 function to only cover vertex insertions
- move other components out of it to (a) clearup code, and (b) make step 3 independent from step 2. these components are:
    - grouping intersection per edge intersected
    - pre-allocating darts used for step 2
    - computing each intersection's corresponding new dart