### PR TITLE
refactor(core): imrove grid building routines

### DIFF
--- a/honeycomb-core/src/cmap/builder/grid/building_routines.rs
+++ b/honeycomb-core/src/cmap/builder/grid/building_routines.rs
@@ -36,12 +36,6 @@ pub fn build_2d_grid<T: CoordsFloat>(
                 let up_neighbor = d1 + (4 * n_square_x) as DartIdentifier;
                 map.two_link(d3, up_neighbor);
             }
-        });
-    });
-
-    // then cells
-    (0..n_square_y).for_each(|y_idx| {
-        (0..n_square_x).for_each(|x_idx| {
             // update the associated 0-cell
             let base_dart = (1 + 4 * x_idx + n_square_x * 4 * y_idx) as DartIdentifier;
             let vertex_id = map.vertex_id(base_dart);
@@ -137,12 +131,7 @@ pub fn build_2d_splitgrid<T: CoordsFloat>(
                 let up_neighbor = d1 + (6 * n_square_x) as DartIdentifier;
                 map.two_link(d6, up_neighbor);
             }
-        });
-    });
 
-    // then cells
-    (0..n_square_y).for_each(|y_idx| {
-        (0..n_square_x).for_each(|x_idx| {
             // update the associated 0-cell
             let base_dart = (1 + 6 * (x_idx + n_square_x * y_idx)) as DartIdentifier;
             let vertex_id = map.vertex_id(base_dart);

--- a/honeycomb-core/src/cmap/builder/grid/building_routines.rs
+++ b/honeycomb-core/src/cmap/builder/grid/building_routines.rs
@@ -40,59 +40,57 @@ pub fn build_2d_grid<T: CoordsFloat>(
     });
 
     // then cells
-    (0..=n_square_y).for_each(|y_idx| {
-        (0..=n_square_x).for_each(|x_idx| {
+    (0..n_square_y).for_each(|y_idx| {
+        (0..n_square_x).for_each(|x_idx| {
             // update the associated 0-cell
-            if (y_idx < n_square_y) & (x_idx < n_square_x) {
-                let base_dart = (1 + 4 * x_idx + n_square_x * 4 * y_idx) as DartIdentifier;
-                let vertex_id = map.vertex_id(base_dart);
+            let base_dart = (1 + 4 * x_idx + n_square_x * 4 * y_idx) as DartIdentifier;
+            let vertex_id = map.vertex_id(base_dart);
+            map.insert_vertex(
+                vertex_id,
+                origin
+                    + Vector2(
+                        T::from(x_idx).unwrap() * len_per_x,
+                        T::from(y_idx).unwrap() * len_per_y,
+                    ),
+            );
+            let last_column = x_idx == n_square_x - 1;
+            let last_row = y_idx == n_square_y - 1;
+            if last_column {
+                // that last column of 0-cell needs special treatment
+                // bc there are no "horizontal" associated dart
+                let vertex_id = map.vertex_id(base_dart + 1);
+                map.insert_vertex(
+                    vertex_id,
+                    origin
+                        + Vector2(
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx).unwrap() * len_per_y,
+                        ),
+                );
+            }
+            if last_row {
+                // same as the case on x
+                let vertex_id = map.vertex_id(base_dart + 3);
                 map.insert_vertex(
                     vertex_id,
                     origin
                         + Vector2(
                             T::from(x_idx).unwrap() * len_per_x,
-                            T::from(y_idx).unwrap() * len_per_y,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
                         ),
                 );
-                let last_column = x_idx == n_square_x - 1;
-                let last_row = y_idx == n_square_y - 1;
-                if last_column {
-                    // that last column of 0-cell needs special treatment
-                    // bc there are no "horizontal" associated dart
-                    let vertex_id = map.vertex_id(base_dart + 1);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx + 1).unwrap() * len_per_x,
-                                T::from(y_idx).unwrap() * len_per_y,
-                            ),
-                    );
-                }
-                if last_row {
-                    // same as the case on x
-                    let vertex_id = map.vertex_id(base_dart + 3);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx).unwrap() * len_per_x,
-                                T::from(y_idx + 1).unwrap() * len_per_y,
-                            ),
-                    );
-                }
-                if last_row & last_column {
-                    // need to do the upper right corner
-                    let vertex_id = map.vertex_id(base_dart + 2);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx + 1).unwrap() * len_per_x,
-                                T::from(y_idx + 1).unwrap() * len_per_y,
-                            ),
-                    );
-                }
+            }
+            if last_row & last_column {
+                // need to do the upper right corner
+                let vertex_id = map.vertex_id(base_dart + 2);
+                map.insert_vertex(
+                    vertex_id,
+                    origin
+                        + Vector2(
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
+                        ),
+                );
             }
         });
     });
