### PR TITLE
refactor!(core): update sew variants

### DIFF
--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -1,7 +1,7 @@
 mod one;
 mod two;
 
-use stm::{StmResult, Transaction};
+use stm::Transaction;
 
 use crate::{
     cmap::{CMap2, CMapResult, DartIdType},
@@ -30,22 +30,26 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method should be called in a transactional context. The `Result` is then used to
-    /// validate the transaction; It should not be processed manually. The policy in case of
-    /// failure can be defined when creating the transaction, using `Transaction::with_control`.
+    /// This variant will abort the sew operation and raise an error if:
+    /// - the transaction cannot be completed,
+    /// - one (or more) attribute merge fails,
+    /// - for `I == 2`: orientation is inconsistent.
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes (see `Transaction::with_control`).
     ///
     /// # Panics
     ///
     /// The method may panic if:
     /// - `I >= 3` or `I == 0`
-    /// - the two darts are not I-sewable,
-    /// - for `I == 2`: orientation is inconsistent.
+    /// - the two darts are not I-sewable,    
     pub fn sew<const I: u8>(
         &self,
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> StmResult<()> {
+    ) -> CMapResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -77,16 +81,20 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// # Errors
     ///
-    /// This method should be called in a transactional context. The `Result` is then used to
-    /// validate the transaction; It should not be processed manually. The policy in case of
-    /// failure can be defined when creating the transaction, using `Transaction::with_control`.
+    /// This variant will abort the unsew operation and raise an error if:
+    /// - the transaction cannot be completed,
+    /// - one (or more) attribute split fails,
+    ///
+    /// The returned error can be used in conjunction with transaction control to avoid any
+    /// modifications in case of failure at attribute level. The user can then choose, through its
+    /// transaction control policy, to retry or abort as he wishes (see `Transaction::with_control`).
     ///
     /// # Panics
     ///
     /// The method may panic if:
     /// - `I >= 3` or `I == 0`
     /// - `ld` is already `I`-free,
-    pub fn unsew<const I: u8>(&self, trans: &mut Transaction, ld: DartIdType) -> StmResult<()> {
+    pub fn unsew<const I: u8>(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -149,93 +157,6 @@ impl<T: CoordsFloat> CMap2<T> {
         match I {
             1 => self.force_one_unsew(ld),
             2 => self.force_two_unsew(ld),
-            _ => unreachable!(),
-        }
-    }
-
-    /// # `I`-sew operator.
-    ///
-    /// This variant will abort the unsew operation and raise an error if attributes cannot be
-    /// merged correctly.
-    ///
-    /// # Arguments
-    ///
-    /// - `const I: u8` -- Sew dimension.
-    /// - `trans: &mut Transaction` -- Transaction associated to the operation.
-    /// - `ld: DartIdType` -- First dart ID.
-    /// - `rd: DartIdType` -- Second dart ID.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed,
-    /// - one (or more) attribute merge fails,
-    /// - for `I == 2`: orientation is inconsistent.
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
-    ///
-    /// # Panics
-    ///
-    /// The method may panic if:
-    /// - `I >= 3` or `I == 0`
-    /// - the two darts are not I-sewable,
-    pub fn try_sew<const I: u8>(
-        &self,
-        trans: &mut Transaction,
-        ld: DartIdType,
-        rd: DartIdType,
-    ) -> CMapResult<()> {
-        // these assertions + match on a const are optimized away
-        assert!(I < 3);
-        assert_ne!(I, 0);
-        match I {
-            1 => self.try_one_sew(trans, ld, rd),
-            2 => self.try_two_sew(trans, ld, rd),
-            _ => unreachable!(),
-        }
-    }
-
-    /// # `I`-unsew operator.
-    ///
-    /// This variant will abort the unsew operation and raise an error if attributes cannot be
-    /// split correctly.
-    ///
-    /// # Arguments
-    ///
-    /// - `const I: u8` -- Unsew dimension.
-    /// - `trans: &mut Transaction` -- Transaction associated to the operation.
-    /// - `ld: DartIdType` -- First dart ID.
-    ///
-    /// The second dart ID is fetched using `I` and `ld`.
-    ///
-    /// # Errors
-    ///
-    /// This method will fail, returning an error, if:
-    /// - the transaction cannot be completed,
-    /// - one (or more) attribute split fails,
-    ///
-    /// The returned error can be used in conjunction with transaction control to avoid any
-    /// modifications in case of failure at attribute level. The user can then choose, through its
-    /// transaction control policy, to retry or abort as he wishes.
-    ///
-    /// # Panics
-    ///
-    /// The method may panic if:
-    /// - `I >= 3` or `I == 0`
-    /// - `ld` is already `I`-free,
-    pub fn try_unsew<const I: u8>(
-        &self,
-        trans: &mut Transaction,
-        ld: DartIdType,
-    ) -> CMapResult<()> {
-        // these assertions + match on a const are optimized away
-        assert!(I < 3);
-        assert_ne!(I, 0);
-        match I {
-            1 => self.try_one_unsew(trans, ld),
-            2 => self.try_two_unsew(trans, ld),
             _ => unreachable!(),
         }
     }

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, StmResult, Transaction};
+use stm::{atomically, Transaction};
 
 use crate::{
     attributes::UnknownAttributeStorage,

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -15,38 +15,6 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
-        let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        if b2lhs_dart_id == NULL_DART_ID {
-            self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
-        } else {
-            let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
-            let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-
-            self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-
-            let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
-
-            // FIXME: VertexIdentifier should be cast to DartIdentifier
-            self.vertices
-                .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-            self.attributes
-                .merge_vertex_attributes(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
-            Ok(())
-        }
-    }
-
-    /// 1-sew implementation.
-    pub(super) fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.one_sew(trans, lhs_dart_id, rhs_dart_id));
-    }
-
-    /// 1-sew defensive implementation.
-    pub(super) fn try_one_sew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-        rhs_dart_id: DartIdType,
     ) -> CMapResult<()> {
         let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         if b2lhs_dart_id == NULL_DART_ID {
@@ -59,7 +27,6 @@ impl<T: CoordsFloat> CMap2<T> {
 
             let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-            // TODO: these should be attempts, only succeding if it's a full merge
             self.vertices
                 .try_merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
             self.attributes.try_merge_vertex_attributes(
@@ -71,6 +38,33 @@ impl<T: CoordsFloat> CMap2<T> {
         }
         Ok(())
     }
+
+    /// 1-sew implementation.
+    pub(super) fn force_one_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
+        atomically(|trans| {
+            let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            if b2lhs_dart_id == NULL_DART_ID {
+                self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
+            } else {
+                let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
+                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+
+                self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+
+                let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
+
+                self.vertices
+                    .merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old)?;
+                self.attributes.merge_vertex_attributes(
+                    trans,
+                    new_vid,
+                    b2lhs_vid_old,
+                    rhs_vid_old,
+                )?;
+                Ok(())
+            }
+        });
+    }
 }
 
 #[doc(hidden)]
@@ -78,39 +72,6 @@ impl<T: CoordsFloat> CMap2<T> {
 impl<T: CoordsFloat> CMap2<T> {
     /// 1-unsew transactional implementation.
     pub(super) fn one_unsew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
-        let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        if b2lhs_dart_id == NULL_DART_ID {
-            self.betas.one_unlink_core(trans, lhs_dart_id)?;
-        } else {
-            // fetch IDs before topology update
-            let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-            let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-            // update the topology
-            self.betas.one_unlink_core(trans, lhs_dart_id)?;
-            // split vertices & attributes from the old ID to the new ones
-            // FIXME: VertexIdentifier should be cast to DartIdentifier
-            let (new_lhs, new_rhs) = (
-                self.vertex_id_transac(trans, b2lhs_dart_id)?,
-                self.vertex_id_transac(trans, rhs_dart_id)?,
-            );
-            self.vertices.split(trans, new_lhs, new_rhs, vid_old)?;
-            self.attributes
-                .split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
-        }
-        Ok(())
-    }
-
-    /// 1-unsew implementation.
-    pub(super) fn force_one_unsew(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.one_unsew(trans, lhs_dart_id));
-    }
-
-    /// 1-unsew defensive implementation.
-    pub(super) fn try_one_unsew(
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
@@ -125,7 +86,6 @@ impl<T: CoordsFloat> CMap2<T> {
             // update the topology
             self.betas.one_unlink_core(trans, lhs_dart_id)?;
             // split vertices & attributes from the old ID to the new ones
-            // TODO: these should be attempts, only succeding if splitting a value
             let (new_lhs, new_rhs) = (
                 self.vertex_id_transac(trans, b2lhs_dart_id)?,
                 self.vertex_id_transac(trans, rhs_dart_id)?,
@@ -135,5 +95,30 @@ impl<T: CoordsFloat> CMap2<T> {
                 .try_split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
         }
         Ok(())
+    }
+
+    /// 1-unsew implementation.
+    pub(super) fn force_one_unsew(&self, lhs_dart_id: DartIdType) {
+        atomically(|trans| {
+            let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            if b2lhs_dart_id == NULL_DART_ID {
+                self.betas.one_unlink_core(trans, lhs_dart_id)?;
+            } else {
+                // fetch IDs before topology update
+                let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+                let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                // update the topology
+                self.betas.one_unlink_core(trans, lhs_dart_id)?;
+                // split vertices & attributes from the old ID to the new ones
+                let (new_lhs, new_rhs) = (
+                    self.vertex_id_transac(trans, b2lhs_dart_id)?,
+                    self.vertex_id_transac(trans, rhs_dart_id)?,
+                );
+                self.vertices.split(trans, new_lhs, new_rhs, vid_old)?;
+                self.attributes
+                    .split_vertex_attributes(trans, new_lhs, new_rhs, vid_old)?;
+            }
+            Ok(())
+        });
     }
 }

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, StmResult, Transaction};
+use stm::{atomically, Transaction};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
@@ -147,6 +147,7 @@ impl<T: CoordsFloat> CMap2<T> {
     }
 
     /// 2-sew implementation.
+    #[allow(clippy::too_many_lines)]
     pub(super) fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
         atomically(|trans| {
             let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -16,136 +16,6 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
-        let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-        let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
-        // match (is lhs 1-free, is rhs 1-free)
-        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
-            // trivial case, no update needed
-            (true, true) => {
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-            }
-            // update vertex associated to b1rhs/lhs
-            (true, false) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.attributes.merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes
-                    .merge_edge_attributes(trans, eid_new, lhs_eid_old, rhs_eid_old)?;
-            }
-            // update vertex associated to b1lhs/rhs
-            (false, true) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes
-                    .merge_edge_attributes(trans, eid_new, lhs_eid_old, rhs_eid_old)?;
-            }
-            // update both vertices making up the edge
-            (false, false) => {
-                // fetch vertices ID before topology update
-                let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
-                // (lhs/b1rhs) vertex
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
-                // (b1lhs/rhs) vertex
-                let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-
-                // check orientation
-                #[rustfmt::skip]
-                    if let (
-                        Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
-                        Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
-                    ) = (
-                        self.vertices.read(trans, lhs_vid_old)?, self.vertices.read(trans, b1rhs_vid_old)?,// (lhs/b1rhs)
-                        self.vertices.read(trans, b1lhs_vid_old)?, self.vertices.read(trans, rhs_vid_old)? // (b1lhs/rhs)
-                    )
-                    {
-                        let lhs_vector = b1l_vertex - l_vertex;
-                        let rhs_vector = b1r_vertex - r_vertex;
-                        // dot product should be negative if the two darts have opposite direction
-                        // we could also put restriction on the angle made by the two darts to prevent
-                        // drastic deformation
-                        assert!(
-                            lhs_vector.dot(&rhs_vector) < T::zero(),
-                            "{}",
-                            format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
-                        );
-                    };
-
-                // update the topology
-                self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
-                // merge vertices & attributes from the old IDs to the new one
-                let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
-                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.vertices
-                    .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes.merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes
-                    .merge_edge_attributes(trans, eid_new, lhs_eid_old, rhs_eid_old)?;
-            }
-        }
-        Ok(())
-    }
-
-    /// 2-sew implementation.
-    pub(super) fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.two_sew(trans, lhs_dart_id, rhs_dart_id));
-    }
-
-    /// 2-sew defensive implementation.
-    #[allow(clippy::too_many_lines, clippy::missing_panics_doc)]
-    pub(super) fn try_two_sew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-        rhs_dart_id: DartIdType,
     ) -> CMapResult<()> {
         let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
         let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
@@ -275,6 +145,139 @@ impl<T: CoordsFloat> CMap2<T> {
         }
         Ok(())
     }
