### PR TITLE
refactor!(core): simplify transaction API

### DIFF
--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -82,31 +82,6 @@ impl<A: AttributeBind + AttributeUpdate> UnknownAttributeStorage for AttrSparseV
         out: DartIdType,
         lhs_inp: DartIdType,
         rhs_inp: DartIdType,
-    ) -> StmResult<()> {
-        let new_v = match (
-            self.data[lhs_inp as usize].read(trans)?,
-            self.data[rhs_inp as usize].read(trans)?,
-        ) {
-            (Some(v1), Some(v2)) => Ok(AttributeUpdate::merge(v1, v2)),
-            (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_incomplete(v),
-            (None, None) => AttributeUpdate::merge_from_none(),
-        };
-        if new_v.is_err() {
-            eprintln!("W: cannot merge two null attribute value");
-            eprintln!("   setting new target value to `None`");
-        }
-        self.data[rhs_inp as usize].write(trans, None)?;
-        self.data[lhs_inp as usize].write(trans, None)?;
-        self.data[out as usize].write(trans, new_v.ok())?;
-        Ok(())
-    }
-
-    fn try_merge(
-        &self,
-        trans: &mut Transaction,
-        out: DartIdType,
-        lhs_inp: DartIdType,
-        rhs_inp: DartIdType,
     ) -> CMapResult<()> {
         let new_v = match (
             self.data[lhs_inp as usize].read(trans)?,
@@ -128,31 +103,6 @@ impl<A: AttributeBind + AttributeUpdate> UnknownAttributeStorage for AttrSparseV
         lhs_out: DartIdType,
         rhs_out: DartIdType,
         inp: DartIdType,
-    ) -> StmResult<()> {
-        let res = if let Some(val) = self.data[inp as usize].read(trans)? {
-            Ok(AttributeUpdate::split(val))
-        } else {
-            AttributeUpdate::split_from_none()
-        };
-        if let Ok((lhs_val, rhs_val)) = res {
-            self.data[inp as usize].write(trans, None)?;
-            self.data[lhs_out as usize].write(trans, Some(lhs_val))?;
-            self.data[rhs_out as usize].write(trans, Some(rhs_val))?;
-        } else {
-            eprintln!("W: cannot split attribute value (not found in storage)");
-            eprintln!("   setting both new values to `None`");
-            self.data[lhs_out as usize].write(trans, None)?;
-            self.data[rhs_out as usize].write(trans, None)?;
-        }
-        Ok(())
-    }
-
-    fn try_split(
-        &self,
-        trans: &mut Transaction,
-        lhs_out: DartIdType,
-        rhs_out: DartIdType,
-        inp: DartIdType,
     ) -> CMapResult<()> {
         let (lhs_val, rhs_val) = if let Some(val) = self.data[inp as usize].read(trans)? {
             AttributeUpdate::split(val)
@@ -163,6 +113,48 @@ impl<A: AttributeBind + AttributeUpdate> UnknownAttributeStorage for AttrSparseV
         self.data[lhs_out as usize].write(trans, Some(lhs_val))?;
         self.data[rhs_out as usize].write(trans, Some(rhs_val))?;
         Ok(())
+    }
+
+    fn force_merge(&self, out: DartIdType, lhs_inp: DartIdType, rhs_inp: DartIdType) {
+        atomically(|trans| {
+            let new_v = match (
+                self.data[lhs_inp as usize].read(trans)?,
+                self.data[rhs_inp as usize].read(trans)?,
+            ) {
+                (Some(v1), Some(v2)) => Ok(AttributeUpdate::merge(v1, v2)),
+                (Some(v), None) | (None, Some(v)) => AttributeUpdate::merge_incomplete(v),
+                (None, None) => AttributeUpdate::merge_from_none(),
+            };
+            if new_v.is_err() {
+                eprintln!("W: cannot merge two null attribute value");
+                eprintln!("   setting new target value to `None`");
+            }
+            self.data[rhs_inp as usize].write(trans, None)?;
+            self.data[lhs_inp as usize].write(trans, None)?;
+            self.data[out as usize].write(trans, new_v.ok())?;
+            Ok(())
+        });
+    }
+
+    fn force_split(&self, lhs_out: DartIdType, rhs_out: DartIdType, inp: DartIdType) {
+        atomically(|trans| {
+            let res = if let Some(val) = self.data[inp as usize].read(trans)? {
+                Ok(AttributeUpdate::split(val))
+            } else {
+                AttributeUpdate::split_from_none()
+            };
+            if let Ok((lhs_val, rhs_val)) = res {
+                self.data[inp as usize].write(trans, None)?;
+                self.data[lhs_out as usize].write(trans, Some(lhs_val))?;
+                self.data[rhs_out as usize].write(trans, Some(rhs_val))?;
+            } else {
+                eprintln!("W: cannot split attribute value (not found in storage)");
+                eprintln!("   setting both new values to `None`");
+                self.data[lhs_out as usize].write(trans, None)?;
+                self.data[rhs_out as usize].write(trans, None)?;
+            }
+            Ok(())
+        });
     }
 }
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -194,6 +194,7 @@ impl AttrStorageManager {
     /// ## Generic
     ///
     /// - `A: AttributeBind` -- Attribute of which the storage should be extended.
+    #[allow(unused)]
     pub fn extend_storage<A: AttributeBind>(&mut self, length: usize) {
         get_storage_mut!(self, storage);
         if let Some(st) = storage {
@@ -218,6 +219,7 @@ impl AttrStorageManager {
     /// - there's no storage associated with the specified attribute
     /// - downcasting `Box<dyn UnknownAttributeStorage>` to `<A as AttributeBind>::StorageType` fails
     #[must_use = "unused getter result - please remove this method call"]
+    #[allow(unused)]
     pub fn get_storage<A: AttributeBind>(&self) -> Option<&<A as AttributeBind>::StorageType> {
         let probably_storage = match A::BIND_POLICY {
             OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => &self.vertices[&TypeId::of::<A>()],
@@ -258,6 +260,7 @@ impl AttrStorageManager {
     ///
     /// This variant is equivalent to `merge_attributes`, but internally uses a transaction
     /// that will be retried until validated.
+    #[allow(unused)]
     pub fn force_merge_attributes(
         &self,
         trans: &mut Transaction,
@@ -354,6 +357,7 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[allow(unused)]
     pub fn merge_attributes(
         &self,
         trans: &mut Transaction,
@@ -476,6 +480,7 @@ impl AttrStorageManager {
     ///
     /// This variant is equivalent to `merge_attribute`, but internally uses a transaction
     /// that will be retried until validated.
+    #[allow(unused)]
     pub fn force_merge_attribute<A: AttributeBind>(
         &self,
         trans: &mut Transaction,
@@ -514,6 +519,7 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[allow(unused)]
     pub fn merge_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,
@@ -543,6 +549,7 @@ impl AttrStorageManager {
     ///
     /// This variant is equivalent to `split_attributes`, but internally uses a transaction
     /// that will be retried until validated.
+    #[allow(unused)]
     pub fn force_split_attributes(
         &self,
         trans: &mut Transaction,
@@ -606,6 +613,7 @@ impl AttrStorageManager {
     ///
     /// This variant is equivalent to `split_face_attributes`, but internally uses a transaction
     /// that will be retried until validated.
+    #[allow(unused)]
     pub fn force_split_face_attributes(
         &self,
         trans: &mut Transaction,
@@ -642,6 +650,7 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[allow(unused)]
     pub fn split_attributes(
         &self,
         trans: &mut Transaction,
@@ -765,6 +774,7 @@ impl AttrStorageManager {
     ///
     /// This variant is equivalent to `split_attribute`, but internally uses a transaction
     /// that will be retried until validated.
+    #[allow(unused)]
     pub fn force_split_attribute<A: AttributeBind>(
         &self,
         trans: &mut Transaction,
@@ -803,6 +813,7 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[allow(unused)]
     pub fn split_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -260,18 +260,21 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_merge_attributes(
         &self,
+        trans: &mut Transaction,
         orbit_policy: &OrbitPolicy,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         match orbit_policy {
             OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
-                self.force_merge_vertex_attributes(id_out, id_in_lhs, id_in_rhs);
+                self.force_merge_vertex_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
-            OrbitPolicy::Edge => self.force_merge_edge_attributes(id_out, id_in_lhs, id_in_rhs),
+            OrbitPolicy::Edge => {
+                self.force_merge_edge_attributes(trans, id_out, id_in_lhs, id_in_rhs)
+            }
             OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.force_merge_face_attributes(id_out, id_in_lhs, id_in_rhs);
+                self.force_merge_face_attributes(trans, id_out, id_in_lhs, id_in_rhs)
             }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
@@ -283,13 +286,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_merge_vertex_attributes(
         &self,
+        trans: &mut Transaction,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.vertices.values() {
-            storage.force_merge(id_out, id_in_lhs, id_in_rhs);
+            storage.force_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
+        Ok(())
     }
 
     /// Execute a merging operation on all attributes associated with edges for specified cells.
@@ -298,13 +303,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_merge_edge_attributes(
         &self,
+        trans: &mut Transaction,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.edges.values() {
-            storage.force_merge(id_out, id_in_lhs, id_in_rhs);
+            storage.force_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
+        Ok(())
     }
 
     /// Execute a merging operation on all attributes associated with faces for specified cells.
@@ -313,13 +320,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_merge_face_attributes(
         &self,
+        trans: &mut Transaction,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.faces.values() {
-            storage.force_merge(id_out, id_in_lhs, id_in_rhs);
+            storage.force_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
+        Ok(())
     }
 
     // attribute-agnostic regular
@@ -469,18 +478,20 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_merge_attribute<A: AttributeBind>(
         &self,
+        trans: &mut Transaction,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         get_storage!(self, storage);
         if let Some(st) = storage {
-            st.force_merge(id_out, id_in_lhs, id_in_rhs);
+            st.force_merge(trans, id_out, id_in_lhs, id_in_rhs)
         } else {
             eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
+            Ok(())
         }
     }
 
@@ -534,18 +545,21 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_split_attributes(
         &self,
+        trans: &mut Transaction,
         orbit_policy: &OrbitPolicy,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         match orbit_policy {
             OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
-                self.force_split_vertex_attributes(id_out_lhs, id_out_rhs, id_in);
+                self.force_split_vertex_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
-            OrbitPolicy::Edge => self.force_split_edge_attributes(id_out_lhs, id_out_rhs, id_in),
+            OrbitPolicy::Edge => {
+                self.force_split_edge_attributes(trans, id_out_lhs, id_out_rhs, id_in)
+            }
             OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.force_split_face_attributes(id_out_lhs, id_out_rhs, id_in);
+                self.force_split_face_attributes(trans, id_out_lhs, id_out_rhs, id_in)
             }
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
@@ -558,13 +572,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_split_vertex_attributes(
         &self,
+        trans: &mut Transaction,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.vertices.values() {
-            storage.force_split(id_out_lhs, id_out_rhs, id_in);
+            storage.force_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
+        Ok(())
     }
 
     /// Execute a splitting operation on all attributes associated with edges
@@ -574,13 +590,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_split_edge_attributes(
         &self,
+        trans: &mut Transaction,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.edges.values() {
-            storage.force_split(id_out_lhs, id_out_rhs, id_in);
+            storage.force_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
+        Ok(())
     }
 
     /// Execute a splitting operation on all attributes associated with faces
@@ -590,13 +608,15 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_split_face_attributes(
         &self,
+        trans: &mut Transaction,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         for storage in self.faces.values() {
-            storage.force_split(id_out_lhs, id_out_rhs, id_in);
+            storage.force_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
+        Ok(())
     }
 
     // attribute-agnostic regular
@@ -747,18 +767,20 @@ impl AttrStorageManager {
     /// that will be retried until validated.
     pub fn force_split_attribute<A: AttributeBind>(
         &self,
+        trans: &mut Transaction,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) {
+    ) -> StmResult<()> {
         get_storage!(self, storage);
         if let Some(st) = storage {
-            st.force_split(id_out_lhs, id_out_rhs, id_in);
+            st.force_split(trans, id_out_lhs, id_out_rhs, id_in)
         } else {
             eprintln!(
                 "W: could not update storage of attribute {} - storage not found",
                 std::any::type_name::<A>()
             );
+            Ok(())
         }
     }
 

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -9,8 +9,9 @@ mod manager;
 mod traits;
 
 pub use collections::AttrSparseVec;
-pub use manager::AttrStorageManager;
 pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
+
+pub(crate) use manager::AttrStorageManager;
 
 // ------ TESTS
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -220,7 +220,7 @@ fn test_merge_attributes() {
     manager.force_write_attribute(1, Temperature::from(30.0));
 
     // Test merge
-    manager.force_merge_attribute::<Temperature>(2, 0, 1);
+    atomically(|trans| manager.force_merge_attribute::<Temperature>(trans, 2, 0, 1));
 
     // The exact result depends on how merge is implemented in AttributeStorage
     // Just verify that something was stored at the output location
@@ -236,7 +236,7 @@ fn test_split_attributes() {
     manager.force_write_attribute(0, Temperature::from(25.0));
 
     // Test split
-    manager.force_split_attribute::<Temperature>(1, 2, 0);
+    atomically(|trans| manager.force_split_attribute::<Temperature>(trans, 1, 2, 0));
 
     // The exact results depend on how split is implemented in AttributeStorage
     // Just verify that something was stored at both output locations
@@ -273,7 +273,7 @@ fn test_orbit_specific_merges() {
     manager.force_write_attribute(1, Temperature::from(30.0));
 
     // Test vertex-specific merge
-    manager.force_merge_vertex_attributes(2, 0, 1);
+    atomically(|trans| manager.force_merge_vertex_attributes(trans, 2, 0, 1));
 
     assert!(manager.force_read_attribute::<Temperature>(2).is_some());
 }
@@ -287,7 +287,7 @@ fn test_orbit_specific_splits() {
     manager.force_write_attribute(0, Temperature::from(25.0));
 
     // Test vertex-specific split
-    manager.force_split_vertex_attributes(1, 2, 0);
+    atomically(|trans| manager.force_split_vertex_attributes(trans, 1, 2, 0));
 
     assert!(manager.force_read_attribute::<Temperature>(1).is_some());
     assert!(manager.force_read_attribute::<Temperature>(2).is_some());
@@ -501,7 +501,7 @@ fn sparse_vec_merge() {
     assert_eq!(storage.force_read(3), Some(Temperature::from(279.0)));
     assert_eq!(storage.force_read(6), Some(Temperature::from(285.0)));
     assert_eq!(storage.force_read(8), Some(Temperature::from(289.0)));
-    storage.force_merge(8, 3, 6);
+    atomically(|trans| storage.force_merge(trans, 8, 3, 6));
     assert_eq!(storage.force_read(3), None);
     assert_eq!(storage.force_read(6), None);
     assert_eq!(storage.force_read(8), Some(Temperature::from(282.0)));
@@ -514,13 +514,13 @@ fn sparse_vec_merge_undefined() {
     assert_eq!(storage.force_remove(6), Some(Temperature::from(285.0)));
     assert_eq!(storage.force_remove(8), Some(Temperature::from(289.0)));
     // merge from two undefined value
-    storage.force_merge(8, 3, 6);
+    atomically(|trans| storage.force_merge(trans, 8, 3, 6));
     assert_eq!(storage.force_read(3), None);
     assert_eq!(storage.force_read(6), None);
     assert_eq!(storage.force_read(8), Some(Temperature::from(0.0)));
     // merge from one undefined value
     assert_eq!(storage.force_read(4), Some(Temperature::from(281.0)));
-    storage.force_merge(6, 3, 4);
+    atomically(|trans| storage.force_merge(trans, 6, 3, 4));
     assert_eq!(storage.force_read(3), None);
     assert_eq!(storage.force_read(4), None);
     assert_eq!(storage.force_read(6), Some(Temperature::from(281.0 / 2.0)));
@@ -532,7 +532,7 @@ fn sparse_vec_split() {
     assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
     assert_eq!(storage.force_remove(6), Some(Temperature::from(285.0)));
     assert_eq!(storage.force_read(8), Some(Temperature::from(289.0)));
-    storage.force_split(3, 6, 8);
+    atomically(|trans| storage.force_split(trans, 3, 6, 8));
     assert_eq!(storage.force_read(3), Some(Temperature::from(289.0)));
     assert_eq!(storage.force_read(6), Some(Temperature::from(289.0)));
     assert_eq!(storage.force_read(8), None);
@@ -686,7 +686,7 @@ fn manager_merge_attribute() {
         manager.force_read_attribute(8),
         Some(Temperature::from(289.0))
     );
-    manager.force_merge_attribute::<Temperature>(8, 3, 6);
+    atomically(|trans| manager.force_merge_attribute::<Temperature>(trans, 8, 3, 6));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
     assert_eq!(
@@ -711,7 +711,7 @@ fn manager_merge_undefined_attribute() {
         Some(Temperature::from(289.0))
     );
     // merge from two undefined value
-    manager.force_merge_attribute::<Temperature>(8, 3, 6);
+    atomically(|trans| manager.force_merge_attribute::<Temperature>(trans, 8, 3, 6));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
     assert_eq!(
@@ -723,7 +723,7 @@ fn manager_merge_undefined_attribute() {
         manager.force_read_attribute(4),
         Some(Temperature::from(281.0))
     );
-    manager.force_merge_attribute::<Temperature>(6, 3, 4);
+    atomically(|trans| manager.force_merge_attribute::<Temperature>(trans, 6, 3, 4));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(4), None);
     assert_eq!(
@@ -747,7 +747,7 @@ fn manager_split_attribute() {
         manager.force_read_attribute(8),
         Some(Temperature::from(289.0))
     );
-    manager.force_split_attribute::<Temperature>(3, 6, 8);
+    atomically(|trans| manager.force_split_attribute::<Temperature>(trans, 3, 6, 8));
     assert_eq!(
         manager.force_read_attribute(3),
         Some(Temperature::from(289.0))

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -8,7 +8,7 @@ use super::{
     UnknownAttributeStorage,
 };
 use crate::{
-    cmap::{CMapResult, EdgeIdType},
+    cmap::{CMapError, CMapResult, EdgeIdType},
     prelude::{CMap2, CMapBuilder, FaceIdType, OrbitPolicy, Vertex2, VertexIdType},
 };
 use std::any::Any;

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -8,7 +8,7 @@ use super::{
     UnknownAttributeStorage,
 };
 use crate::{
-    cmap::{CMapError, CMapResult, EdgeIdType},
+    cmap::{CMapResult, EdgeIdType},
     prelude::{CMap2, CMapBuilder, FaceIdType, OrbitPolicy, Vertex2, VertexIdType},
 };
 use std::any::Any;
@@ -310,7 +310,7 @@ fn test_merge_vertex_attributes() {
     manager.force_write_attribute(0, Temperature::from(20.0));
     manager.force_write_attribute(1, Temperature::from(30.0));
 
-    atomically(|trans| manager.merge_vertex_attributes(trans, 2, 0, 1));
+    atomically(|trans| Ok(manager.merge_vertex_attributes(trans, 2, 0, 1)?));
 
     // Verify merged result
     let merged = manager.force_read_attribute::<Temperature>(2);
@@ -325,7 +325,7 @@ fn test_split_vertex_attributes() {
     // Set initial value
     manager.force_write_attribute(0, Temperature::from(20.0));
 
-    atomically(|trans| manager.split_vertex_attributes(trans, 1, 2, 0));
+    atomically(|trans| Ok(manager.split_vertex_attributes(trans, 1, 2, 0)?));
 
     // Verify split results
     let split1 = manager.force_read_attribute::<Temperature>(1);
@@ -385,7 +385,7 @@ fn test_merge_attribute() {
     manager.force_write_attribute(0, Temperature::from(20.0));
     manager.force_write_attribute(1, Temperature::from(30.0));
 
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 2, 0, 1));
+    atomically(|trans| Ok(manager.merge_attribute::<Temperature>(trans, 2, 0, 1)?));
 
     let merged = manager.force_read_attribute::<Temperature>(2);
     assert!(merged.is_some());
@@ -399,7 +399,7 @@ fn test_split_attribute() {
     // Set initial value
     manager.force_write_attribute(0, Temperature::from(20.0));
 
-    atomically(|trans| manager.split_attribute::<Temperature>(trans, 1, 2, 0));
+    atomically(|trans| Ok(manager.split_attribute::<Temperature>(trans, 1, 2, 0)?));
 
     let split1 = manager.force_read_attribute::<Temperature>(1);
     let split2 = manager.force_read_attribute::<Temperature>(2);

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -306,14 +306,26 @@ pub trait UnknownAttributeStorage: Any + Debug + Downcast {
     /// This variant is equivalent to `merge`, but internally uses
     /// - a transaction that will be retried until validated
     /// - a fallback merge logic
-    fn force_merge(&self, out: DartIdType, lhs_inp: DartIdType, rhs_inp: DartIdType);
+    fn force_merge(
+        &self,
+        trans: &mut Transaction,
+        out: DartIdType,
+        lhs_inp: DartIdType,
+        rhs_inp: DartIdType,
+    ) -> StmResult<()>;
 
     /// Split attribute to specified indices
     ///
     /// This variant is equivalent to `split`, but internally uses
     /// - a transaction that will be retried until validated
     /// - a fallback merge logic
-    fn force_split(&self, lhs_out: DartIdType, rhs_out: DartIdType, inp: DartIdType);
+    fn force_split(
+        &self,
+        trans: &mut Transaction,
+        lhs_out: DartIdType,
+        rhs_out: DartIdType,
+        inp: DartIdType,
+    ) -> StmResult<()>;
 }
 
 impl_downcast!(UnknownAttributeStorage);

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -303,9 +303,8 @@ pub trait UnknownAttributeStorage: Any + Debug + Downcast {
 
     /// Merge attributes at specified index
     ///
-    /// This variant is equivalent to `merge`, but internally uses
-    /// - a transaction that will be retried until validated
-    /// - a fallback merge logic
+    /// This variant is equivalent to `merge`, but internally uses a fallback merge logic
+    #[allow(clippy::missing_errors_doc)]
     fn force_merge(
         &self,
         trans: &mut Transaction,
@@ -316,9 +315,8 @@ pub trait UnknownAttributeStorage: Any + Debug + Downcast {
 
     /// Split attribute to specified indices
     ///
-    /// This variant is equivalent to `split`, but internally uses
-    /// - a transaction that will be retried until validated
-    /// - a fallback merge logic
+    /// This variant is equivalent to `split`, but internally uses a fallback split logic
+    #[allow(clippy::missing_errors_doc)]
     fn force_split(
         &self,
         trans: &mut Transaction,

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -1,6 +1,6 @@
 //! 1D sew implementations
 
-use stm::{atomically, StmResult, Transaction};
+use stm::{atomically, Transaction};
 
 use crate::{
     attributes::UnknownAttributeStorage,
@@ -29,8 +29,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
+    /// This method will fail, returning an error, if:
+    /// - the transaction cannot be completed
+    /// - one (or more) attribute merge fails
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes.
     ///
     /// The policy in case of failure can be defined through the transaction, using
     /// `Transaction::with_control` for construction.
@@ -39,51 +44,6 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The method may panic if the two darts are not 1-sewable.
     pub fn one_sew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-        rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
-        let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        if b2lhs_dart_id == NULL_DART_ID {
-            self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
-        } else {
-            let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
-            let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-
-            self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-
-            let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
-
-            // FIXME: VertexIdentifier should be cast to DartIdentifier
-            self.vertices
-                .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-            self.attributes
-                .merge_vertex_attributes(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-            Ok(())
-        }
-    }
-
-    /// 1-sew two darts.
-    ///
-    /// This variant is equivalent to `one_sew`, but internally uses a transaction that will be
-    /// retried until validated.
-    pub fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.one_sew(trans, lhs_dart_id, rhs_dart_id));
-    }
-
-    /// Attempt to 1-sew two darts.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed
-    /// - one (or more) attribute merge fails
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
-    pub fn try_one_sew(
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
@@ -100,17 +60,43 @@ impl<T: CoordsFloat> CMap2<T> {
 
             let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-            // TODO: these should be attempts, only succeding if it's a full merge
             self.vertices
-                .try_merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-            self.attributes.try_merge_vertex_attributes(
-                trans,
-                new_vid,
-                b2lhs_vid_old,
-                rhs_vid_old,
-            )?;
+                .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
+            self.attributes
+                .merge_vertex_attributes(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
         }
         Ok(())
+    }
+
+    /// 1-sew two darts.
+    ///
+    /// This variant is equivalent to `one_sew`, but internally uses a transaction that will be
+    /// retried until validated.
+    pub fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
+        // FIXME: this should use force variants for attribute ops
+        atomically(|trans| {
+            let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            if b2lhs_dart_id == NULL_DART_ID {
+                self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
+            } else {
+                let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
+                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+
+                self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+
+                let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
+
+                self.vertices
+                    .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
+                self.attributes.merge_vertex_attributes(
+                    trans,
+                    new_vid,
+                    b2lhs_vid_old,
+                    rhs_vid_old,
+                )?;
+                Ok(())
+            }
+        });
     }
 }
 
@@ -134,8 +120,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
+    /// This method will fail, returning an error, if:
+    /// - the transaction cannot be completed
+    /// - one (or more) attribute merge fails
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes.
     ///
     /// The policy in case of failure can be defined through the transaction, using
     /// `Transaction::with_control` for construction.
@@ -145,7 +136,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// The method may panic if there's a missing attribute at the splitting step. While the
     /// implementation could fall back to a simple unlink operation, it probably should have been
     /// called by the user, instead of unsew, in the first place.
-    pub fn one_unsew(&self, trans: &mut Transaction, lhs_dart_id: DartIdType) -> StmResult<()> {
+    pub fn one_unsew(&self, trans: &mut Transaction, lhs_dart_id: DartIdType) -> CMapResult<()> {
         let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         if b2lhs_dart_id == NULL_DART_ID {
             self.betas.one_unlink_core(trans, lhs_dart_id)?;
@@ -156,7 +147,6 @@ impl<T: CoordsFloat> CMap2<T> {
             // update the topology
             self.betas.one_unlink_core(trans, lhs_dart_id)?;
             // split vertices & attributes from the old ID to the new ones
-            // FIXME: VertexIdentifier should be cast to DartIdentifier
             let (new_lhs, new_rhs) = (
                 self.vertex_id_transac(trans, b2lhs_dart_id)?,
                 self.vertex_id_transac(trans, rhs_dart_id)?,
@@ -173,44 +163,28 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This variant is equivalent to `one_unsew`, but internally uses a transaction that will
     /// be retried until validated.
     pub fn force_one_unsew(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.one_unsew(trans, lhs_dart_id));
-    }
-
-    /// Attempt to 1-unsew two darts.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed
-    /// - one (or more) attribute merge fails
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
-    pub fn try_one_unsew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-    ) -> CMapResult<()> {
-        let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        if b2lhs_dart_id == NULL_DART_ID {
-            self.betas.one_unlink_core(trans, lhs_dart_id)?;
-        } else {
-            // fetch IDs before topology update
-            let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-            let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-            // update the topology
-            self.betas.one_unlink_core(trans, lhs_dart_id)?;
-            // split vertices & attributes from the old ID to the new ones
-            // TODO: these should be attempts, only succeding if splitting a value
-            let (new_lhs, new_rhs) = (
-                self.vertex_id_transac(trans, b2lhs_dart_id)?,
-                self.vertex_id_transac(trans, rhs_dart_id)?,
-            );
-            self.vertices.try_split(trans, new_lhs, new_rhs, vid_old)?;
-            self.attributes
-                .try_split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
-        }
-        Ok(())
+        // FIXME: this should use force variants for attribute ops
+        atomically(|trans| {
+            let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            if b2lhs_dart_id == NULL_DART_ID {
+                self.betas.one_unlink_core(trans, lhs_dart_id)?;
+            } else {
+                // fetch IDs before topology update
+                let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+                let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                // update the topology
+                self.betas.one_unlink_core(trans, lhs_dart_id)?;
+                // split vertices & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
+                let (new_lhs, new_rhs) = (
+                    self.vertex_id_transac(trans, b2lhs_dart_id)?,
+                    self.vertex_id_transac(trans, rhs_dart_id)?,
+                );
+                self.vertices.split(trans, new_lhs, new_rhs, vid_old)?;
+                self.attributes
+                    .split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
+            }
+            Ok(())
+        });
     }
 }

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -73,7 +73,6 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This variant is equivalent to `one_sew`, but internally uses a transaction that will be
     /// retried until validated.
     pub fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        // FIXME: this should use force variants for attribute ops
         atomically(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             if b2lhs_dart_id == NULL_DART_ID {
@@ -87,8 +86,8 @@ impl<T: CoordsFloat> CMap2<T> {
                 let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
 
                 self.vertices
-                    .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-                self.attributes.merge_vertex_attributes(
+                    .force_merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
+                self.attributes.force_merge_vertex_attributes(
                     trans,
                     new_vid,
                     b2lhs_vid_old,
@@ -163,7 +162,6 @@ impl<T: CoordsFloat> CMap2<T> {
     /// This variant is equivalent to `one_unsew`, but internally uses a transaction that will
     /// be retried until validated.
     pub fn force_one_unsew(&self, lhs_dart_id: DartIdType) {
-        // FIXME: this should use force variants for attribute ops
         atomically(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             if b2lhs_dart_id == NULL_DART_ID {
@@ -180,9 +178,10 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.vertex_id_transac(trans, b2lhs_dart_id)?,
                     self.vertex_id_transac(trans, rhs_dart_id)?,
                 );
-                self.vertices.split(trans, new_lhs, new_rhs, vid_old)?;
+                self.vertices
+                    .force_split(trans, new_lhs, new_rhs, vid_old)?;
                 self.attributes
-                    .split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
+                    .force_split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
             }
             Ok(())
         });

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -70,8 +70,9 @@ impl<T: CoordsFloat> CMap2<T> {
 
     /// 1-sew two darts.
     ///
-    /// This variant is equivalent to `one_sew`, but internally uses a transaction that will be
-    /// retried until validated.
+    /// This variant is equivalent to `one_sew`, but internally uses
+    /// - a transaction that will be retried until validated
+    /// - a fallback merge logic
     pub fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
         atomically(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
@@ -159,8 +160,9 @@ impl<T: CoordsFloat> CMap2<T> {
 
     /// 1-unsew two darts.
     ///
-    /// This variant is equivalent to `one_unsew`, but internally uses a transaction that will
-    /// be retried until validated.
+    /// This variant is equivalent to `one_unsew`, but internally uses
+    /// - a transaction that will be retried until validated
+    /// - a fallback merge logic
     pub fn force_one_unsew(&self, lhs_dart_id: DartIdType) {
         atomically(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -1,6 +1,6 @@
 //! 2D sew implementations
 
-use stm::{atomically, StmResult, Transaction};
+use stm::{atomically, Transaction};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
@@ -29,8 +29,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
+    /// This method will fail, returning an error, if:
+    /// - the transaction cannot be completed
+    /// - one (or more) attribute merge fails
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes.
     ///
     /// The policy in case of failure can be defined through the transaction, using
     /// `Transaction::with_control` for construction.
@@ -46,7 +51,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> CMapResult<()> {
         let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
         let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
         // match (is lhs 1-free, is rhs 1-free)
@@ -116,11 +121,11 @@ impl<T: CoordsFloat> CMap2<T> {
                 // check orientation
                 #[rustfmt::skip]
                     if let (
-                        Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
-                        Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
+                        Ok(Some(l_vertex)), Ok(Some(b1r_vertex)), // (lhs/b1rhs) vertices
+                        Ok(Some(b1l_vertex)), Ok(Some(r_vertex)), // (b1lhs/rhs) vertices
                     ) = (
-                        self.vertices.read(trans, lhs_vid_old)?, self.vertices.read(trans, b1rhs_vid_old)?,// (lhs/b1rhs)
-                        self.vertices.read(trans, b1lhs_vid_old)?, self.vertices.read(trans, rhs_vid_old)? // (b1lhs/rhs)
+                        self.vertices.read(trans, lhs_vid_old), self.vertices.read(trans, b1rhs_vid_old),// (lhs/b1rhs)
+                        self.vertices.read(trans, b1lhs_vid_old), self.vertices.read(trans, rhs_vid_old) // (b1lhs/rhs)
                     )
                     {
                         let lhs_vector = b1l_vertex - l_vertex;
@@ -168,110 +173,92 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to `two_sew`, but internally uses a transaction that will be
     /// retried until validated.
-    pub fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.two_sew(trans, lhs_dart_id, rhs_dart_id));
-    }
-
-    /// Attempt to 2-sew two darts.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed
-    /// - one (or more) attribute merge fails
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
     #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
-    pub fn try_two_sew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-        rhs_dart_id: DartIdType,
-    ) -> CMapResult<()> {
-        let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-        let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
-        // match (is lhs 1-free, is rhs 1-free)
-        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
-            // trivial case, no update needed
-            (true, true) => {
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-            }
-            // update vertex associated to b1rhs/lhs
-            (true, false) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
-            }
-            // update vertex associated to b1lhs/rhs
-            (false, true) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
-            }
-            // update both vertices making up the edge
-            (false, false) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                // (lhs/b1rhs) vertex
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
-                // (b1lhs/rhs) vertex
-                let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+    pub fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
+        // FIXME: this should use force variants for attribute ops
+        atomically(|trans| {
+            let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+            let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
+            // match (is lhs 1-free, is rhs 1-free)
+            match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+                // trivial case, no update needed
+                (true, true) => {
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                }
+                // update vertex associated to b1rhs/lhs
+                (true, false) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
+                // update vertex associated to b1lhs/rhs
+                (false, true) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
+                // update both vertices making up the edge
+                (false, false) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    // (lhs/b1rhs) vertex
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
+                    // (b1lhs/rhs) vertex
+                    let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-                // check orientation
-                #[rustfmt::skip]
+                    // check orientation
+                    #[rustfmt::skip]
                     if let (
-                        Ok(Some(l_vertex)), Ok(Some(b1r_vertex)), // (lhs/b1rhs) vertices
-                        Ok(Some(b1l_vertex)), Ok(Some(r_vertex)), // (b1lhs/rhs) vertices
+                        Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
+                        Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
                     ) = (
-                        self.vertices.read(trans, lhs_vid_old), self.vertices.read(trans, b1rhs_vid_old),// (lhs/b1rhs)
-                        self.vertices.read(trans, b1lhs_vid_old), self.vertices.read(trans, rhs_vid_old) // (b1lhs/rhs)
+                        self.vertices.read(trans, lhs_vid_old)?, self.vertices.read(trans, b1rhs_vid_old)?,// (lhs/b1rhs)
+                        self.vertices.read(trans, b1lhs_vid_old)?, self.vertices.read(trans, rhs_vid_old)? // (b1lhs/rhs)
                     )
                     {
                         let lhs_vector = b1l_vertex - l_vertex;
@@ -286,37 +273,38 @@ impl<T: CoordsFloat> CMap2<T> {
                         );
                     };
 
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.vertices
-                    .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                    self.vertices
+                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    )?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
             }
-        }
-        Ok(())
+            Ok(())
+        });
     }
 }
 
@@ -340,8 +328,13 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
+    /// This method will fail, returning an error, if:
+    /// - the transaction cannot be completed
+    /// - one (or more) attribute merge fails
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes.
     ///
     /// The policy in case of failure can be defined through the transaction, using
     /// `Transaction::with_control` for construction.
@@ -351,7 +344,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// The method may panic if there's a missing attribute at the splitting step. While the
     /// implementation could fall back to a simple unlink operation, it probably should have been
     /// called by the user, instead of unsew, in the first place.
-    pub fn two_unsew(&self, trans: &mut Transaction, lhs_dart_id: DartIdType) -> StmResult<()> {
+    pub fn two_unsew(&self, trans: &mut Transaction, lhs_dart_id: DartIdType) -> CMapResult<()> {
         let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
         let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
@@ -363,6 +356,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 // update the topology
                 self.betas.two_unlink_core(trans, lhs_dart_id)?;
                 // split attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
                 self.attributes
                     .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
             }
@@ -373,6 +367,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 // update the topology
                 self.betas.two_unlink_core(trans, lhs_dart_id)?;
                 // split vertex & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
                 self.attributes
                     .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
                 let (new_lv_lhs, new_lv_rhs) = (
@@ -393,6 +388,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 // update the topology
                 self.betas.two_unlink_core(trans, lhs_dart_id)?;
                 // split vertex & attributes from the old ID to the new ones
+                // FIXME: VertexIdentifier should be cast to DartIdentifier
                 self.attributes
                     .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
                 let (new_rv_lhs, new_rv_rhs) = (
@@ -446,132 +442,114 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to `two_unsew`, but internally uses a transaction that will
     /// be retried until validated.
+    #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
     pub fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.two_unsew(trans, lhs_dart_id));
-    }
-
-    /// Attempt to 2-unsew two darts.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed
-    /// - one (or more) attribute merge fails
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
-    pub fn try_two_unsew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-    ) -> CMapResult<()> {
-        let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-        let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
-        // match (is lhs 1-free, is rhs 1-free)
-        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
-            (true, true) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split attributes from the old ID to the new ones
-                // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
+        // FIXME: this should use force variants for attribute ops
+        atomically(|trans| {
+            let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+            let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
+            // match (is lhs 1-free, is rhs 1-free)
+            match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+                (true, true) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                }
+                (true, false) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertex & attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_lv_lhs, new_lv_rhs) = (
+                        self.vertex_id_transac(trans, lhs_dart_id)?,
+                        self.vertex_id_transac(trans, b1rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    )?;
+                }
+                (false, true) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertex & attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_rv_lhs, new_rv_rhs) = (
+                        self.vertex_id_transac(trans, b1lhs_dart_id)?,
+                        self.vertex_id_transac(trans, rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    )?;
+                }
+                (false, false) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertices & attributes from the old ID to the new ones
+                    // FIXME: VertexIdentifier should be cast to DartIdentifier
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_lv_lhs, new_lv_rhs) = (
+                        self.vertex_id_transac(trans, lhs_dart_id)?,
+                        self.vertex_id_transac(trans, b1rhs_dart_id)?,
+                    );
+                    let (new_rv_lhs, new_rv_rhs) = (
+                        self.vertex_id_transac(trans, b1lhs_dart_id)?,
+                        self.vertex_id_transac(trans, rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    )?;
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    )?;
+                }
             }
-            (true, false) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertex & attributes from the old ID to the new ones
-                // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
-                let (new_lv_lhs, new_lv_rhs) = (
-                    self.vertex_id_transac(trans, lhs_dart_id)?,
-                    self.vertex_id_transac(trans, b1rhs_dart_id)?,
-                );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
-            }
-            (false, true) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertex & attributes from the old ID to the new ones
-                // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
-                let (new_rv_lhs, new_rv_rhs) = (
-                    self.vertex_id_transac(trans, b1lhs_dart_id)?,
-                    self.vertex_id_transac(trans, rhs_dart_id)?,
-                );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
-            }
-            (false, false) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertices & attributes from the old ID to the new ones
-                // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
-                let (new_lv_lhs, new_lv_rhs) = (
-                    self.vertex_id_transac(trans, lhs_dart_id)?,
-                    self.vertex_id_transac(trans, b1rhs_dart_id)?,
-                );
-                let (new_rv_lhs, new_rv_rhs) = (
-                    self.vertex_id_transac(trans, b1lhs_dart_id)?,
-                    self.vertex_id_transac(trans, rhs_dart_id)?,
-                );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
-            }
-        }
-        Ok(())
+            Ok(())
+        });
     }
 }

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -171,8 +171,9 @@ impl<T: CoordsFloat> CMap2<T> {
 
     /// 2-sew two darts.
     ///
-    /// This variant is equivalent to `two_sew`, but internally uses a transaction that will be
-    /// retried until validated.
+    /// This variant is equivalent to `two_sew`, but internally uses
+    /// - a transaction that will be retried until validated
+    /// - a fallback merge logic
     #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
     pub fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
         atomically(|trans| {
@@ -439,8 +440,9 @@ impl<T: CoordsFloat> CMap2<T> {
 
     /// 2-unsew two darts.
     ///
-    /// This variant is equivalent to `two_unsew`, but internally uses a transaction that will
-    /// be retried until validated.
+    /// This variant is equivalent to `two_unsew`, but internally uses
+    /// - a transaction that will be retried until validated
+    /// - a fallback merge logic
     #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
     pub fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
         atomically(|trans| {

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -175,7 +175,6 @@ impl<T: CoordsFloat> CMap2<T> {
     /// retried until validated.
     #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
     pub fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        // FIXME: this should use force variants for attribute ops
         atomically(|trans| {
             let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
             let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
@@ -198,14 +197,14 @@ impl<T: CoordsFloat> CMap2<T> {
                     let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
                     let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
                     self.vertices
-                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                    self.attributes.merge_vertex_attributes(
+                        .force_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                    self.attributes.force_merge_vertex_attributes(
                         trans,
                         lhs_vid_new,
                         lhs_vid_old,
                         b1rhs_vid_old,
                     )?;
-                    self.attributes.merge_edge_attributes(
+                    self.attributes.force_merge_edge_attributes(
                         trans,
                         eid_new,
                         lhs_eid_old,
@@ -225,14 +224,14 @@ impl<T: CoordsFloat> CMap2<T> {
                     let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
                     let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
                     self.vertices
-                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                    self.attributes.merge_vertex_attributes(
+                        .force_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.force_merge_vertex_attributes(
                         trans,
                         rhs_vid_new,
                         b1lhs_vid_old,
                         rhs_vid_old,
                     )?;
-                    self.attributes.merge_edge_attributes(
+                    self.attributes.force_merge_edge_attributes(
                         trans,
                         eid_new,
                         lhs_eid_old,
@@ -280,22 +279,22 @@ impl<T: CoordsFloat> CMap2<T> {
                     let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
                     let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
                     self.vertices
-                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                        .force_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
                     self.vertices
-                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                    self.attributes.merge_vertex_attributes(
+                        .force_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.force_merge_vertex_attributes(
                         trans,
                         lhs_vid_new,
                         lhs_vid_old,
                         b1rhs_vid_old,
                     )?;
-                    self.attributes.merge_vertex_attributes(
+                    self.attributes.force_merge_vertex_attributes(
                         trans,
                         rhs_vid_new,
                         b1lhs_vid_old,
                         rhs_vid_old,
                     )?;
-                    self.attributes.merge_edge_attributes(
+                    self.attributes.force_merge_edge_attributes(
                         trans,
                         eid_new,
                         lhs_eid_old,
@@ -444,7 +443,6 @@ impl<T: CoordsFloat> CMap2<T> {
     /// be retried until validated.
     #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
     pub fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
-        // FIXME: this should use force variants for attribute ops
         atomically(|trans| {
             let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
@@ -457,7 +455,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     // update the topology
                     self.betas.two_unlink_core(trans, lhs_dart_id)?;
                     // split attributes from the old ID to the new ones
-                    self.attributes.split_edge_attributes(
+                    self.attributes.force_split_edge_attributes(
                         trans,
                         lhs_dart_id,
                         rhs_dart_id,
@@ -471,7 +469,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     // update the topology
                     self.betas.two_unlink_core(trans, lhs_dart_id)?;
                     // split vertex & attributes from the old ID to the new ones
-                    self.attributes.split_edge_attributes(
+                    self.attributes.force_split_edge_attributes(
                         trans,
                         lhs_dart_id,
                         rhs_dart_id,
@@ -481,7 +479,7 @@ impl<T: CoordsFloat> CMap2<T> {
                         self.vertex_id_transac(trans, lhs_dart_id)?,
                         self.vertex_id_transac(trans, b1rhs_dart_id)?,
                     );
-                    self.attributes.split_vertex_attributes(
+                    self.attributes.force_split_vertex_attributes(
                         trans,
                         new_lv_lhs,
                         new_lv_rhs,
@@ -495,7 +493,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     // update the topology
                     self.betas.two_unlink_core(trans, lhs_dart_id)?;
                     // split vertex & attributes from the old ID to the new ones
-                    self.attributes.split_edge_attributes(
+                    self.attributes.force_split_edge_attributes(
                         trans,
                         lhs_dart_id,
                         rhs_dart_id,
@@ -505,7 +503,7 @@ impl<T: CoordsFloat> CMap2<T> {
                         self.vertex_id_transac(trans, b1lhs_dart_id)?,
                         self.vertex_id_transac(trans, rhs_dart_id)?,
                     );
-                    self.attributes.split_vertex_attributes(
+                    self.attributes.force_split_vertex_attributes(
                         trans,
                         new_rv_lhs,
                         new_rv_rhs,
@@ -521,7 +519,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.betas.two_unlink_core(trans, lhs_dart_id)?;
                     // split vertices & attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
-                    self.attributes.split_edge_attributes(
+                    self.attributes.force_split_edge_attributes(
                         trans,
                         lhs_dart_id,
                         rhs_dart_id,
@@ -535,13 +533,13 @@ impl<T: CoordsFloat> CMap2<T> {
                         self.vertex_id_transac(trans, b1lhs_dart_id)?,
                         self.vertex_id_transac(trans, rhs_dart_id)?,
                     );
-                    self.attributes.split_vertex_attributes(
+                    self.attributes.force_split_vertex_attributes(
                         trans,
                         new_lv_lhs,
                         new_lv_rhs,
                         lhs_vid_old,
                     )?;
-                    self.attributes.split_vertex_attributes(
+                    self.attributes.force_split_vertex_attributes(
                         trans,
                         new_rv_lhs,
                         new_rv_rhs,

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -20,9 +20,6 @@ pub enum CMapError {
     /// Geometry check failed.
     #[error("operation incompatible with map geometry: {0}")]
     IncorrectGeometry(&'static str),
-    /// No attribute value associated to specified ID.
-    #[error("missing attribute: {0}")]
-    MissingAttribute(&'static str),
     /// Accessed attribute isn't in the map storage.
     #[error("unknown attribute: {0}")]
     UnknownAttribute(&'static str),
@@ -42,8 +39,7 @@ impl From<CMapError> for StmError {
             CMapError::FailedAttributeMerge(_)
             | CMapError::FailedAttributeSplit(_)
             | CMapError::IncorrectGeometry(_)
-            | CMapError::MissingAttribute(_)
-            | CMapError::UnknownAttribute(_) => StmError::Retry,
+            | CMapError::UnknownAttribute(_) => StmError::Failure,
         }
     }
 }


### PR DESCRIPTION
### Description

**Scope**:  core 

**Type of change**: refactor 

**Content description**:

- Remove the regular variants and replace it with the `try_` variant. The latter has been renamed accordingly
- The behavior of the `force_` variant has not changed, but it is not a wrapper around the regular variant anymore: It ignores attribute-related failure and retry the transaction until complete  

### Additional information

- [x] Breaking change
