### PR TITLE
feat(kernel): implement DSATUR coloring algorithm for vertices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ honeycomb-render = { version = "0.6.0", path = "./honeycomb-render" }
 
 # common
 cfg-if = "1"
+itertools = "0.13.0"
 rustversion = "1.0.18"
 thiserror = "2.0.3"
 

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -294,6 +294,18 @@ impl<T: CoordsFloat> CMap2<T> {
     }
     // --- big guns
 
+    /// Add a new attribute storage to the map.
+    ///
+    /// This method is useful for kernels using a specific attribute to execute, or as return
+    /// values.
+    ///
+    /// # Generic
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute stored by the fetched storage.
+    pub fn add_attribute_storage<A: AttributeBind + AttributeUpdate>(&mut self) {
+        self.attributes.add_storage::<A>(self.n_darts() + 1);
+    }
+
     /// Remove an entire attribute storage from the map.
     ///
     /// This method is useful when implementing routines that uses attributes to run; Those can then be removed

--- a/honeycomb-kernels/Cargo.toml
+++ b/honeycomb-kernels/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 honeycomb-core = { workspace = true, features = ["io", "utils"] }
 itertools.workspace = true
 num-traits.workspace = true
-rayon = "1.10.0"
+rayon.workspace = true
 thiserror.workspace = true
 vtkio.workspace = true
 

--- a/honeycomb-kernels/Cargo.toml
+++ b/honeycomb-kernels/Cargo.toml
@@ -14,6 +14,7 @@ publish = true
 
 [dependencies]
 honeycomb-core = { workspace = true, features = ["io", "utils"] }