+
+    /// 2-sew implementation.
+    pub(super) fn force_two_sew(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
+        atomically(|trans| {
+            let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+            let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
+            // match (is lhs 1-free, is rhs 1-free)
+            match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+                // trivial case, no update needed
+                (true, true) => {
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                }
+                // update vertex associated to b1rhs/lhs
+                (true, false) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
+                // update vertex associated to b1lhs/rhs
+                (false, true) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
+                // update both vertices making up the edge
+                (false, false) => {
+                    // fetch vertices ID before topology update
+                    let lhs_eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_eid_old = self.edge_id_transac(trans, b1rhs_dart_id)?;
+                    // (lhs/b1rhs) vertex
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
+                    // (b1lhs/rhs) vertex
+                    let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+
+                    // check orientation
+                    #[rustfmt::skip]
+                    if let (
+                        Some(l_vertex), Some(b1r_vertex), // (lhs/b1rhs) vertices
+                        Some(b1l_vertex), Some(r_vertex), // (b1lhs/rhs) vertices
+                    ) = (
+                        self.vertices.read(trans, lhs_vid_old)?, self.vertices.read(trans, b1rhs_vid_old)?,// (lhs/b1rhs)
+                        self.vertices.read(trans, b1lhs_vid_old)?, self.vertices.read(trans, rhs_vid_old)? // (b1lhs/rhs)
+                    )
+                    {
+                        let lhs_vector = b1l_vertex - l_vertex;
+                        let rhs_vector = b1r_vertex - r_vertex;
+                        // dot product should be negative if the two darts have opposite direction
+                        // we could also put restriction on the angle made by the two darts to prevent
+                        // drastic deformation
+                        assert!(
+                            lhs_vector.dot(&rhs_vector) < T::zero(),
+                            "{}",
+                            format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
+                        );
+                    };
+
+                    // update the topology
+                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    // merge vertices & attributes from the old IDs to the new one
+                    let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                    self.vertices
+                        .merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
+                    self.vertices
+                        .merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    )?;
+                    self.attributes.merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    )?;
+                    self.attributes.merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    )?;
+                }
+            }
+            Ok(())
+        });
+    }
 }
 
 #[doc(hidden)]
