### PR TITLE
refactor(kernels::grisubal): rewrite step 1 to enable parallelization

### DIFF
--- a/honeycomb-kernels/src/grisubal/grid.rs
+++ b/honeycomb-kernels/src/grisubal/grid.rs
@@ -10,7 +10,7 @@
 ///
 /// Cells `(X, Y)` take value in range `(0, 0)` to `(N, M)`,
 /// from left to right (X), from bottom to top (Y).
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 pub struct GridCellId(pub usize, pub usize);
 
 impl GridCellId {

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -244,15 +244,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
             // trivial case:
             // v1 & v2 belong to the same cell
             0 => {
-                //new_segments.insert(
-                //    make_geometry_vertex!(geometry, v1_id),
-                //    make_geometry_vertex!(geometry, v2_id),
-                //);
-                [
-                    make_geometry_vertex!(geometry, v1_id),
-                    make_geometry_vertex!(geometry, v2_id)
-                ].windows(2).map(transform
-                    ).collect::<Vec<_>>()
+                vec![(make_geometry_vertex!(geometry, v1_id), make_geometry_vertex!(geometry, v2_id))]
             }
             // ok case:
             // v1 & v2 belong to neighboring cells
@@ -288,11 +280,10 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                 let id = i_ids.start;
                 intersection_metadata[id] = (dart_id, t);
 
-                [
-                    make_geometry_vertex!(geometry, v1_id),
-                    GeometryVertex::Intersec(id),
-                    make_geometry_vertex!(geometry, v2_id)
-                ].windows(2).map(transform).collect::<Vec<_>>()
+                vec![
+                    (make_geometry_vertex!(geometry, v1_id), GeometryVertex::Intersec(id)),
+                    (GeometryVertex::Intersec(id), make_geometry_vertex!(geometry, v2_id)),
+                ]
             }
             // highly annoying case:
             // v1 & v2 do not belong to neighboring cell
@@ -333,6 +324,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
 
                                 GeometryVertex::Intersec(id)
                             });
+
                         // because of how the range is written, we need to reverse the iterator in one case
                         // to keep intersection ordered from v1 to v2 (i.e. ensure the segments we build are correct)
                         let mut vs: VecDeque<GeometryVertex> = if i > 0 {
@@ -340,10 +332,15 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                         } else {
                             tmp.rev().collect()
                         };
+
+                        // complete the vertex list
                         vs.push_front(make_geometry_vertex!(geometry, v1_id));
                         vs.push_back(make_geometry_vertex!(geometry, v2_id));
-                        vs.make_contiguous().windows(2).map(transform
-                        ).collect::<Vec<_>>()
+
+                        vs.make_contiguous()
+                            .windows(2)
+                            .map(transform)
+                            .collect::<Vec<_>>()
                     }
                     (0, j) => {
                         // we can solve the intersection equation
@@ -373,6 +370,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
 
                                 GeometryVertex::Intersec(id)
                             });
+
                         // because of how the range is written, we need to reverse the iterator in one case
                         // to keep intersection ordered from v1 to v2 (i.e. ensure the segments we build are correct)
                         let mut vs: VecDeque<GeometryVertex> = if j > 0 {
@@ -380,11 +378,15 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                         } else {
                             tmp.rev().collect()
                         };
+
                         // complete the vertex list
                         vs.push_front(make_geometry_vertex!(geometry, v1_id));
                         vs.push_back(make_geometry_vertex!(geometry, v2_id));
-                        vs.make_contiguous().windows(2).map(transform
-                        ).collect::<Vec<_>>()
+
+                        vs.make_contiguous()
+                            .windows(2)
+                            .map(transform)
+                            .collect::<Vec<_>>()
                     }
                     (i, j) => {
                         // in order to process this, we'll consider a "sub-grid" & use the direction of the segment to
@@ -472,6 +474,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                 None
                             })
                             .collect();
+
                         // sort intersections from v1 to v2
                         intersec_data.retain(|(s, _, _)| (T::zero() <= *s) && (*s <= T::one()));
                         // panic unreachable because of the retain above; there's no s s.t. s == NaN
@@ -497,9 +500,12 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                 GeometryVertex::Intersec(id)
                             }
                         }));
+
                         vs.push(make_geometry_vertex!(geometry, v2_id));
-                        vs.windows(2).map(transform
-                        ).collect::<Vec<_>>()
+
+                        vs.windows(2)
+                            .map(transform)
+                            .collect::<Vec<_>>()
                     }
                 }
             }

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -292,10 +292,8 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                     _ => unreachable!(),
                 };
 
-                // FIXME: these two lines should be atomic
                 debug_assert_eq!(i_ids.len(), 1);
                 let id = i_ids.start;
-                //let id = intersection_metadata.len();
                 intersection_metadata[id] = (dart_id, t);
 
                 new_segments.insert(
@@ -345,8 +343,6 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                     left_intersec!(v1, v2, v_dart, cy)
                                 };
 
-                                // FIXME: these two lines should be atomic
-                                // let id = intersection_metadata.len();
                                 intersection_metadata[id] = (dart_id, t);
 
                                 GeometryVertex::Intersec(id)
@@ -388,8 +384,6 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                     down_intersec!(v1, v2, v_dart, cx)
                                 };
 
-                                // FIXME: these two lines should be atomic
-                                // let id = intersection_metadata.len();
                                 intersection_metadata[id] = (dart_id, t);
 
                                 GeometryVertex::Intersec(id)
@@ -510,13 +504,11 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                                 // should start: the one incident to the vertex in the opposite quadrant
 
                                 // in that case, the preallocated intersection metadata slot will stay as (0, Nan)
