### PR TITLE
refactor!(core): update `AttributeUpdate` methods returns

### DIFF
--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -8,7 +8,7 @@ use super::{
     UnknownAttributeStorage,
 };
 use crate::{
-    cmap::EdgeIdType,
+    cmap::{CMapResult, EdgeIdType},
     prelude::{CMap2, CMapBuilder, FaceIdType, OrbitPolicy, Vertex2, VertexIdType},
 };
 use std::any::Any;
@@ -35,12 +35,12 @@ impl AttributeUpdate for Temperature {
         (attr, attr)
     }
 
-    fn merge_incomplete(attr: Self) -> Self {
-        Temperature::from(attr.val / 2.0)
+    fn merge_incomplete(attr: Self) -> CMapResult<Self> {
+        Ok(Temperature::from(attr.val / 2.0))
     }
 
-    fn merge_from_none() -> Option<Self> {
-        Some(Temperature::from(0.0))
+    fn merge_from_none() -> CMapResult<Self> {
+        Ok(Temperature::from(0.0))
     }
 }
 
@@ -449,9 +449,9 @@ fn attribute_update() {
     assert_eq!(Temperature::split(t_new), (t_ref, t_ref)); // or Temperature::_
     assert_eq!(
         Temperature::merge_incomplete(t_ref),
-        Temperature::from(t_ref.val / 2.0)
+        Ok(Temperature::from(t_ref.val / 2.0))
     );
-    assert_eq!(Temperature::merge_from_none(), Some(Temperature::from(0.0)));
+    assert_eq!(Temperature::merge_from_none(), Ok(Temperature::from(0.0)));
 }
 
 #[test]

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -27,7 +27,7 @@ use stm::{atomically, StmResult, Transaction};
 /// like this:
 ///
 /// ```rust
-/// use honeycomb_core::prelude::AttributeUpdate;
+/// use honeycomb_core::prelude::{AttributeUpdate, CMapResult};
 ///
 /// #[derive(Clone, Copy, Debug, PartialEq)]
 /// pub struct Temperature {
@@ -43,12 +43,12 @@ use stm::{atomically, StmResult, Transaction};
 ///         (attr, attr)
 ///     }
 ///
-///     fn merge_incomplete(attr: Self) -> Self {
-///         Temperature { val: attr.val / 2.0 }
+///     fn merge_incomplete(attr: Self) -> CMapResult<Self> {
+///         Ok(Temperature { val: attr.val / 2.0 })
 ///     }
 ///
-///     fn merge_from_none() -> Option<Self> {
-///         Some(Temperature { val: 0.0 })
+///     fn merge_from_none() -> CMapResult<Self> {
+///         Ok(Temperature { val: 0.0 })
 ///     }
 /// }
 ///
@@ -105,7 +105,7 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
 /// to faces if we're modeling a 2D mesh:
 ///
 /// ```rust
-/// use honeycomb_core::prelude::{AttributeBind, AttributeUpdate, FaceIdType, OrbitPolicy};
+/// use honeycomb_core::prelude::{AttributeBind, AttributeUpdate, CMapResult, FaceIdType, OrbitPolicy};
 /// use honeycomb_core::attributes::AttrSparseVec;
 ///
 /// #[derive(Clone, Copy, Debug, PartialEq)]
@@ -121,12 +121,12 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
 /// #         (attr, attr)
 /// #     }
 /// #
-/// #     fn merge_incomplete(attr: Self) -> Self {
-/// #         Temperature { val: attr.val / 2.0 }
+/// #     fn merge_incomplete(attr: Self) -> CMapResult<Self> {
+/// #         Ok(Temperature { val: attr.val / 2.0 })
 /// #     }
 /// #
-/// #     fn merge_from_none() -> Option<Self> {
-/// #         Some(Temperature { val: 0.0 })
+/// #     fn merge_from_none() -> CMapResult<Self> {
+/// #         Ok(Temperature { val: 0.0 })
 /// #     }
 /// # }
 ///

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -78,10 +78,19 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     /// Fallback merging routine, i.e. how to obtain the new attribute value from no existing
     /// value.
     ///
-    /// The default implementation return `None`.
+    /// The default implementation return `Err(CMapError::FailedAttributeMerge)`.
     #[allow(clippy::must_use_candidate)]
     fn merge_from_none() -> CMapResult<Self> {
         Err(CMapError::FailedAttributeMerge(type_name::<Self>()))
+    }
+
+    /// Fallback splitting routine, i.e. how to obtain the new attribute value from no existing
+    /// value.
+    ///
+    /// The default implementation return `Err(CMapError::FailedAttributeSplit)`.
+    #[allow(clippy::must_use_candidate)]
+    fn split_from_none() -> CMapResult<(Self, Self)> {
+        Err(CMapError::FailedAttributeSplit(type_name::<Self>()))
     }
 }
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -6,11 +6,11 @@
 // ------ IMPORTS
 
 use crate::{
-    cmap::CMapResult,
+    cmap::{CMapError, CMapResult},
     prelude::{DartIdType, OrbitPolicy},
 };
 use downcast_rs::{impl_downcast, Downcast};
-use std::any::Any;
+use std::any::{type_name, Any};
 use std::fmt::Debug;
 use stm::{atomically, StmResult, Transaction};
 