@@ -143,59 +141,57 @@ pub fn build_2d_splitgrid<T: CoordsFloat>(
     });
 
     // then cells
-    (0..=n_square_y).for_each(|y_idx| {
-        (0..=n_square_x).for_each(|x_idx| {
+    (0..n_square_y).for_each(|y_idx| {
+        (0..n_square_x).for_each(|x_idx| {
             // update the associated 0-cell
-            if (y_idx < n_square_y) & (x_idx < n_square_x) {
-                let base_dart = (1 + 6 * (x_idx + n_square_x * y_idx)) as DartIdentifier;
-                let vertex_id = map.vertex_id(base_dart);
+            let base_dart = (1 + 6 * (x_idx + n_square_x * y_idx)) as DartIdentifier;
+            let vertex_id = map.vertex_id(base_dart);
+            map.insert_vertex(
+                vertex_id,
+                origin
+                    + Vector2(
+                        T::from(x_idx).unwrap() * len_per_x,
+                        T::from(y_idx).unwrap() * len_per_y,
+                    ),
+            );
+            let last_column = x_idx == n_square_x - 1;
+            let last_row = y_idx == n_square_y - 1;
+            if last_column {
+                // that last column of 0-cell needs special treatment
+                // bc there are no "horizontal" associated dart
+                let vertex_id = map.vertex_id(base_dart + 4);
+                map.insert_vertex(
+                    vertex_id,
+                    origin
+                        + Vector2(
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx).unwrap() * len_per_y,
+                        ),
+                );
+            }
+            if last_row {
+                // same as the case on x
+                let vertex_id = map.vertex_id(base_dart + 2);
                 map.insert_vertex(
                     vertex_id,
                     origin
                         + Vector2(
                             T::from(x_idx).unwrap() * len_per_x,
-                            T::from(y_idx).unwrap() * len_per_y,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
                         ),
                 );
-                let last_column = x_idx == n_square_x - 1;
-                let last_row = y_idx == n_square_y - 1;
-                if last_column {
-                    // that last column of 0-cell needs special treatment
-                    // bc there are no "horizontal" associated dart
-                    let vertex_id = map.vertex_id(base_dart + 4);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx + 1).unwrap() * len_per_x,
-                                T::from(y_idx).unwrap() * len_per_y,
-                            ),
-                    );
-                }
-                if last_row {
-                    // same as the case on x
-                    let vertex_id = map.vertex_id(base_dart + 2);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx).unwrap() * len_per_x,
-                                T::from(y_idx + 1).unwrap() * len_per_y,
-                            ),
-                    );
-                }
-                if last_row & last_column {
-                    // need to do the upper right corner
-                    let vertex_id = map.vertex_id(base_dart + 5);
-                    map.insert_vertex(
-                        vertex_id,
-                        origin
-                            + Vector2(
-                                T::from(x_idx + 1).unwrap() * len_per_x,
-                                T::from(y_idx + 1).unwrap() * len_per_y,
-                            ),
-                    );
-                }
+            }
+            if last_row & last_column {
+                // need to do the upper right corner
+                let vertex_id = map.vertex_id(base_dart + 5);
+                map.insert_vertex(
+                    vertex_id,
+                    origin
+                        + Vector2(
+                            T::from(x_idx + 1).unwrap() * len_per_x,
+                            T::from(y_idx + 1).unwrap() * len_per_y,
+                        ),
+                );
             }
         });
     });

--- a/honeycomb-core/src/cmap/builder/grid/building_routines.rs
+++ b/honeycomb-core/src/cmap/builder/grid/building_routines.rs
@@ -103,7 +103,7 @@ pub fn build_2d_grid<T: CoordsFloat>(
         });
 
     // and then build faces
-    assert_eq!(map.fetch_faces().identifiers.len(), n_square_x * n_square_y);
+    debug_assert_eq!(map.fetch_faces().identifiers.len(), n_square_x * n_square_y);
 
     map
 }
@@ -214,7 +214,7 @@ pub fn build_2d_splitgrid<T: CoordsFloat>(
         });
 
     // rebuild faces
-    assert_eq!(
+    debug_assert_eq!(
         map.fetch_faces().identifiers.len(),
         n_square_x * n_square_y * 2
     );


### PR DESCRIPTION
1. remove a useless if / wrong range in the second construction loop
2. fuse and flatten both construction loops, removing redundant computations at the same time
3. replace `link` usages with `set_beta` usages
4. set the last assertion to debug only (it can be removed entirely I think).

performance changes for a 512x512 grid (exec time in ms):

| Grid type | Original | new fetch_<CELLS> | Optim 1, 2, 3 | Optim 4 |
| --------- | --------:| -----------------:| -------------:| -------:|
| Square    | `157.11` |           `89.83` |       `92.98` | `24.54` |
| Triangle  | `246.48` |          `120.16` |      `121.79` | `35.54` |