-                                // this is ok, we can simply ignore the entry when computing edge processing the data
+                                // this is ok, we can simply ignore the entry when processing the data later
 
                                 let dart_in = *dart_id;
                                 GeometryVertex::IntersecCorner(dart_in)
                             } else {
-                                // FIXME: these two lines should be atomic
-                                // let id = intersection_metadata.len();
                                 intersection_metadata[id] = (*dart_id, *t);
 
                                 GeometryVertex::Intersec(id)

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -227,18 +227,18 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
     let n_intersec: usize = tmp.iter().map(|(dist, _, _, _, _, _, _)| dist).sum();
     // we're using the prefix sum to compute an offset from the start. that's why we need a 0 at the front
     // we'll cut off the last element later
-    let prefix_sum: Vec<usize> = [0]
+    let prefix_sum: Vec<usize> = tmp
         .iter()
-        .chain(tmp.iter().map(|(dist, _, _, _, _, _, _)| dist))
+        .map(|(dist, _, _, _, _, _, _)| dist)
         .scan(0, |state, &dist| {
             *state += dist;
-            Some(*state)
+            Some(*state - dist) // we want an offset, not the actual sum
         })
         .collect();
     // preallocate the intersection vector
     let mut intersection_metadata = vec![(NULL_DART_ID, T::nan()); n_intersec];
 
-    let new_segments: Segments = tmp.iter().zip(prefix_sum[..prefix_sum.len()-1].iter()).flat_map(|(&(dist, diff, v1, v2, v1_id, v2_id, c1), start)| {
+    let new_segments: Segments = tmp.iter().zip(prefix_sum.iter()).flat_map(|(&(dist, diff, v1, v2, v1_id, v2_id, c1), start)| {
         let transform = Box::new(|seg: &[GeometryVertex]| {
             assert_eq!(seg.len(), 2);
             (seg[0].clone(), seg[1].clone())

--- a/honeycomb-kernels/src/grisubal/kernel.rs
+++ b/honeycomb-kernels/src/grisubal/kernel.rs
@@ -227,18 +227,17 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
     let n_intersec: usize = tmp.iter().map(|(dist, _, _, _, _, _, _)| dist).sum();
     // we're using the prefix sum to compute an offset from the start. that's why we need a 0 at the front
     // we'll cut off the last element later
-    let prefix_sum: Vec<usize> = tmp
+    let prefix_sum = tmp
         .iter()
         .map(|(dist, _, _, _, _, _, _)| dist)
         .scan(0, |state, &dist| {
             *state += dist;
             Some(*state - dist) // we want an offset, not the actual sum
-        })
-        .collect();
+        });
     // preallocate the intersection vector
     let mut intersection_metadata = vec![(NULL_DART_ID, T::nan()); n_intersec];
 
-    let new_segments: Segments = tmp.iter().zip(prefix_sum.iter()).flat_map(|(&(dist, diff, v1, v2, v1_id, v2_id, c1), start)| {
+    let new_segments: Segments = tmp.iter().zip(prefix_sum).flat_map(|(&(dist, diff, v1, v2, v1_id, v2_id, c1), start)| {
         let transform = Box::new(|seg: &[GeometryVertex]| {
             assert_eq!(seg.len(), 2);
             (seg[0].clone(), seg[1].clone())
@@ -280,7 +279,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
                     _ => unreachable!(),
                 };
 
-                let id = *start;
+                let id = start;
                 intersection_metadata[id] = (dart_id, t);
 
                 vec![
@@ -293,7 +292,7 @@ pub(super) fn generate_intersection_data<T: CoordsFloat>(
             _ => {
                 // pure vertical / horizontal traversal are treated separately because it ensures we're not trying
                 // to compute intersections of parallel segments (which results at best in a division by 0)
-                let i_ids = *start..*start+dist;
+                let i_ids = start..start+dist;
                 match diff {
                     (i, 0) => {
                         // we can solve the intersection equation

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -140,7 +140,6 @@ fn regular_intersections() {
         generate_intersection_data(&cmap, &geometry, [2, 2], [1.0, 1.0], Vertex2::default());
 
     assert_eq!(intersection_metadata.len(), 4);
-    // FIXME: INDEX ACCESSES WON'T WORK IN PARALLEL
     assert_eq!(intersection_metadata[0], (2, 0.5));
     assert_eq!(intersection_metadata[1], (7, 0.5));
     assert_eq!(intersection_metadata[2], (16, 0.5));
@@ -261,6 +260,8 @@ fn regular_intersections() {
 
 #[test]
 fn corner_intersection() {
+    use num_traits::Float;
+
     let mut cmap = CMapBuilder::from(
         GridDescriptor::default()
             .len_per_cell([1.0; 3])
@@ -280,7 +281,15 @@ fn corner_intersection() {
     let (segments, intersection_metadata) =
         generate_intersection_data(&cmap, &geometry, [2, 2], [1.0, 1.0], Vertex2::default());
 
-    assert_eq!(intersection_metadata.len(), 2);
+    // because we intersec a corner, some entries were preallocated but not needed.
+    // entries were initialized with (0, Nan), so they're easy to filter
+    assert_eq!(
+        intersection_metadata
+            .iter()
+            .filter(|(_, t)| !t.is_nan())
+            .count(),
+        2
+    );
     assert_eq!(intersection_metadata[0], (2, 0.5));
     assert_eq!(intersection_metadata[1], (7, 0.5));
 


### PR DESCRIPTION
there are two main changes to make it happen:
- split the main iterator in two, to compute and preallocate intersection metadata vector, allowing edition of the vector with no pushes
- rewrite the second part of the iterator to collect `(K, V)` pairs directly into the Hashmap rather than insert each manually

using the bench scripts, it seems like the performance is unchanged for now, which is a win since step 1 is now parallelizable