@@ -71,8 +71,8 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     /// value.
     ///
     /// The default implementation simply returns the passed value.
-    fn merge_incomplete(attr: Self) -> Self {
-        attr
+    fn merge_incomplete(attr: Self) -> CMapResult<Self> {
+        Ok(attr)
     }
 
     /// Fallback merging routine, i.e. how to obtain the new attribute value from no existing
@@ -80,8 +80,8 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     ///
     /// The default implementation return `None`.
     #[allow(clippy::must_use_candidate)]
-    fn merge_from_none() -> Option<Self> {
-        None
+    fn merge_from_none() -> CMapResult<Self> {
+        Err(CMapError::FailedAttributeMerge(type_name::<Self>()))
     }
 }
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -70,6 +70,16 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     /// Fallback merging routine, i.e. how to obtain the new attribute value from a single existing
     /// value.
     ///
+    /// The returned value directly affects the behavior of [`UnknownAttributeStorage::merge`],
+    /// [`UnknownAttributeStorage::try_merge`], therefore of sewing methods too.
+    ///
+    /// For example, if this method returns an error for a given attribute, the `try_merge` method
+    /// will fail. This allow the user to define some attributes as essential (fail if the merge
+    /// isn't done properly from two values) and other as mores flexible (can fallback to a default
+    /// value).
+    ///
+    /// # Errors
+    ///
     /// The default implementation simply returns the passed value.
     fn merge_incomplete(attr: Self) -> CMapResult<Self> {
         Ok(attr)
@@ -77,6 +87,16 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
 
     /// Fallback merging routine, i.e. how to obtain the new attribute value from no existing
     /// value.
+    ///
+    /// The returned value directly affects the behavior of [`UnknownAttributeStorage::merge`],
+    /// [`UnknownAttributeStorage::try_merge`], therefore of sewing methods too.
+    ///
+    /// For example, if this method returns an error for a given attribute, the `try_merge` method
+    /// will fail. This allow the user to define some attributes as essential (fail if the merge
+    /// isn't done properly from two values) and others as more flexible (can fallback to a default
+    /// value).
+    ///
+    /// # Errors
     ///
     /// The default implementation return `Err(CMapError::FailedAttributeMerge)`.
     #[allow(clippy::must_use_candidate)]
@@ -86,6 +106,16 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
 
     /// Fallback splitting routine, i.e. how to obtain the new attribute value from no existing
     /// value.
+    ///
+    /// The returned value directly affects the behavior of [`UnknownAttributeStorage::split`],
+    /// [`UnknownAttributeStorage::try_split`], therefore of sewing methods too.
+    ///
+    /// For example, if this method returns an error for a given attribute, the `try_split` method
+    /// will fail. This allow the user to define some attributes as essential (fail if the split
+    /// isn't done properly from a value) and others as more flexible (can fallback to a default
+    /// value).
+    ///
+    /// # Errors
     ///
     /// The default implementation return `Err(CMapError::FailedAttributeSplit)`.
     #[allow(clippy::must_use_candidate)]

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -6,7 +6,7 @@ use stm::StmError;
 pub type CMapResult<T> = Result<T, CMapError>;
 
 /// `CMap` error enum.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CMapError {
     /// STM transaction failed.
     #[error("transaction failed")]

--- a/honeycomb-core/src/prelude.rs
+++ b/honeycomb-core/src/prelude.rs
@@ -2,9 +2,9 @@
 
 pub use crate::attributes::{AttributeBind, AttributeUpdate};
 pub use crate::cmap::{
-    BuilderError, CMap2, CMapBuilder, DartIdType, EdgeIdType, FaceIdType, Orbit2, OrbitPolicy,
-    VertexIdType, VolumeIdType, NULL_DART_ID, NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID,
-    NULL_VOLUME_ID,
+    BuilderError, CMap2, CMapBuilder, CMapResult, DartIdType, EdgeIdType, FaceIdType, Orbit2,
+    OrbitPolicy, VertexIdType, VolumeIdType, NULL_DART_ID, NULL_EDGE_ID, NULL_FACE_ID,
+    NULL_VERTEX_ID, NULL_VOLUME_ID,
 };
 pub use crate::geometry::{CoordsError, CoordsFloat, Vector2, Vertex2};
 

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -8,6 +8,7 @@
 
 use crate::grisubal::GrisubalError;
 use honeycomb_core::attributes::AttrSparseVec;
+use honeycomb_core::cmap::CMapResult;
 use honeycomb_core::prelude::{
     AttributeBind, AttributeUpdate, CoordsFloat, DartIdType, OrbitPolicy, Vertex2,
 };
@@ -263,8 +264,8 @@ impl AttributeUpdate for Boundary {
         unreachable!()
     }
 
-    fn merge_from_none() -> Option<Self> {
-        Some(Boundary::None)
+    fn merge_from_none() -> CMapResult<Self> {
+        Ok(Boundary::None)
     }
 }
 


### PR DESCRIPTION
### Description

**Associated issue**: closes #232 

**Content description**:
- change:
	- `AttributeUpdate::merge_incomplete` return type to `CMapResult<Self>`
	- `AttributeUpdate::merge_from_none` return type to `CMapResult<Self>`
- add:
	- `AttributeUpdate::split_from_none` fallback method
- update all affected implementation

### Additional information

- [x] Breaking change
