### PR TITLE
feat(benches): add two new binaries to benchmark scaling

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -18,6 +18,7 @@ _single_precision = []
 cfg-if.workspace = true
 honeycomb.workspace = true
 rayon.workspace = true
+rand = { workspace = true, features = ["small_rng"] }
 
 [dev-dependencies]
 honeycomb-core.workspace = true
@@ -30,6 +31,11 @@ rand = { workspace = true, features = ["small_rng"] }
 [[bin]]
 name = "builder"
 path = "src/builder.rs"
+doc = false
+
+[[bin]]
+name = "grid-random-split"
+path = "src/grid_random_split.rs"
 doc = false
 
 [[bin]]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -34,6 +34,11 @@ path = "src/builder.rs"
 doc = false
 
 [[bin]]
+name = "cut-edges"
+path = "src/cut_edges.rs"
+doc = false
+
+[[bin]]
 name = "grid-random-split"
 path = "src/grid_random_split.rs"
 doc = false

--- a/benches/src/cut_edges.rs
+++ b/benches/src/cut_edges.rs
@@ -1,0 +1,103 @@
+use std::time::Instant;
+
+use honeycomb::prelude::{
+    splits::split_edge_noalloc, CMap2, CMapBuilder, CoordsFloat, DartIdType, EdgeIdType,
+};
+
+use honeycomb_core::stm::atomically;
+use rayon::prelude::*;
+
+const INPUT_MAP: &str = "grid_split.vtk";
+const TARGET_LENGTH: f64 = 0.1;
+
+fn fetch_edges_to_process<'a, 'b, T: CoordsFloat>(
+    map: &'a CMap2<T>,
+    length: &'b T,
+) -> impl Iterator<Item = EdgeIdType> + 'a
+where
+    'b: 'a,
+{
+    map.iter_edges().filter(|&e| {
+        let (vid1, vid2) = (
+            map.vertex_id(e as DartIdType),
+            map.vertex_id(map.beta::<1>(e as DartIdType)),
+        );
+        let (v1, v2) = (
+            map.force_read_vertex(vid1).unwrap(),
+            map.force_read_vertex(vid2).unwrap(),
+        );
+
+        (v2 - v1).norm() > *length
+    })
+}
+
+fn main() {
+    let mut instant = Instant::now();
+    // load map from file
+    let mut map: CMap2<f64> = CMapBuilder::from(INPUT_MAP).build().unwrap();
+    println!("map loaded in {}ms", instant.elapsed().as_millis());
+
+    instant = Instant::now();
+    // compute first batch
+    let mut edges: Vec<EdgeIdType> = fetch_edges_to_process(&map, &TARGET_LENGTH).collect();
+    let mut nd = map.add_free_darts(6 * edges.len()); // 2 for edge split + 2*2 for new edges in neighbor tets
+    let mut darts: Vec<DartIdType> = (nd..nd + 6 * edges.len() as DartIdType).collect();
+    println!(
+        "first batch computed in {}ms",
+        instant.elapsed().as_millis()
+    );
+
+    while !edges.is_empty() {
+        instant = Instant::now();
+        // process edges in parallel with transactions
+        edges
+            .par_drain(..)
+            .zip(darts.par_chunks(6))
+            .for_each(|(e, sl)| {
+                // we can read invariants outside of the transaction
+                let &[nd1, nd2, nd3, nd4, nd5, nd6] = sl else {
+                    unreachable!()
+                };
+                let (ld, rd) = (e as DartIdType, map.beta::<2>(e as DartIdType));
+
+                atomically(|trans| {
+                    // adding a b0 read helps with conflict detection
+                    let (_b0ld, b1ld) = (
+                        map.beta_transac::<0>(trans, ld)?,
+                        map.beta_transac::<1>(trans, ld)?,
+                    );
+                    let (_b0rd, b1rd) = (
+                        map.beta_transac::<0>(trans, rd)?,
+                        map.beta_transac::<1>(trans, rd)?,
+                    );
+
+                    // split_edge_noalloc(&map, e, (nd1, nd2), None);
+
+                    // left side tet
+                    map.unlink::<1>(trans, ld)?;
+                    map.unlink::<1>(trans, b1ld)?;
+                    map.link::<2>(trans, nd3, nd4)?;
+                    map.link::<1>(trans, ld, nd4)?;
+                    map.link::<1>(trans, nd4, nd2)?;
+                    // right side tet
+                    map.unlink::<1>(trans, rd)?;
+                    map.unlink::<1>(trans, b1rd)?;
+                    map.link::<2>(trans, nd5, nd6)?;
+                    map.link::<1>(trans, rd, nd6)?;
+                    map.link::<1>(trans, nd5, nd1)?;
+
+                    Ok(())
+                });
+            });
+        println!("batch processed in {}ms", instant.elapsed().as_millis());
+
+        instant = Instant::now();
+        // update the edge list
+        edges.extend(fetch_edges_to_process(&map, &TARGET_LENGTH));
+        // allocate necessary darts
+        nd = map.add_free_darts(6 * edges.len());
+        darts.par_drain(..); // is there a better way?
+        darts.extend(nd..nd + 6 * edges.len() as DartIdType);
+        println!("new batch computed in {}ms", instant.elapsed().as_millis());
+    }
+}

