### PR TITLE
refactor!(core): add new variants to `OrbitPolicy`

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -21,9 +21,11 @@ use std::{any::TypeId, collections::HashMap};
 macro_rules! get_storage {
     ($slf: ident, $id: ident) => {
         let probably_storage = match A::BIND_POLICY {
-            OrbitPolicy::Vertex => $slf.vertices.get(&TypeId::of::<A>()),
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                $slf.vertices.get(&TypeId::of::<A>())
+            }
             OrbitPolicy::Edge => $slf.edges.get(&TypeId::of::<A>()),
-            OrbitPolicy::Face => $slf.faces.get(&TypeId::of::<A>()),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => $slf.faces.get(&TypeId::of::<A>()),
             OrbitPolicy::Custom(_) => $slf.others.get(&TypeId::of::<A>()),
         };
         let $id = probably_storage
@@ -35,9 +37,11 @@ macro_rules! get_storage {
 macro_rules! get_storage_mut {
     ($slf: ident, $id: ident) => {
         let probably_storage = match A::BIND_POLICY {
-            OrbitPolicy::Vertex => $slf.vertices.get_mut(&TypeId::of::<A>()),
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                $slf.vertices.get_mut(&TypeId::of::<A>())
+            }
             OrbitPolicy::Edge => $slf.edges.get_mut(&TypeId::of::<A>()),
-            OrbitPolicy::Face => $slf.faces.get_mut(&TypeId::of::<A>()),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => $slf.faces.get_mut(&TypeId::of::<A>()),
             OrbitPolicy::Custom(_) => $slf.others.get_mut(&TypeId::of::<A>()),
         };
         let $id = probably_storage
@@ -162,9 +166,13 @@ impl AttrStorageManager {
         let typeid = TypeId::of::<A>();
         let new_storage = <A as AttributeBind>::StorageType::new(size);
         if match A::BIND_POLICY {
-            OrbitPolicy::Vertex => self.vertices.insert(typeid, Box::new(new_storage)),
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                self.vertices.insert(typeid, Box::new(new_storage))
+            }
             OrbitPolicy::Edge => self.edges.insert(typeid, Box::new(new_storage)),
-            OrbitPolicy::Face => self.faces.insert(typeid, Box::new(new_storage)),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
+                self.faces.insert(typeid, Box::new(new_storage))
+            }
             OrbitPolicy::Custom(_) => self.others.insert(typeid, Box::new(new_storage)),
         }
         .is_some()
@@ -212,9 +220,9 @@ impl AttrStorageManager {
     #[must_use = "unused getter result - please remove this method call"]
     pub fn get_storage<A: AttributeBind>(&self) -> Option<&<A as AttributeBind>::StorageType> {
         let probably_storage = match A::BIND_POLICY {
-            OrbitPolicy::Vertex => &self.vertices[&TypeId::of::<A>()],
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => &self.vertices[&TypeId::of::<A>()],
             OrbitPolicy::Edge => &self.edges[&TypeId::of::<A>()],
-            OrbitPolicy::Face => &self.faces[&TypeId::of::<A>()],
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => &self.faces[&TypeId::of::<A>()],
             OrbitPolicy::Custom(_) => &self.others[&TypeId::of::<A>()],
         };
         probably_storage.downcast_ref::<<A as AttributeBind>::StorageType>()
@@ -231,9 +239,11 @@ impl AttrStorageManager {
     pub fn remove_storage<A: AttributeBind>(&mut self) {
         // we could return it ?
         let _ = match A::BIND_POLICY {
-            OrbitPolicy::Vertex => &self.vertices.remove(&TypeId::of::<A>()),
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                &self.vertices.remove(&TypeId::of::<A>())
+            }
             OrbitPolicy::Edge => &self.edges.remove(&TypeId::of::<A>()),
-            OrbitPolicy::Face => &self.faces.remove(&TypeId::of::<A>()),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => &self.faces.remove(&TypeId::of::<A>()),
             OrbitPolicy::Custom(_) => &self.others.remove(&TypeId::of::<A>()),
         };
     }
@@ -256,9 +266,13 @@ impl AttrStorageManager {
         id_in_rhs: DartIdType,
     ) {
         match orbit_policy {
-            OrbitPolicy::Vertex => self.force_merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                self.force_merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs)
+            }
             OrbitPolicy::Edge => self.force_merge_edge_attributes(id_out, id_in_lhs, id_in_rhs),
-            OrbitPolicy::Face => self.force_merge_face_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
+                self.force_merge_face_attributes(id_out, id_in_lhs, id_in_rhs)
+            }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
@@ -335,11 +349,13 @@ impl AttrStorageManager {
         id_in_rhs: DartIdType,
     ) -> StmResult<()> {
         match orbit_policy {
-            OrbitPolicy::Vertex => {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
                 self.merge_vertex_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
             OrbitPolicy::Edge => self.merge_edge_attributes(trans, id_out, id_in_lhs, id_in_rhs),
-            OrbitPolicy::Face => self.merge_face_attributes(trans, id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
+                self.merge_face_attributes(trans, id_out, id_in_lhs, id_in_rhs)
+            }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
@@ -448,13 +464,13 @@ impl AttrStorageManager {
         id_in_rhs: DartIdType,
     ) -> CMapResult<()> {
         match orbit_policy {
-            OrbitPolicy::Vertex => {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
                 self.try_merge_vertex_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
             OrbitPolicy::Edge => {
                 self.try_merge_edge_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
-            OrbitPolicy::Face => {
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
                 self.try_merge_face_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
             OrbitPolicy::Custom(_) => unimplemented!(),
@@ -637,11 +653,13 @@ impl AttrStorageManager {
         id_in: DartIdType,
     ) {
         match orbit_policy {
-            OrbitPolicy::Vertex => {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
                 self.force_split_vertex_attributes(id_out_lhs, id_out_rhs, id_in);
             }
             OrbitPolicy::Edge => self.force_split_edge_attributes(id_out_lhs, id_out_rhs, id_in),
-            OrbitPolicy::Face => self.force_split_face_attributes(id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
+                self.force_split_face_attributes(id_out_lhs, id_out_rhs, id_in)
+            }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
@@ -721,11 +739,13 @@ impl AttrStorageManager {
         id_in: DartIdType,
     ) -> StmResult<()> {
         match orbit_policy {
-            OrbitPolicy::Vertex => {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
                 self.split_vertex_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
             OrbitPolicy::Edge => self.split_edge_attributes(trans, id_out_lhs, id_out_rhs, id_in),
-            OrbitPolicy::Face => self.split_face_attributes(trans, id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
+                self.split_face_attributes(trans, id_out_lhs, id_out_rhs, id_in)
+            }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
@@ -835,13 +855,13 @@ impl AttrStorageManager {
         id_in: DartIdType,
     ) -> CMapResult<()> {
         match orbit_policy {
-            OrbitPolicy::Vertex => {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
                 self.try_split_vertex_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
             OrbitPolicy::Edge => {
                 self.try_split_edge_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
-            OrbitPolicy::Face => {
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
                 self.try_split_face_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
             OrbitPolicy::Custom(_) => unimplemented!(),

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -267,11 +267,11 @@ impl AttrStorageManager {
     ) {
         match orbit_policy {
             OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
-                self.force_merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs)
+                self.force_merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs);
             }
             OrbitPolicy::Edge => self.force_merge_edge_attributes(id_out, id_in_lhs, id_in_rhs),
             OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.force_merge_face_attributes(id_out, id_in_lhs, id_in_rhs)
+                self.force_merge_face_attributes(id_out, id_in_lhs, id_in_rhs);
             }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
@@ -658,7 +658,7 @@ impl AttrStorageManager {
             }
             OrbitPolicy::Edge => self.force_split_edge_attributes(id_out_lhs, id_out_rhs, id_in),
             OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.force_split_face_attributes(id_out_lhs, id_out_rhs, id_in)
+                self.force_split_face_attributes(id_out_lhs, id_out_rhs, id_in);
             }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }

--- a/honeycomb-core/src/cmap/builder/grid/tests.rs
+++ b/honeycomb-core/src/cmap/builder/grid/tests.rs
@@ -112,11 +112,12 @@ fn square_cmap2_correctness() {
     assert_eq!(cmap.face_id(3), 1);
     assert_eq!(cmap.face_id(4), 1);
 
+    // i-cell uses beta 0 to ensure correctness, so the iterator is BFS-like
     let mut face = cmap.i_cell::<2>(1);
     assert_eq!(face.next(), Some(1));
-    assert_eq!(face.next(), Some(2));
-    assert_eq!(face.next(), Some(3));
-    assert_eq!(face.next(), Some(4));
+    assert_eq!(face.next(), Some(2)); // b1
+    assert_eq!(face.next(), Some(4)); // b0
+    assert_eq!(face.next(), Some(3)); // b1b1
     assert_eq!(face.next(), None);
 
     assert_eq!(cmap.beta::<1>(1), 2);
@@ -138,8 +139,8 @@ fn square_cmap2_correctness() {
     let mut face = cmap.i_cell::<2>(5);
     assert_eq!(face.next(), Some(5));
     assert_eq!(face.next(), Some(6));
-    assert_eq!(face.next(), Some(7));
     assert_eq!(face.next(), Some(8));
+    assert_eq!(face.next(), Some(7));
     assert_eq!(face.next(), None);
 
     assert_eq!(cmap.beta::<1>(5), 6);
@@ -161,8 +162,8 @@ fn square_cmap2_correctness() {
     let mut face = cmap.i_cell::<2>(9);
     assert_eq!(face.next(), Some(9));
     assert_eq!(face.next(), Some(10));
-    assert_eq!(face.next(), Some(11));
     assert_eq!(face.next(), Some(12));
+    assert_eq!(face.next(), Some(11));
     assert_eq!(face.next(), None);
 
     assert_eq!(cmap.beta::<1>(9), 10);
@@ -184,8 +185,8 @@ fn square_cmap2_correctness() {
     let mut face = cmap.i_cell::<2>(13);
     assert_eq!(face.next(), Some(13));
     assert_eq!(face.next(), Some(14));
-    assert_eq!(face.next(), Some(15));
     assert_eq!(face.next(), Some(16));
+    assert_eq!(face.next(), Some(15));
     assert_eq!(face.next(), None);
 
     assert_eq!(cmap.beta::<1>(13), 14);


### PR DESCRIPTION
### Description

**Associated issue**: closes #235 

**Content description**:
- add two new variants `OrbitPolicy::VertexLinear` & `OrbitPolicy::FaceLinear`
- handle their computation in `Orbit2`
- change `OrbitPolicy::Face` to use the beta 0 & beta 1 functions (it previously only used beta 1, which is what `OrbitPolicy::FaceLinear` does now)

### Additional information

- [x] Breaking change