### PR TITLE
refactor(core): remove dead code from `AttributeStorageManager`

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -54,7 +54,6 @@ macro_rules! get_storage_mut {
     };
 }
 
-// TODO: make the structure private & remove unused methods
 /// Main attribute storage structure.
 ///
 /// **This structure is not meant to be used directly**.
@@ -113,7 +112,7 @@ macro_rules! get_storage_mut {
 /// }
 /// ```
 #[derive(Default)]
-pub struct AttrStorageManager {
+pub(crate) struct AttrStorageManager {
     /// Vertex attributes' storages.
     vertices: HashMap<TypeId, Box<dyn UnknownAttributeStorage>>,
     /// Edge attributes' storages.

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -35,6 +35,26 @@ macro_rules! get_storage {
     };
 }
 
+#[cfg(test)]
+macro_rules! get_storage_mut {
+    ($slf: ident, $id: ident) => {
+        let probably_storage = match A::BIND_POLICY {
+            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
+                $slf.vertices.get_mut(&TypeId::of::<A>())
+            }
+            OrbitPolicy::Edge => $slf.edges.get_mut(&TypeId::of::<A>()),
+            OrbitPolicy::Face | OrbitPolicy::FaceLinear => $slf.faces.get_mut(&TypeId::of::<A>()),
+            OrbitPolicy::Volume | OrbitPolicy::VolumeLinear => {
+                $slf.volumes.get_mut(&TypeId::of::<A>())
+            }
+            OrbitPolicy::Custom(_) => $slf.others.get_mut(&TypeId::of::<A>()),
+        };
+        let $id = probably_storage
+            .map(|m| m.downcast_mut::<<A as AttributeBind>::StorageType>())
+            .flatten();
+    };
+}
+
 /// Main attribute storage structure.
 ///
 /// **This structure is not meant to be used directly**.
@@ -177,7 +197,7 @@ impl AttrStorageManager {
         }
     }
 
-    /*
+    #[cfg(test)]
     /// Extend the size of the storage of a given attribute.
     ///
     /// # Arguments
@@ -208,6 +228,7 @@ impl AttrStorageManager {
     /// This method may panic if:
     /// - there's no storage associated with the specified attribute
     /// - downcasting `Box<dyn UnknownAttributeStorage>` to `<A as AttributeBind>::StorageType` fails
+    #[cfg(test)]
     #[must_use = "unused return value"]
     pub fn get_storage<A: AttributeBind>(&self) -> Option<&<A as AttributeBind>::StorageType> {
         let probably_storage = match A::BIND_POLICY {
@@ -219,7 +240,6 @@ impl AttrStorageManager {
         };
         probably_storage.downcast_ref::<<A as AttributeBind>::StorageType>()
     }
-    */
 
     /// Remove an entire attribute storage from the manager.
     ///

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -269,6 +269,7 @@ impl AttrStorageManager {
 impl AttrStorageManager {
     // attribute-agnostic regular
 
+    /*
     #[allow(clippy::missing_errors_doc)]
     /// Execute a merging operation on all attributes associated with a given orbit
     /// for specified cells.
@@ -307,6 +308,7 @@ impl AttrStorageManager {
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
+    */
 
     #[allow(clippy::missing_errors_doc)]
     /// Execute a merging operation on all attributes associated with vertices for specified cells.
@@ -389,6 +391,7 @@ impl AttrStorageManager {
         Ok(())
     }
 
+    /*
     #[allow(clippy::missing_errors_doc)]
     /// Execute a merging operation on all attributes associated with volumes for specified cells.
     ///
@@ -415,9 +418,11 @@ impl AttrStorageManager {
         }
         Ok(())
     }
+    */
 
     // attribute-agnostic try
 
+    /*
     /// Execute a merging operation on all attributes associated with a given orbit
     /// for specified cells.
     ///
@@ -454,6 +459,7 @@ impl AttrStorageManager {
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
+    */
 
     /// Execute a merging operation on all attributes associated with vertices for specified cells.
     ///
@@ -527,6 +533,7 @@ impl AttrStorageManager {
         Ok(())
     }
 
+    /*
     /// Execute a merging operation on all attributes associated with volumes for specified cells.
     ///
     /// # Errors
@@ -550,6 +557,7 @@ impl AttrStorageManager {
         }
         Ok(())
     }
+    */
 
     // attribute-specific
 
@@ -567,6 +575,7 @@ impl AttrStorageManager {
     ///
     /// This method is meant to be called in a context where the returned `Result` is used to
     /// validate the transaction passed as argument. The result should not be processed manually.
+    #[cfg(test)]
     pub fn merge_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,
@@ -586,6 +595,7 @@ impl AttrStorageManager {
         }
     }
 
+    /*
     /// Merge given attribute values.
     ///
     /// # Errors
@@ -615,12 +625,14 @@ impl AttrStorageManager {
             Ok(())
         }
     }
+    */
 }
 
 /// Split variants.
 impl AttrStorageManager {
     // attribute-agnostic regular
 
+    /*
     #[allow(clippy::missing_errors_doc)]
     /// Execute a splitting operation on all attributes associated with a given orbit
     /// for specified cells.
@@ -659,6 +671,7 @@ impl AttrStorageManager {
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
+    */
 
     #[allow(clippy::missing_errors_doc)]
     /// Execute a splitting operation on all attributes associated with vertices
@@ -742,6 +755,7 @@ impl AttrStorageManager {
         Ok(())
     }
 
+    /*
     #[allow(clippy::missing_errors_doc)]
     /// Execute a splitting operation on all attributes associated with volumes for specified cells.
     ///
@@ -768,9 +782,11 @@ impl AttrStorageManager {
         }
         Ok(())
     }
+    */
 
     // attribute-agnostic try
 
+    /*
     /// Execute a splitting operation on all attributes associated with a given orbit
     /// for specified cells.
     ///
@@ -807,6 +823,7 @@ impl AttrStorageManager {
             OrbitPolicy::Custom(_) => unimplemented!(),
         }
     }
+    */
 
     /// Execute a splitting operation on all attributes associated with vertices for specified cells.
     ///
@@ -880,6 +897,7 @@ impl AttrStorageManager {
         Ok(())
     }
 
+    /*
     /// Execute a splitting operation on all attributes associated with volumes for specified cells.
     ///
     /// # Errors
@@ -903,6 +921,7 @@ impl AttrStorageManager {
         }
         Ok(())
     }
+    */
 
     // attribute-specific
 
@@ -920,6 +939,7 @@ impl AttrStorageManager {
     ///
     /// This method is meant to be called in a context where the returned `Result` is used to
     /// validate the transaction passed as argument. The result should not be processed manually.
+    #[cfg(test)]
     pub fn split_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,
@@ -939,6 +959,7 @@ impl AttrStorageManager {
         }
     }
 
+    /*
     /// Split given attribute value.
     ///
     /// # Errors
@@ -968,6 +989,7 @@ impl AttrStorageManager {
             Ok(())
         }
     }
+    */
 }
 
 /// **Attribute read & write methods**

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -7,8 +7,9 @@ mod manager;
 mod traits;
 
 pub use collections::AttrSparseVec;
-pub use manager::AttrStorageManager;
 pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
+
+pub(crate) use manager::AttrStorageManager;
 
 // ------ TESTS
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -220,7 +220,7 @@ fn test_merge_attributes() {
     manager.force_write_attribute(1, Temperature::from(30.0));
 
     // Test merge
-    manager.force_merge_attribute::<Temperature>(2, 0, 1);
+    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 2, 0, 1));
 
     // The exact result depends on how merge is implemented in AttributeStorage
     // Just verify that something was stored at the output location