--- a/benches/src/grid_random_split.rs
+++ b/benches/src/grid_random_split.rs
@@ -1,0 +1,105 @@
+use std::{fs::File, time::Instant};
+
+use honeycomb::{
+    core::{
+        cmap::CMapError,
+        stm::{atomically, StmError},
+    },
+    prelude::{CMap2, CMapBuilder, DartIdType, Orbit2, OrbitPolicy},
+};
+
+use rand::{
+    distr::{Bernoulli, Distribution},
+    rngs::SmallRng,
+    SeedableRng,
+};
+
+use rayon::prelude::*;
+
+macro_rules! process_unsew {
+    ($op: expr) => {
+        if let Err(e) = $op {
+            return match e {
+                CMapError::FailedTransaction(e) => Err(e),
+                CMapError::FailedAttributeSplit(_) => Err(StmError::Retry),
+                CMapError::FailedAttributeMerge(_)
+                | CMapError::IncorrectGeometry(_)
+                | CMapError::UnknownAttribute(_) => unreachable!(),
+            };
+        }
+    };
+}
+
+macro_rules! process_sew {
+    ($op: expr) => {
+        if let Err(e) = $op {
+            return match e {
+                CMapError::FailedTransaction(e) => Err(e),
+                CMapError::FailedAttributeMerge(_) => Err(StmError::Retry),
+                CMapError::FailedAttributeSplit(_)
+                | CMapError::IncorrectGeometry(_)
+                | CMapError::UnknownAttribute(_) => unreachable!(),
+            };
+        }
+    };
+}
+const N_SQUARE: usize = 1024;
+const N_DIAG: usize = N_SQUARE.pow(2);
+const P_BERNOULLI: f64 = 0.6;
+const SEED: u64 = 9_817_498_146_784;
+
+fn main() {
+    let mut instant = Instant::now();
+    // (a) generate the grid
+    let mut map: CMap2<f64> = CMapBuilder::unit_grid(N_SQUARE).build().unwrap();
+    // collect these now so additional darts don't mess up the iterator
+    let faces = map.iter_faces().collect::<Vec<_>>();
+
+    // (b) split diagonals one way or the other
+    // sample diag orientation
+    let rng = SmallRng::seed_from_u64(SEED);
+    let dist = Bernoulli::new(P_BERNOULLI).unwrap();
+    let splits: Vec<bool> = dist.sample_iter(rng).take(N_DIAG).collect();
+    // allocate diag darts
+    let nd = map.add_free_darts(N_DIAG * 2);
+    let nd_range = (nd..nd + (N_DIAG * 2) as DartIdType).collect::<Vec<_>>();
+
+    instant = Instant::now();
+    // build diags
+    faces
+        .into_iter()
+        .zip(nd_range.chunks(2))
+        .zip(splits.into_iter())
+        .par_bridge()
+        .for_each(|((df, sl), split)| {
+            let square = df as DartIdType;
+            assert_eq!(Orbit2::new(&map, OrbitPolicy::FaceLinear, df).count(), 4);
+            let (ddown, dright, dup, dleft) = (square, square + 1, square + 2, square + 3);
+
+            let &[dsplit1, dsplit2] = sl else {
+                unreachable!()
+            };
+            let (dbefore1, dbefore2, dafter1, dafter2) = if split {
+                (ddown, dup, dleft, dright)
+            } else {
+                (dright, dleft, ddown, dup)
+            };
+            map.force_link::<2>(dsplit1, dsplit2);
+
+            atomically(|trans| {
+                process_unsew!(map.unsew::<1>(trans, dbefore1));
+                process_unsew!(map.unsew::<1>(trans, dbefore2));
+                process_sew!(map.sew::<1>(trans, dsplit1, dafter1));
+                process_sew!(map.sew::<1>(trans, dsplit2, dafter2));
+
+                process_sew!(map.sew::<1>(trans, dbefore1, dsplit1));
+                process_sew!(map.sew::<1>(trans, dbefore2, dsplit2));
+                Ok(())
+            });
+        });
+    println!("split diags in {}ms", instant.elapsed().as_millis());
+
+    // (c) save the map
+    let mut f = File::create("grid_split.vtk").unwrap();
+    map.to_vtk_binary(&mut f);
+}

--- a/benches/src/grid_random_split.rs
+++ b/benches/src/grid_random_split.rs
@@ -54,6 +54,7 @@ fn main() {
     let mut map: CMap2<f64> = CMapBuilder::unit_grid(N_SQUARE).build().unwrap();
     // collect these now so additional darts don't mess up the iterator
     let faces = map.iter_faces().collect::<Vec<_>>();
+    println!("grid built in {}ms", instant.elapsed().as_millis());
 
     // (b) split diagonals one way or the other
     // sample diag orientation
@@ -97,9 +98,11 @@ fn main() {
                 Ok(())
             });
         });
-    println!("split diags in {}ms", instant.elapsed().as_millis());
+    println!("diagonals split in {}ms", instant.elapsed().as_millis());
 
+    instant = Instant::now();
     // (c) save the map
     let mut f = File::create("grid_split.vtk").unwrap();
     map.to_vtk_binary(&mut f);
+    println!("map saved in {}ms", instant.elapsed().as_millis());
 }


### PR DESCRIPTION
### Description

**Scope**:  benches

**Type of change**: feat

**Content description**:
- add the `grid-random-split` binary. it generates a fixed size unit grid with each square cell having a diagonal split, the direction being random. the map is saved as a legacy VTK binary file
- add the `cut-edges` binary. it loads a a map from a VTK file, and divide its cells iteratively until a target edge size is reached. the input mesh is assumed to be a triangle mesh, we guarantee that each intermediate step and final result are as well