@@ -282,107 +285,6 @@ impl<T: CoordsFloat> CMap2<T> {
 impl<T: CoordsFloat> CMap2<T> {
     /// 2-unsew transactional implementation.
     pub(super) fn two_unsew(
-        &self,
-        trans: &mut Transaction,
-        lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
-        let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
-        let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
-        let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
-        // match (is lhs 1-free, is rhs 1-free)
-        match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
-            (true, true) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split attributes from the old ID to the new ones
-                self.attributes
-                    .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
-            }
-            (true, false) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertex & attributes from the old ID to the new ones
-                self.attributes
-                    .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
-                let (new_lv_lhs, new_lv_rhs) = (
-                    self.vertex_id_transac(trans, lhs_dart_id)?,
-                    self.vertex_id_transac(trans, b1rhs_dart_id)?,
-                );
-                self.attributes.split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
-            }
-            (false, true) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertex & attributes from the old ID to the new ones
-                self.attributes
-                    .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
-                let (new_rv_lhs, new_rv_rhs) = (
-                    self.vertex_id_transac(trans, b1lhs_dart_id)?,
-                    self.vertex_id_transac(trans, rhs_dart_id)?,
-                );
-                self.attributes.split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
-            }
-            (false, false) => {
-                // fetch IDs before topology update
-                let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
-                let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
-                let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
-                // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
-                // split vertices & attributes from the old ID to the new ones
-                // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes
-                    .split_edge_attributes(trans, lhs_dart_id, rhs_dart_id, eid_old)?;
-                let (new_lv_lhs, new_lv_rhs) = (
-                    self.vertex_id_transac(trans, lhs_dart_id)?,
-                    self.vertex_id_transac(trans, b1rhs_dart_id)?,
-                );
-                let (new_rv_lhs, new_rv_rhs) = (
-                    self.vertex_id_transac(trans, b1lhs_dart_id)?,
-                    self.vertex_id_transac(trans, rhs_dart_id)?,
-                );
-                self.attributes.split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
-                self.attributes.split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
-            }
-        }
-        Ok(())
-    }
-
-    /// 2-unsew implementation.
-    pub(super) fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.two_unsew(trans, lhs_dart_id));
-    }
-
-    /// 2-unsew defensive implementation.
-    pub(super) fn try_two_unsew(
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
@@ -494,5 +396,115 @@ impl<T: CoordsFloat> CMap2<T> {
             }
         }
         Ok(())