@@ -236,7 +236,7 @@ fn test_split_attributes() {
     manager.force_write_attribute(0, Temperature::from(25.0));
 
     // Test split
-    manager.force_split_attribute::<Temperature>(1, 2, 0);
+    atomically(|trans| manager.split_attribute::<Temperature>(trans, 1, 2, 0));
 
     // The exact results depend on how split is implemented in AttributeStorage
     // Just verify that something was stored at both output locations
@@ -273,7 +273,7 @@ fn test_orbit_specific_merges() {
     manager.force_write_attribute(1, Temperature::from(30.0));
 
     // Test vertex-specific merge
-    manager.force_merge_vertex_attributes(2, 0, 1);
+    atomically(|trans| manager.merge_vertex_attributes(trans, 2, 0, 1));
 
     assert!(manager.force_read_attribute::<Temperature>(2).is_some());
 }
@@ -287,7 +287,7 @@ fn test_orbit_specific_splits() {
     manager.force_write_attribute(0, Temperature::from(25.0));
 
     // Test vertex-specific split
-    manager.force_split_vertex_attributes(1, 2, 0);
+    atomically(|trans| manager.split_vertex_attributes(trans, 1, 2, 0));
 
     assert!(manager.force_read_attribute::<Temperature>(1).is_some());
     assert!(manager.force_read_attribute::<Temperature>(2).is_some());
@@ -686,7 +686,7 @@ fn manager_merge_attribute() {
         manager.force_read_attribute(8),
         Some(Temperature::from(289.0))
     );
-    manager.force_merge_attribute::<Temperature>(8, 3, 6);
+    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 8, 3, 6));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
     assert_eq!(
@@ -711,7 +711,7 @@ fn manager_merge_undefined_attribute() {
         Some(Temperature::from(289.0))
     );
     // merge from two undefined value
-    manager.force_merge_attribute::<Temperature>(8, 3, 6);
+    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 8, 3, 6));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
     assert_eq!(
@@ -723,7 +723,7 @@ fn manager_merge_undefined_attribute() {
         manager.force_read_attribute(4),
         Some(Temperature::from(281.0))
     );
-    manager.force_merge_attribute::<Temperature>(6, 3, 4);
+    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 6, 3, 4));
     assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
     assert_eq!(manager.force_read_attribute::<Temperature>(4), None);
     assert_eq!(
@@ -747,7 +747,7 @@ fn manager_split_attribute() {
         manager.force_read_attribute(8),
         Some(Temperature::from(289.0))
     );
-    manager.force_split_attribute::<Temperature>(3, 6, 8);
+    atomically(|trans| manager.split_attribute::<Temperature>(trans, 3, 6, 8));
     assert_eq!(
         manager.force_read_attribute(3),
         Some(Temperature::from(289.0))


### PR DESCRIPTION
### Description

**Scope**:  core

**Type of change**: refactor

**Content description**:

- make `AttributeStorageManager` only visible in the crate
- remove all of its `force_` variants
- comment out the rest of the unused methods

### Additional information

- [x] Breaking change: technically breaking since I remove `AttributeStorageManager` from the public API. It shouldn't be used as a standalone anyway

