### PR TITLE
refactor(core): improve `iter_<CELLS>` methods

### DIFF
--- a/honeycomb-core/src/cmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/basic_ops.rs
@@ -13,7 +13,6 @@ use crate::prelude::{
     CMap2, DartIdType, EdgeIdType, FaceIdType, Orbit2, OrbitPolicy, VertexIdType, NULL_DART_ID,
 };
 use crate::{attributes::UnknownAttributeStorage, geometry::CoordsFloat};
-use itertools::Itertools;
 use stm::{atomically, StmResult, Transaction};
 
 // ------ CONTENT
@@ -366,14 +365,23 @@ impl<T: CoordsFloat> CMap2<T> {
     pub fn iter_vertices(&self) -> impl Iterator<Item = VertexIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let vid = self.vertex_id(d);
+                if d == vid {
+                    Some(vid)
                 } else {
-                    Some(self.vertex_id(d))
+                    None
                 }
             })
-            .unique()
     }
 
     /// Return an iterator over IDs of all the map's edges.
@@ -381,14 +389,23 @@ impl<T: CoordsFloat> CMap2<T> {
     pub fn iter_edges(&self) -> impl Iterator<Item = EdgeIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let eid = self.edge_id(d);
+                if d == eid {
+                    Some(eid)
                 } else {
-                    Some(self.edge_id(d))
+                    None
                 }
             })
-            .unique()
     }
 
     /// Return an iterator over IDs of all the map's faces.
@@ -396,13 +413,22 @@ impl<T: CoordsFloat> CMap2<T> {
     pub fn iter_faces(&self) -> impl Iterator<Item = FaceIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let fid = self.face_id(d);
+                if d == fid {
+                    Some(fid)
                 } else {
-                    Some(self.face_id(d))
+                    None
                 }
             })
-            .unique()
     }
 }

--- a/honeycomb-core/src/cmap/dim3/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim3/basic_ops.rs
@@ -9,7 +9,6 @@
 
 // ------ IMPORTS
 
-use itertools::Itertools;
 use std::collections::{HashSet, VecDeque};
 use stm::{atomically, StmError, StmResult, Transaction};
 
@@ -541,55 +540,91 @@ impl<T: CoordsFloat> CMap3<T> {
     pub fn iter_vertices(&self) -> impl Iterator<Item = VertexIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let vid = self.vertex_id(d);
+                if d == vid {
+                    Some(vid)
                 } else {
-                    Some(self.vertex_id(d))
+                    None
                 }
             })
-            .unique()
     }
 
     /// Return an iterator over IDs of all the map's edges.
     pub fn iter_edges(&self) -> impl Iterator<Item = EdgeIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let eid = self.edge_id(d);
+                if d == eid {
+                    Some(eid)
                 } else {
-                    Some(self.edge_id(d))
+                    None
                 }
             })
-            .unique()
     }
 
     /// Return an iterator over IDs of all the map's faces.
     pub fn iter_faces(&self) -> impl Iterator<Item = FaceIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let fid = self.face_id(d);
+                if d == fid {
+                    Some(fid)
                 } else {
-                    Some(self.face_id(d))
+                    None
                 }
             })
-            .unique()
     }
 
     /// Return an iterator over IDs of all the map's volumes.
     pub fn iter_volumes(&self) -> impl Iterator<Item = VolumeIdType> + '_ {
         (1..self.n_darts() as DartIdType)
             .zip(self.unused_darts.iter().skip(1))
-            .filter_map(|(d, unused)| {
-                if unused.read_atomic() {
-                    None
+            .filter_map(
+                |(d, unused)| {
+                    if unused.read_atomic() {
+                        None
+                    } else {
+                        Some(d)
+                    }
+                },
+            )
+            .filter_map(|d| {
+                let vid = self.volume_id(d);
+                if d == vid {
+                    Some(vid)
                 } else {
-                    Some(self.volume_id(d))
+                    None
                 }
             })
-            .unique()
     }
 }


### PR DESCRIPTION
### Description

**Scope**:  core

**Type of change**: refactor

**Content description**:

remove the usage of `.unique()` from itertools by using dart properties to filter values. this was motivted by the fact that `.unique()` allocates a Set to perform its task, while this solution uses no additional allocation.

exec time is reduced by 3 / 30 / 8 % for cells of dimension 0 / 1 / 2