+    }
+
+    /// 2-unsew implementation.
+    pub(super) fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
+        atomically(|trans| {
+            let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
+            let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
+            let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
+            // match (is lhs 1-free, is rhs 1-free)
+            match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
+                (true, true) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                }
+                (true, false) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertex & attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_lv_lhs, new_lv_rhs) = (
+                        self.vertex_id_transac(trans, lhs_dart_id)?,
+                        self.vertex_id_transac(trans, b1rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    )?;
+                }
+                (false, true) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertex & attributes from the old ID to the new ones
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_rv_lhs, new_rv_rhs) = (
+                        self.vertex_id_transac(trans, b1lhs_dart_id)?,
+                        self.vertex_id_transac(trans, rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    )?;
+                }
+                (false, false) => {
+                    // fetch IDs before topology update
+                    let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
+                    let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
+                    let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
+                    // update the topology
+                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    // split vertices & attributes from the old ID to the new ones
+                    // FIXME: VertexIdentifier should be cast to DartIdentifier
+                    self.attributes.split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    )?;
+                    let (new_lv_lhs, new_lv_rhs) = (
+                        self.vertex_id_transac(trans, lhs_dart_id)?,
+                        self.vertex_id_transac(trans, b1rhs_dart_id)?,
+                    );
+                    let (new_rv_lhs, new_rv_rhs) = (
+                        self.vertex_id_transac(trans, b1lhs_dart_id)?,
+                        self.vertex_id_transac(trans, rhs_dart_id)?,
+                    );
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    )?;
+                    self.attributes.split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    )?;
+                }
+            }
+            Ok(())
+        });
     }
 }


### PR DESCRIPTION
### Description

**Content description**:

replaces #247, without the `StmError` to `CMapError` auto-coercion. from the old PR:

- Remove the regular variants and replace it with the `try_` variant. The latter has been renamed accordingly
- The behavior of the `force_` variant has not changed, but it is not a wrapper around the regular variant anymore: It ignores attribute-related failure and retry the transaction until complete  

### Additional information

- [x] Breaking change