+itertools.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
 vtkio.workspace = true

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -1,22 +1,75 @@
-use std::collections::HashMap;
+use std::{cmp::Ordering, collections::HashMap};
 
 use honeycomb_core::{
     cmap::{CMap2, DartIdType, Orbit2, OrbitPolicy, VertexIdType, NULL_DART_ID},
     prelude::CoordsFloat,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Color(u8);
 
+/// DSATUR algorithm implementation
 pub fn color<T: CoordsFloat>(cmap: &CMap2<T>) {
-    // build connectivity data
-    let mut vertices = cmap.fetch_vertices().identifiers.clone();
+    // build graph data as a collection of (Vertex, Vec<Neighbors>)
+    let nodes: Vec<(VertexIdType, Vec<VertexIdType>)> = cmap
+        .fetch_vertices()
+        .identifiers
+        .into_iter()
+        .filter_map(|v| {
+            if Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
+                .any(|d| cmap.beta::<2>(d) == NULL_DART_ID)
+            {
+                None
+            } else {
+                Some((
+                    v,
+                    Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
+                        .map(|d| cmap.vertex_id(cmap.beta::<2>(d)))
+                        .collect(),
+                ))
+            }
+        })
+        .collect();
     // this can be a builtin attribute when I add a method to hijack the manager
-    let mut colors: HashMap<VertexIdType, Color> = HashMap::with_capacity(vertices.len());
-    let mut saturations = vec![0_u8; vertices.len()];
+    let mut colors: HashMap<VertexIdType, Color> = HashMap::with_capacity(nodes.len());
+    let mut saturations: HashMap<VertexIdType, u8> =
+        (0..nodes.len()).map(|i| (nodes[i].0, 0)).collect();
 
-    while 
-}
+    // find the highest degree node to start from
+    let mut crt_node = nodes.iter().max_by(|n1, n2| n1.1.len().cmp(&n2.1.len()));
 
-fn color_candidates() -> &[VertexIdType] {
-    todo!()
+    while let Some((v, neighbors)) = crt_node {
+        let neigh_colors: Vec<Color> = neighbors
+            .iter()
+            .filter_map(|nghb| {
+                *saturations.get_mut(nghb).unwrap() += 1;
+                colors.get(nghb)
+            })
+            .copied()
+            .collect();
+
+        let mut tmp = 0;
+        while neigh_colors.contains(&Color(tmp)) {
+            tmp += 1;
+        }
+
+        colors.insert(*v, Color(tmp));
+
+        // find next candidate that is:
+        //
+        // - not colored
+        // - of highest saturation
+        //   - if there are multiple, take the one of highest degree
+        crt_node = nodes
+            .iter()
+            .filter(|(v, _)| !colors.contains_key(v))
+            .max_by(|n1, n2| {
+                let order = saturations[&n1.0].cmp(&saturations[&n2.0]);
+                if order == Ordering::Equal {
+                    n1.1.len().cmp(&n2.1.len())
+                } else {
+                    order
+                }
+            });
+    }
 }

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -17,19 +17,13 @@ pub fn color<T: CoordsFloat>(cmap: &mut CMap2<T>) -> u8 {
         .fetch_vertices()
         .identifiers
         .into_iter()
-        .filter_map(|v| {
-            if Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
-                .any(|d| cmap.beta::<2>(d) == NULL_DART_ID)
-            {
-                None
-            } else {
-                Some((
-                    v,
-                    Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
-                        .map(|d| cmap.vertex_id(cmap.beta::<2>(d)))
-                        .collect(),
-                ))
-            }
+        .map(|v| {
+            (
+                v,
+                Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
+                    .map(|d| cmap.vertex_id(cmap.beta::<1>(d)))
+                    .collect(),
+            )
         })
         .collect();
     // this can be a builtin attribute when I add a method to hijack the manager

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -5,6 +5,7 @@ use honeycomb_core::{
     prelude::CoordsFloat,
     stm::atomically,
 };
+use itertools::Itertools;
 
 use super::Color;
 
@@ -30,11 +31,20 @@ pub fn color<T: CoordsFloat>(cmap: &mut CMap2<T>) -> u8 {
             (
                 v,
                 Orbit2::new(cmap, OrbitPolicy::Vertex, v as DartIdType)
-                    .map(|d| cmap.vertex_id(cmap.beta::<1>(d)))
+                    .flat_map(|d| {
+                        [
+                            cmap.vertex_id(cmap.beta::<1>(d)),
+                            // needed when both nodes are on the boundary
+                            cmap.vertex_id(cmap.beta::<0>(d)),
+                        ]
+                        .into_iter()
+                    })
+                    .unique()
                     .collect(),
             )
         })
         .collect();
+
     // this can be a builtin attribute when I add a method to hijack the manager
     let mut colors: HashMap<VertexIdType, Color> = HashMap::with_capacity(nodes.len());
     let mut saturations: HashMap<VertexIdType, u8> =

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -14,6 +14,7 @@ use super::Color;
 /// DSATUR algorithm implementation
 ///
 /// This algorithm is a coloring algorithm similar to the greedy coloring algorithm.
+/// Its complexity is `O(n^2)`.
 ///
 /// [Reference](https://en.wikipedia.org/wiki/DSatur).
 ///

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use honeycomb_core::{
+    cmap::{CMap2, DartIdType, Orbit2, OrbitPolicy, VertexIdType, NULL_DART_ID},
+    prelude::CoordsFloat,
+};
+
+struct Color(u8);
+
+pub fn color<T: CoordsFloat>(cmap: &CMap2<T>) {
+    // build connectivity data
+    let mut vertices = cmap.fetch_vertices().identifiers.clone();
+    // this can be a builtin attribute when I add a method to hijack the manager
+    let mut colors: HashMap<VertexIdType, Color> = HashMap::with_capacity(vertices.len());
+    let mut saturations = vec![0_u8; vertices.len()];
+
+    while 
+}
+
+fn color_candidates() -> &[VertexIdType] {
+    todo!()
+}

--- a/honeycomb-kernels/src/coloring/dsatur.rs
+++ b/honeycomb-kernels/src/coloring/dsatur.rs
@@ -1,14 +1,23 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use honeycomb_core::{
-    cmap::{CMap2, DartIdType, Orbit2, OrbitPolicy, VertexIdType, NULL_DART_ID},
+    cmap::{CMap2, DartIdType, Orbit2, OrbitPolicy, VertexIdType},
     prelude::CoordsFloat,
     stm::atomically,
 };
 
 use super::Color;
 
+#[allow(clippy::missing_panics_doc)]
 /// DSATUR algorithm implementation
+///
+/// This algorithm is a coloring algorithm similar to the greedy coloring algorithm.
+///
+/// [Reference](https://en.wikipedia.org/wiki/DSatur).
+///
+/// # Return
+///
+/// The function will return the maximal used color, i.e. the `n_color_used - 1`.
 pub fn color<T: CoordsFloat>(cmap: &mut CMap2<T>) -> u8 {
     cmap.add_attribute_storage::<Color>();
 
@@ -29,7 +38,7 @@ pub fn color<T: CoordsFloat>(cmap: &mut CMap2<T>) -> u8 {
     // this can be a builtin attribute when I add a method to hijack the manager
     let mut colors: HashMap<VertexIdType, Color> = HashMap::with_capacity(nodes.len());
     let mut saturations: HashMap<VertexIdType, u8> =
-        (0..nodes.len()).map(|i| (nodes[i].0, 0)).collect();
+        (0..nodes.len()).map(|i| (nodes[i].0, 0)).collect(); // (*)
 
     // find the highest degree node to start from
     let mut cmax = 0;
@@ -39,7 +48,7 @@ pub fn color<T: CoordsFloat>(cmap: &mut CMap2<T>) -> u8 {
         let neigh_colors: Vec<Color> = neighbors
             .iter()
             .filter_map(|nghb| {
-                *saturations.get_mut(nghb).unwrap() += 1;
+                *saturations.get_mut(nghb).expect("E: unreachable") += 1; // due to (*)
                 colors.get(nghb)
             })
             .copied()

--- a/honeycomb-kernels/src/coloring/mod.rs
+++ b/honeycomb-kernels/src/coloring/mod.rs
@@ -1,0 +1,1 @@
+mod dsatur;

--- a/honeycomb-kernels/src/coloring/mod.rs
+++ b/honeycomb-kernels/src/coloring/mod.rs
@@ -8,7 +8,7 @@ mod dsatur;
 
 pub use dsatur::color as color_dsatur;
 
-// --- common content
+// ---
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color(u8);
@@ -28,3 +28,8 @@ impl AttributeBind for Color {
     type IdentifierType = VertexIdType;
     const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
 }
+
+// ---
+
+#[cfg(test)]
+mod tests;

--- a/honeycomb-kernels/src/coloring/mod.rs
+++ b/honeycomb-kernels/src/coloring/mod.rs
@@ -1,3 +1,8 @@
+//! Graph colorign algorithms
+//!
+//! This module contains all coloring algorithms we implement for N-maps. The main purpose of such
+//! algorithms is to help generate independent subsets of data for meshing algorithms to process.
+
 use honeycomb_core::{
     attributes::AttrSparseVec,
     cmap::{OrbitPolicy, VertexIdType},
@@ -10,6 +15,7 @@ pub use dsatur::color as color_dsatur;
 
 // ---
 
+/// Color attribute used to mark vertices
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color(u8);
 

--- a/honeycomb-kernels/src/coloring/mod.rs
+++ b/honeycomb-kernels/src/coloring/mod.rs
@@ -1,1 +1,30 @@
+use honeycomb_core::{
+    attributes::AttrSparseVec,
+    cmap::{OrbitPolicy, VertexIdType},
+    prelude::{AttributeBind, AttributeUpdate},
+};
+
 mod dsatur;
+
+pub use dsatur::color as color_dsatur;
+
+// --- common content
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Color(u8);
+
+impl AttributeUpdate for Color {
+    fn merge(attr1: Self, _attr2: Self) -> Self {
+        attr1
+    }
+
+    fn split(attr: Self) -> (Self, Self) {
+        (attr, attr)
+    }
+}
+
+impl AttributeBind for Color {
+    type StorageType = AttrSparseVec<Self>;
+    type IdentifierType = VertexIdType;
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
+}

--- a/honeycomb-kernels/src/coloring/tests.rs
+++ b/honeycomb-kernels/src/coloring/tests.rs
@@ -5,23 +5,54 @@ use crate::coloring::{color_dsatur, Color};
 // test many different maps for basic properties of the result
 #[test]
 fn dsatur_invariants() {
-    let mut map: CMap2<f64> = CMapBuilder::unit_grid(64).build().unwrap();
-    let colors = 0..=color_dsatur(&mut map);
-    let vertices = map.fetch_vertices().identifiers.clone();
+    {
+        let mut map: CMap2<f64> = CMapBuilder::unit_grid(64).build().unwrap();
+        let colors = 0..=color_dsatur(&mut map);
+        let vertices = map.fetch_vertices().identifiers.clone();
 
-    // all vertices are colored, colors being in (0..=cmax)
-    assert!(vertices
-        .iter()
-        .map(|id| map.force_read_attribute::<Color>(*id))
-        .all(|c| c.is_some_and(|Color(val)| colors.contains(&val))));
-    // for all vertices v, v has no neighbor with the same color
-    assert!(vertices
-        .iter()
-        .map(|id| (
-            map.force_read_attribute::<Color>(*id).unwrap(),
-            Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
-                .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
-                .unwrap())
-        ))
-        .all(|(c, mut cns)| cns.all(|cn| cn != c)));
+        // all vertices are colored, colors being in (0..=cmax)
+        assert!(vertices
+            .iter()
+            .map(|id| map.force_read_attribute::<Color>(*id))
+            .all(|c| c.is_some_and(|Color(val)| colors.contains(&val))));
+        // for all vertices v, v has no neighbor with the same color
+        assert!(vertices
+            .iter()
+            .map(|id| (
+                map.force_read_attribute::<Color>(*id).unwrap(),
+                Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
+                    .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
+                    .unwrap())
+            ))
+            .all(|(c, mut cns)| cns.all(|cn| cn != c)));
+    }
+
+    {
+        let mut map: CMap2<f64> = CMapBuilder::unit_triangles(2).build().unwrap();
+        let colors = 0..=color_dsatur(&mut map);
+        let vertices = map.fetch_vertices().identifiers.clone();
+
+        for &v in &vertices {
+            println!(
+                "Vertex {v} has color {:?}",
+                map.force_read_attribute::<Color>(v).unwrap()
+            );
+        }
+
+        // all vertices are colored, colors being in (0..=cmax)
+        assert!(vertices
+            .iter()
+            .map(|id| map.force_read_attribute::<Color>(*id))
+            .all(|c| c.is_some_and(|Color(val)| colors.contains(&val))));
+        // for all vertices v, v has no neighbor with the same color
+        assert!(vertices
+            .iter()
+            .map(|id| (
+                map.force_read_attribute::<Color>(*id).unwrap(),
+                Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
+                    .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
+                    .unwrap())
+            ))
+            .all(|(c, mut cns)| cns.all(|cn| cn != c)));
+    }
 }

--- a/honeycomb-kernels/src/coloring/tests.rs
+++ b/honeycomb-kernels/src/coloring/tests.rs
@@ -1,0 +1,27 @@
+use honeycomb_core::cmap::{CMap2, CMapBuilder, Orbit2, OrbitPolicy};
+
+use crate::coloring::{color_dsatur, Color};
+
+// test many different maps for basic properties of the result
+#[test]
+fn dsatur_invariants() {
+    let mut map: CMap2<f64> = CMapBuilder::unit_grid(64).build().unwrap();
+    let colors = 0..=color_dsatur(&mut map);
+    let vertices = map.fetch_vertices().identifiers.clone();
+
+    // all vertices are colored, colors being in (0..=cmax)
+    assert!(vertices
+        .iter()
+        .map(|id| map.force_read_attribute::<Color>(*id))
+        .all(|c| c.is_some_and(|Color(val)| colors.contains(&val))));
+    // for all vertices v, v has no neighbor with the same color
+    assert!(vertices
+        .iter()
+        .map(|id| (
+            map.force_read_attribute::<Color>(*id).unwrap(),
+            Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
+                .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
+                .unwrap())
+        ))
+        .all(|(c, mut cns)| cns.all(|cn| cn != c)));
+}

--- a/honeycomb-kernels/src/coloring/tests.rs
+++ b/honeycomb-kernels/src/coloring/tests.rs
@@ -3,6 +3,75 @@ use itertools::Itertools;
 
 use crate::coloring::{color_dsatur, Color};
 
+// same map as the triangulation tests
+// you can copy paste it into the render example to visualize it
+fn generate_map() -> CMap2<f64> {
+    let cmap: CMap2<f64> = CMapBuilder::default().n_darts(28).build().unwrap();
+
+    // topology
+    cmap.force_one_link(1, 2);
+    cmap.force_one_link(2, 3);
+    cmap.force_one_link(3, 4);
+    cmap.force_one_link(4, 5);
+    cmap.force_one_link(5, 6);
+    cmap.force_one_link(6, 1);
+
+    cmap.force_one_link(7, 8);
+    cmap.force_one_link(8, 9);
+    cmap.force_one_link(9, 10);
+    cmap.force_one_link(10, 11);
+    cmap.force_one_link(11, 12);
+    cmap.force_one_link(12, 7);
+
+    cmap.force_one_link(13, 14);
+    cmap.force_one_link(14, 15);
+    cmap.force_one_link(15, 16);
+    cmap.force_one_link(16, 13);
+
+    cmap.force_one_link(17, 18);
+    cmap.force_one_link(18, 19);
+    cmap.force_one_link(19, 20);
+    cmap.force_one_link(20, 21);
+    cmap.force_one_link(21, 22);
+    cmap.force_one_link(22, 23);
+    cmap.force_one_link(23, 24);
+    cmap.force_one_link(24, 25);
+    cmap.force_one_link(25, 17);
+
+    cmap.force_one_link(26, 27);
+    cmap.force_one_link(27, 28);
+    cmap.force_one_link(28, 26);
+
+    cmap.force_two_link(3, 7);
+    cmap.force_two_link(4, 13);
+    cmap.force_two_link(10, 27);
+    cmap.force_two_link(11, 26);
+    cmap.force_two_link(12, 14);
+    cmap.force_two_link(15, 17);
+    cmap.force_two_link(18, 28);
+
+    // geometry
+    cmap.force_write_vertex(1, (1.0, 0.0));
+    cmap.force_write_vertex(2, (2.0, 0.0));
+    cmap.force_write_vertex(3, (2.5, 0.5));
+    cmap.force_write_vertex(4, (2.0, 1.0));
+    cmap.force_write_vertex(5, (1.0, 1.0));
+    cmap.force_write_vertex(6, (0.5, 0.5));
+    cmap.force_write_vertex(9, (3.0, 1.0));
+    cmap.force_write_vertex(10, (3.0, 2.0));
+    cmap.force_write_vertex(11, (2.5, 1.0));
+    cmap.force_write_vertex(12, (2.0, 2.0));
+    cmap.force_write_vertex(16, (1.0, 2.0));
+    cmap.force_write_vertex(20, (3.0, 3.0));
+    cmap.force_write_vertex(21, (2.7, 3.0));
+    cmap.force_write_vertex(22, (2.7, 2.3));
+    cmap.force_write_vertex(23, (1.3, 2.3));
+    cmap.force_write_vertex(24, (1.3, 3.0));
+    cmap.force_write_vertex(25, (1.0, 3.0));
+
+    cmap
+}
+
 // test many different maps for basic properties of the result
 #[test]
 fn dsatur_invariants() {
@@ -38,6 +107,43 @@ fn dsatur_invariants() {
 
     {
         let mut map: CMap2<f64> = CMapBuilder::unit_triangles(8).build().unwrap();
+        let colors = 0..=color_dsatur(&mut map);
+        let vertices = map.fetch_vertices().identifiers.clone();
+
+        for &v in &vertices {
+            println!(
+                "Vertex {v} has color {:?}",
+                map.force_read_attribute::<Color>(v).unwrap()
+            );
+        }
+
+        // all vertices are colored, colors being in (0..=cmax)
+        assert!(vertices
+            .iter()
+            .map(|id| map.force_read_attribute::<Color>(*id))
+            .all(|c| c.is_some_and(|Color(val)| colors.contains(&val))));
+        // for all vertices v, v has no neighbor with the same color
+        assert!(vertices
+            .iter()
+            .map(|id| (
+                map.force_read_attribute::<Color>(*id).unwrap(),
+                Orbit2::new(&map, OrbitPolicy::Vertex, *id)
+                    .flat_map(|d| {
+                        [
+                            map.vertex_id(map.beta::<1>(d)),
+                            // needed when both nodes are on the boundary
+                            map.vertex_id(map.beta::<0>(d)),
+                        ]
+                        .into_iter()
+                    })
+                    .unique()
+                    .map(|v| map.force_read_attribute::<Color>(v).unwrap())
+            ))
+            .all(|(c, mut cns)| cns.all(|cn| cn != c)));
+    }
+
+    {
+        let mut map: CMap2<f64> = generate_map();
         let colors = 0..=color_dsatur(&mut map);
         let vertices = map.fetch_vertices().identifiers.clone();
 

--- a/honeycomb-kernels/src/coloring/tests.rs
+++ b/honeycomb-kernels/src/coloring/tests.rs
@@ -7,7 +7,7 @@ use crate::coloring::{color_dsatur, Color};
 #[test]
 fn dsatur_invariants() {
     {
-        let mut map: CMap2<f64> = CMapBuilder::unit_grid(64).build().unwrap();
+        let mut map: CMap2<f64> = CMapBuilder::unit_grid(8).build().unwrap();
         let colors = 0..=color_dsatur(&mut map);
         let vertices = map.fetch_vertices().identifiers.clone();
 
@@ -37,7 +37,7 @@ fn dsatur_invariants() {
     }
 
     {
-        let mut map: CMap2<f64> = CMapBuilder::unit_triangles(2).build().unwrap();
+        let mut map: CMap2<f64> = CMapBuilder::unit_triangles(8).build().unwrap();
         let colors = 0..=color_dsatur(&mut map);
         let vertices = map.fetch_vertices().identifiers.clone();
 

--- a/honeycomb-kernels/src/coloring/tests.rs
+++ b/honeycomb-kernels/src/coloring/tests.rs
@@ -1,4 +1,5 @@
 use honeycomb_core::cmap::{CMap2, CMapBuilder, Orbit2, OrbitPolicy};
+use itertools::Itertools;
 
 use crate::coloring::{color_dsatur, Color};
 
@@ -20,9 +21,17 @@ fn dsatur_invariants() {
             .iter()
             .map(|id| (
                 map.force_read_attribute::<Color>(*id).unwrap(),
-                Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
-                    .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
-                    .unwrap())
+                Orbit2::new(&map, OrbitPolicy::Vertex, *id)
+                    .flat_map(|d| {
+                        [
+                            map.vertex_id(map.beta::<1>(d)),
+                            // needed when both nodes are on the boundary
+                            map.vertex_id(map.beta::<0>(d)),
+                        ]
+                        .into_iter()
+                    })
+                    .unique()
+                    .map(|v| map.force_read_attribute::<Color>(v).unwrap())
             ))
             .all(|(c, mut cns)| cns.all(|cn| cn != c)));
     }
@@ -49,9 +58,17 @@ fn dsatur_invariants() {
             .iter()
             .map(|id| (
                 map.force_read_attribute::<Color>(*id).unwrap(),
-                Orbit2::new(&map, OrbitPolicy::Vertex, *id).map(|d| map
-                    .force_read_attribute::<Color>(map.vertex_id(map.beta::<1>(d)))
-                    .unwrap())
+                Orbit2::new(&map, OrbitPolicy::Vertex, *id)
+                    .flat_map(|d| {
+                        [
+                            map.vertex_id(map.beta::<1>(d)),
+                            // needed when both nodes are on the boundary
+                            map.vertex_id(map.beta::<0>(d)),
+                        ]
+                        .into_iter()
+                    })
+                    .unique()
+                    .map(|v| map.force_read_attribute::<Color>(v).unwrap())
             ))
             .all(|(c, mut cns)| cns.all(|cn| cn != c)));
     }

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -21,6 +21,7 @@
 
 // ------ MODULE DECLARATIONS
 
+pub mod coloring;
 pub mod grisubal;
 pub mod splits;
 pub mod triangulation;


### PR DESCRIPTION
### Description

**Associated issue**: closes #236 

**Content description**:

- add `add_attribute_storage` method to `CMap2` for convenience
- implement the DSATUR coloring algorithm. ref: https://fr.wikipedia.org/wiki/DSATUR. FR page has better step descriptions 

**Follow-up**

Aside from using it, I think the algorithm implementation can be modified to handle coloring on all types of I-cells, using a trait and the `enum_dispatch` crate to avoid dyn object lookup costs.
