### PR TITLE
fix(deps): revert some upgrades that broke the render menu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ rand = "0.9.0-alpha.2"
 
 # render
 bevy = { version = "0.14.2", default-features = false }
-bevy_egui = "0.30.0"
+bevy_egui = "0.29.0"
 bevy_mod_picking = "0.20.1"
 bevy_mod_outline = "0.8.3"
-egui_dock = "0.14.0"
+egui_dock = "0.13.0"
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
- bevy_egui: 0.30.0 -> 0.29.0
- egui_dock: 0.14.0 -> 0.13.0

I'll figure out the fix later if needed