### PR TITLE
refactor!: rework basic operation errors and checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "2.0.11"
 downcast-rs = "2.0.1"
 loom = "0.7.2"
 num-traits = "0.2.19"
-fast-stm = { git = "https://github.com/imrn99/fast-stm", rev = "6433107819957a620a3e19be8fc1555280e18d3c" }
+fast-stm = { git = "https://github.com/imrn99/fast-stm", rev = "0622c44a59d69417914faded2b7d2f967ac53727" }
 vtkio = { version = "0.7.0-rc1", default-features = false }
 
 # benchmarks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "2.0.11"
 downcast-rs = "2.0.1"
 loom = "0.7.2"
 num-traits = "0.2.19"
-fast-stm = { git = "https://github.com/imrn99/fast-stm", rev = "8eccd2bf1e7e785c9cbca0a4f84e61171f675df0" }
+fast-stm = { git = "https://github.com/imrn99/fast-stm", rev = "6433107819957a620a3e19be8fc1555280e18d3c" }
 vtkio = { version = "0.7.0-rc1", default-features = false }
 
 # benchmarks

--- a/benches/benches/core/cmap2/link_and_sew.rs
+++ b/benches/benches/core/cmap2/link_and_sew.rs
@@ -51,7 +51,7 @@ fn get_sew_map(n_square: usize) -> CMap2<FloatType> {
 #[bench::medium(&mut get_link_map(64))]
 #[bench::large(&mut get_link_map(256))]
 fn one_link(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_link::<1>(4, 6);
+    map.force_link::<1>(4, 6).unwrap();
     black_box(map)
 }
 
@@ -60,7 +60,7 @@ fn one_link(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_link_map(64))]
 #[bench::large(&mut get_link_map(256))]
 fn two_link(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_link::<2>(4, 6);
+    map.force_link::<2>(4, 6).unwrap();
     black_box(map)
 }
 
@@ -69,7 +69,7 @@ fn two_link(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
 fn one_unlink(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_unlink::<1>(4);
+    map.force_unlink::<1>(4).unwrap();
     black_box(map)
 }
 
@@ -78,7 +78,7 @@ fn one_unlink(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
 fn two_unlink(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_unlink::<2>(4);
+    map.force_unlink::<2>(4).unwrap();
     black_box(map)
 }
 
@@ -98,7 +98,7 @@ library_benchmark_group!(
 #[bench::medium(&mut get_sew_map(64))]
 #[bench::large(&mut get_sew_map(256))]
 fn one_sew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_sew::<1>(4, 6);
+    map.force_sew::<1>(4, 6).unwrap();
     black_box(map)
 }
 
@@ -107,7 +107,7 @@ fn one_sew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_sew_map(64))]
 #[bench::large(&mut get_sew_map(256))]
 fn two_sew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_sew::<2>(4, 6);
+    map.force_sew::<2>(4, 6).unwrap();
     black_box(map)
 }
 
@@ -116,7 +116,7 @@ fn two_sew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
 fn one_unsew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_unsew::<1>(4);
+    map.force_unsew::<1>(4).unwrap();
     black_box(map)
 }
 
@@ -125,7 +125,7 @@ fn one_unsew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
 #[bench::medium(&mut get_map(64))]
 #[bench::large(&mut get_map(256))]
 fn two_unsew(map: &mut CMap2<FloatType>) -> &mut CMap2<FloatType> {
-    map.force_unsew::<2>(4);
+    map.force_unsew::<2>(4).unwrap();
     black_box(map)
 }
 

--- a/examples/examples/io/write.rs
+++ b/examples/examples/io/write.rs
@@ -39,17 +39,17 @@ fn main() {
             // unsew the square & duplicate vertices to avoid data loss
             // this duplication effectively means that there are two existing vertices
             // for a short time, before being merged back by the sewing ops
-            map.force_unsew::<1>(d1);
-            map.force_unsew::<1>(d3);
+            map.force_unsew::<1>(d1).unwrap();
+            map.force_unsew::<1>(d3).unwrap();
             // link the two new dart in order to
-            map.force_link::<2>(dsplit1, dsplit2);
+            map.force_link::<2>(dsplit1, dsplit2).unwrap();
             // define beta1 of the new darts, i.e. tell them where they point to
-            map.force_sew::<1>(dsplit1, d4);
-            map.force_sew::<1>(dsplit2, d2);
+            map.force_sew::<1>(dsplit1, d4).unwrap();
+            map.force_sew::<1>(dsplit2, d2).unwrap();
 
             // sew the original darts to the new darts
-            map.force_sew::<1>(d1, dsplit1);
-            map.force_sew::<1>(d3, dsplit2);
+            map.force_sew::<1>(d1, dsplit1).unwrap();
+            map.force_sew::<1>(d3, dsplit2).unwrap();
             // fuse the edges; this is where duplicated vertices are merged back together
         });
     let elapsed = now.elapsed();

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -5,13 +5,12 @@
 
 // ------ IMPORTS
 
-use crate::stm::{StmClosureResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction, TransactionClosureResult};
 
-use super::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
-use crate::{
-    cmap::CMapResult,
-    prelude::{DartIdType, OrbitPolicy},
+use super::{
+    AttributeBind, AttributeError, AttributeStorage, AttributeUpdate, UnknownAttributeStorage,
 };
+use crate::prelude::{DartIdType, OrbitPolicy};
 use std::{any::TypeId, collections::HashMap};
 
 // ------ CONTENT
@@ -478,7 +477,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.vertices.values() {
             storage.try_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -502,7 +501,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.edges.values() {
             storage.try_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -526,7 +525,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.faces.values() {
             storage.try_merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -842,7 +841,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.vertices.values() {
             storage.try_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
@@ -866,7 +865,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.edges.values() {
             storage.try_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
@@ -890,7 +889,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         for storage in self.faces.values() {
             storage.try_split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -13,12 +13,12 @@ pub(crate) use manager::AttrStorageManager;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AttributeError {
-    #[error("cannot merge attributes: {0}")]
-    FailedMerge(&'static str),
-    #[error("cannot split attributes: {0}")]
-    FailedSplit(&'static str),
-    #[error("insufficient data to complete attribute operation: {0}")]
-    InsufficientData(&'static str),
+    #[error("cannot merge attribute {0}: {1}")]
+    FailedMerge(&'static str, &'static str),
+    #[error("cannot split attribute {0}: {1}")]
+    FailedSplit(&'static str, &'static str),
+    #[error("insufficient data to complete {0} operation on {1}")]
+    InsufficientData(&'static str, &'static str),
 }
 
 // ------ TESTS

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -11,6 +11,16 @@ pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttrib
 
 pub(crate) use manager::AttrStorageManager;
 
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AttributeError {
+    #[error("cannot merge attributes: {0}")]
+    FailedMerge(&'static str),
+    #[error("cannot split attributes: {0}")]
+    FailedSplit(&'static str),
+    #[error("insufficient data to complete attribute operation: {0}")]
+    InsufficientData(&'static str),
+}
+
 // ------ TESTS
 
 #[allow(clippy::float_cmp)]

--- a/honeycomb-core/src/attributes/mod.rs
+++ b/honeycomb-core/src/attributes/mod.rs
@@ -11,12 +11,18 @@ pub use traits::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttrib
 
 pub(crate) use manager::AttrStorageManager;
 
+/// Attribute operation error enum
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AttributeError {
+    /// Use in your custom [`AttributeUpdate::merge`], [`AttributeUpdate::merge_incomplete`], and
+    /// [`AttributeUpdate::merge_from_none`] implementations.
     #[error("cannot merge attribute {0}: {1}")]
     FailedMerge(&'static str, &'static str),
+    /// Use in your custom [`AttributeUpdate::split`], [`AttributeUpdate::split_from_none`]
+    /// implementations.
     #[error("cannot split attribute {0}: {1}")]
     FailedSplit(&'static str, &'static str),
+    /// Default return for fallback functions of [`AttributUpdate`].
     #[error("insufficient data to complete {0} operation on {1}")]
     InsufficientData(&'static str, &'static str),
 }

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -149,10 +149,10 @@ fn temperature_map() {
         .add_attribute::<Temperature>();
     let map: CMap2<f64> = builder.build().unwrap();
 
-    map.force_link::<2>(1, 2);
-    map.force_link::<2>(3, 4);
-    map.force_link::<2>(5, 6);
-    map.force_link::<1>(1, 3);
+    map.force_link::<2>(1, 2).unwrap();
+    map.force_link::<2>(3, 4).unwrap();
+    map.force_link::<2>(5, 6).unwrap();
+    map.force_link::<1>(1, 3).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (1.0, 0.0));
     map.force_write_vertex(4, (1.5, 0.0));
@@ -174,7 +174,7 @@ fn temperature_map() {
         Some(Temperature::from(273.))
     );
     // sew one segment
-    map.force_sew::<1>(3, 5);
+    map.force_sew::<1>(3, 5).unwrap();
     assert_eq!(map.vertex_id(4), map.vertex_id(5));
     assert_eq!(
         map.force_read_attribute::<Temperature>(map.vertex_id(4)),
@@ -185,7 +185,7 @@ fn temperature_map() {
         Some(Vertex2::from((2., 0.)))
     );
     // unsew another
-    map.force_unsew::<1>(1);
+    map.force_unsew::<1>(1).unwrap();
     assert_ne!(map.vertex_id(2), map.vertex_id(3));
     assert_eq!(
         map.force_read_attribute::<Temperature>(map.vertex_id(2)),

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -27,7 +27,7 @@ use std::fmt::Debug;
 /// For an intensive property of a system (e.g. a temperature), an implementation would look
 /// like this:
 ///
-/// ```rust
+/// ```ignore
 /// use honeycomb_core::prelude::{AttributeUpdate, CMapResult};
 ///
 /// #[derive(Clone, Copy, Debug, PartialEq)]
@@ -63,9 +63,19 @@ use std::fmt::Debug;
 /// ```
 pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     /// Merging routine, i.e. how to obtain a new value from two existing ones.
+    ///
+    /// # Errors
+    ///
+    /// You may use [`AttributeError::FailedMerge`] to model a possible failure in your attribute
+    /// mergin process.
     fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError>;
 
     /// Splitting routine, i.e. how to obtain the two new values from a single one.
+    ///
+    /// # Errors
+    ///
+    /// You may use [`AttributeError::FailedSplit`] to model a possible failure in your attribute
+    /// mergin process.
     fn split(attr: Self) -> Result<(Self, Self), AttributeError>;
 
     #[allow(clippy::missing_errors_doc)]
@@ -77,7 +87,9 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     ///
     /// # Return / Errors
     ///
-    /// The default implementation succeeds and simply returns the passed value.
+    /// The default implementation fails and returns [`AttributeError::InsufficientData`]. You may
+    /// override the implementation and use [`AttributeError::FailedMerge`] to model another
+    /// possible failure.
     fn merge_incomplete(_: Self) -> Result<Self, AttributeError> {
         Err(AttributeError::InsufficientData(
             "merge",
@@ -85,7 +97,6 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
         ))
     }
 
-    #[allow(clippy::missing_errors_doc)]
     /// Fallback merging routine, i.e. how to obtain a new value from no existing one.
     ///
     /// The returned value directly affects the behavior of sewing methods: For example, if this
@@ -94,8 +105,7 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     ///
     /// # Errors
     ///
-    /// The default implementation fails with `Err(CMapError::FailedAttributeMerge)`.
-    #[allow(clippy::must_use_candidate)]
+    /// The default implementation fails and returns [`AttributeError::InsufficientData`].
     fn merge_from_none() -> Result<Self, AttributeError> {
         Err(AttributeError::InsufficientData(
             "merge",
@@ -112,7 +122,7 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
     ///
     /// # Errors
     ///
-    /// The default implementation fails with `Err(CMapError::FailedAttributeSplit)`.
+    /// The default implementation fails and returns [`AttributeError::InsufficientData`].
     fn split_from_none() -> Result<(Self, Self), AttributeError> {
         Err(AttributeError::InsufficientData(
             "split",
@@ -131,7 +141,7 @@ pub trait AttributeUpdate: Sized + Send + Sync + Clone + Copy {
 /// Using the same context as the for the [`AttributeUpdate`] example, we can associate temperature
 /// to faces and model a 2D heat-map:
 ///
-/// ```rust
+/// ```ignore
 /// # use honeycomb_core::prelude::{AttributeUpdate, CMapResult};
 /// use honeycomb_core::prelude::{FaceIdType, OrbitPolicy};
 /// use honeycomb_core::attributes::{AttributeBind, AttrSparseVec};

--- a/honeycomb-core/src/cmap/builder/io.rs
+++ b/honeycomb-core/src/cmap/builder/io.rs
@@ -188,10 +188,10 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                                             d2 as VertexIdType,
                                             vertices[vids[2]],
                                         );
-                                        cmap.force_link::<1>(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                                        cmap.force_link::<1>(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                                        cmap.force_link::<1>(d2, d0); // edge d2 links vertices vids[2] & vids[0]
-                                                                      // record a trace of the built cell for future 2-sew
+                                        cmap.force_link::<1>(d0, d1).unwrap(); // edge d0 links vertices vids[0] & vids[1]
+                                        cmap.force_link::<1>(d1, d2).unwrap(); // edge d1 links vertices vids[1] & vids[2]
+                                        cmap.force_link::<1>(d2, d0).unwrap(); // edge d2 links vertices vids[2] & vids[0]
+                                                                               // record a trace of the built cell for future 2-sew
                                         sew_buffer.insert((vids[0], vids[1]), d0);
                                         sew_buffer.insert((vids[1], vids[2]), d1);
                                         sew_buffer.insert((vids[2], vids[0]), d2);
@@ -213,7 +213,7 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                                                 di as VertexIdType,
                                                 vertices[vids[i]],
                                             );
-                                            cmap.force_link::<1>(di, dip1);
+                                            cmap.force_link::<1>(di, dip1).unwrap();
                                             sew_buffer
                                                 .insert((vids[i], vids[(i + 1) % n_vertices]), di);
                                         });
@@ -248,11 +248,11 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
                                             d3 as VertexIdType,
                                             vertices[vids[3]],
                                         );
-                                        cmap.force_link::<1>(d0, d1); // edge d0 links vertices vids[0] & vids[1]
-                                        cmap.force_link::<1>(d1, d2); // edge d1 links vertices vids[1] & vids[2]
-                                        cmap.force_link::<1>(d2, d3); // edge d2 links vertices vids[2] & vids[3]
-                                        cmap.force_link::<1>(d3, d0); // edge d3 links vertices vids[3] & vids[0]
-                                                                      // record a trace of the built cell for future 2-sew
+                                        cmap.force_link::<1>(d0, d1).unwrap(); // edge d0 links vertices vids[0] & vids[1]
+                                        cmap.force_link::<1>(d1, d2).unwrap(); // edge d1 links vertices vids[1] & vids[2]
+                                        cmap.force_link::<1>(d2, d3).unwrap(); // edge d2 links vertices vids[2] & vids[3]
+                                        cmap.force_link::<1>(d3, d0).unwrap(); // edge d3 links vertices vids[3] & vids[0]
+                                                                               // record a trace of the built cell for future 2-sew
                                         sew_buffer.insert((vids[0], vids[1]), d0);
                                         sew_buffer.insert((vids[1], vids[2]), d1);
                                         sew_buffer.insert((vids[2], vids[3]), d2);
@@ -281,7 +281,7 @@ pub fn build_2d_from_vtk<T: CoordsFloat>(
     }
     while let Some(((id0, id1), dart_id0)) = sew_buffer.pop_first() {
         if let Some(dart_id1) = sew_buffer.remove(&(id1, id0)) {
-            cmap.force_sew::<2>(dart_id0, dart_id1);
+            cmap.force_sew::<2>(dart_id0, dart_id1).unwrap();
         }
     }
     Ok(cmap)

--- a/honeycomb-core/src/cmap/dim2/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/links/mod.rs
@@ -1,7 +1,8 @@
 mod one;
 mod two;
 
-use crate::stm::{StmClosureResult, Transaction};
+use crate::cmap::error::LinkError;
+use crate::stm::{Transaction, TransactionClosureResult};
 
 use crate::{
     cmap::{CMap2, DartIdType},
@@ -44,7 +45,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -89,7 +90,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         ld: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -105,7 +106,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`link`][Self::link], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_link<const I: u8>(&self, ld: DartIdType, rd: DartIdType) {
+    pub fn force_link<const I: u8>(&self, ld: DartIdType, rd: DartIdType) -> Result<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -121,7 +122,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`unlink`][Self::unlink], but internally uses a transaction
     /// that will be retried until validated.
-    pub fn force_unlink<const I: u8>(&self, ld: DartIdType) {
+    pub fn force_unlink<const I: u8>(&self, ld: DartIdType) -> Result<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/links/mod.rs
@@ -101,7 +101,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// `I`-link operator.
     ///
     /// This variant is equivalent to [`link`][Self::link], but internally uses a transaction that
@@ -117,7 +117,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// # `I`-unlink operator.
     ///
     /// This variant is equivalent to [`unlink`][Self::unlink], but internally uses a transaction

--- a/honeycomb-core/src/cmap/dim2/links/one.rs
+++ b/honeycomb-core/src/cmap/dim2/links/one.rs
@@ -1,7 +1,8 @@
-use crate::stm::{atomically, StmClosureResult, Transaction};
+use crate::stm::{Transaction, TransactionClosureResult};
+use fast_stm::atomically_with_err;
 
 use crate::{
-    cmap::{CMap2, DartIdType},
+    cmap::{error::LinkError, CMap2, DartIdType},
     prelude::CoordsFloat,
 };
 
@@ -14,13 +15,17 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
     /// 1-link defensive implementation.
-    pub(super) fn force_one_link(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id));
+    pub(super) fn force_one_link(
+        &self,
+        lhs_dart_id: DartIdType,
+        rhs_dart_id: DartIdType,
+    ) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id))
     }
 }
 
@@ -32,12 +37,12 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.one_unlink_core(trans, lhs_dart_id)
     }
 
     /// 1-unlink defensive implementation.
-    pub(super) fn force_one_unlink(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.one_unlink_core(trans, lhs_dart_id));
+    pub(super) fn force_one_unlink(&self, lhs_dart_id: DartIdType) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.one_unlink_core(trans, lhs_dart_id))
     }
 }

--- a/honeycomb-core/src/cmap/dim2/links/two.rs
+++ b/honeycomb-core/src/cmap/dim2/links/two.rs
@@ -1,4 +1,7 @@
-use crate::stm::{atomically, StmClosureResult, Transaction};
+use fast_stm::atomically_with_err;
+
+use crate::cmap::error::LinkError;
+use crate::stm::{Transaction, TransactionClosureResult};
 
 use crate::{
     cmap::{CMap2, DartIdType},
@@ -14,13 +17,17 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
     /// 2-link defensive implementation.
-    pub(super) fn force_two_link(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id));
+    pub(super) fn force_two_link(
+        &self,
+        lhs_dart_id: DartIdType,
+        rhs_dart_id: DartIdType,
+    ) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id))
     }
 }
 
@@ -32,12 +39,12 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.two_unlink_core(trans, lhs_dart_id)
     }
 
     /// 2-unlink defensive implementation.
-    pub(super) fn force_two_unlink(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.two_unlink_core(trans, lhs_dart_id));
+    pub(super) fn force_two_unlink(&self, lhs_dart_id: DartIdType) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.two_unlink_core(trans, lhs_dart_id))
     }
 }

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -178,23 +178,23 @@ mod tests {
     fn simple_map() -> CMap2<f64> {
         let mut map: CMap2<f64> = CMap2::new(11);
         // tri1
-        map.force_link::<1>(1, 2);
-        map.force_link::<1>(2, 3);
-        map.force_link::<1>(3, 1);
+        map.force_link::<1>(1, 2).unwrap();
+        map.force_link::<1>(2, 3).unwrap();
+        map.force_link::<1>(3, 1).unwrap();
         // tri2
-        map.force_link::<1>(4, 5);
-        map.force_link::<1>(5, 6);
-        map.force_link::<1>(6, 4);
+        map.force_link::<1>(4, 5).unwrap();
+        map.force_link::<1>(5, 6).unwrap();
+        map.force_link::<1>(6, 4).unwrap();
         // pent on top
-        map.force_link::<1>(7, 8);
-        map.force_link::<1>(8, 9);
-        map.force_link::<1>(9, 10);
-        map.force_link::<1>(10, 11);
-        map.force_link::<1>(11, 7);
+        map.force_link::<1>(7, 8).unwrap();
+        map.force_link::<1>(8, 9).unwrap();
+        map.force_link::<1>(9, 10).unwrap();
+        map.force_link::<1>(10, 11).unwrap();
+        map.force_link::<1>(11, 7).unwrap();
 
         // link all
-        map.force_link::<2>(2, 4);
-        map.force_link::<2>(6, 7);
+        map.force_link::<2>(2, 4).unwrap();
+        map.force_link::<2>(6, 7).unwrap();
 
         assert!(map.force_write_vertex(1, (0.0, 0.0)).is_none());
         assert!(map.force_write_vertex(2, (1.0, 0.0)).is_none());

--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -2,7 +2,7 @@ mod one;
 mod two;
 
 use crate::{
-    cmap::{CMap2, CMapResult, DartIdType, SewError},
+    cmap::{CMap2, DartIdType, SewError},
     prelude::CoordsFloat,
     stm::{Transaction, TransactionClosureResult},
 };
@@ -117,7 +117,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`sew`][Self::sew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_sew<const I: u8>(&self, ld: DartIdType, rd: DartIdType) {
+    pub fn force_sew<const I: u8>(&self, ld: DartIdType, rd: DartIdType) -> Result<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -133,7 +133,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_unsew<const I: u8>(&self, ld: DartIdType) {
+    pub fn force_unsew<const I: u8>(&self, ld: DartIdType) -> Result<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -112,7 +112,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// `I`-sew operator.
     ///
     /// This variant is equivalent to [`sew`][Self::sew], but internally uses a transaction that
@@ -128,7 +128,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// `I`-unsew operator.
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that

--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -1,11 +1,10 @@
 mod one;
 mod two;
 
-use crate::stm::Transaction;
-
 use crate::{
-    cmap::{CMap2, CMapResult, DartIdType},
+    cmap::{CMap2, CMapResult, DartIdType, SewError},
     prelude::CoordsFloat,
+    stm::{Transaction, TransactionClosureResult},
 };
 
 /// # **Sew implementations**
@@ -51,7 +50,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -98,7 +97,11 @@ impl<T: CoordsFloat> CMap2<T> {
     /// The method may panic if:
     /// - `I >= 3` or `I == 0`,
     /// - `ld` is already `I`-free.
-    pub fn unsew<const I: u8>(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
+    pub fn unsew<const I: u8>(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> TransactionClosureResult<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -1,21 +1,10 @@
-use fast_stm::atomically_with_err;
-
-use crate::stm::{Transaction, TransactionClosureResult, TransactionError};
+use crate::stm::{atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult};
 
 use crate::{
     attributes::UnknownAttributeStorage,
     cmap::{CMap2, DartIdType, SewError, NULL_DART_ID},
     prelude::CoordsFloat,
 };
-
-macro_rules! try_map_err {
-    ($op: expr, $to: ident) => {
-        $op.map_err(|e| match e {
-            TransactionError::Abort(e) => TransactionError::Abort($to::from(e)),
-            TransactionError::Stm(e) => TransactionError::Stm(e),
-        })?
-    };
-}
 
 #[doc(hidden)]
 /// 1-sews
@@ -29,7 +18,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ) -> TransactionClosureResult<(), SewError> {
         let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         if b2lhs_dart_id == NULL_DART_ID {
-            try_map_err!(
+            try_or_coerce!(
                 self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id),
                 SewError
             );
@@ -37,19 +26,19 @@ impl<T: CoordsFloat> CMap2<T> {
             let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
             let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-            try_map_err!(
+            try_or_coerce!(
                 self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id),
                 SewError
             );
 
             let new_vid = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-            try_map_err!(
+            try_or_coerce!(
                 self.vertices
                     .try_merge(trans, new_vid, b2lhs_vid_old, rhs_vid_old),
                 SewError
             );
-            try_map_err!(
+            try_or_coerce!(
                 self.attributes.try_merge_vertex_attributes(
                     trans,
                     new_vid,
@@ -71,7 +60,7 @@ impl<T: CoordsFloat> CMap2<T> {
         atomically_with_err(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             if b2lhs_dart_id == NULL_DART_ID {
-                try_map_err!(
+                try_or_coerce!(
                     self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id),
                     SewError
                 );
@@ -79,7 +68,7 @@ impl<T: CoordsFloat> CMap2<T> {
                 let b2lhs_vid_old = self.vertex_id_transac(trans, b2lhs_dart_id)?;
                 let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
 
-                try_map_err!(
+                try_or_coerce!(
                     self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id),
                     SewError
                 );
@@ -111,23 +100,23 @@ impl<T: CoordsFloat> CMap2<T> {
     ) -> TransactionClosureResult<(), SewError> {
         let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         if b2lhs_dart_id == NULL_DART_ID {
-            try_map_err!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
+            try_or_coerce!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
         } else {
             // fetch IDs before topology update
             let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
             let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
             // update the topology
-            try_map_err!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
+            try_or_coerce!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
             // split vertices & attributes from the old ID to the new ones
             let (new_lhs, new_rhs) = (
                 self.vertex_id_transac(trans, b2lhs_dart_id)?,
                 self.vertex_id_transac(trans, rhs_dart_id)?,
             );
-            try_map_err!(
+            try_or_coerce!(
                 self.vertices.try_split(trans, new_lhs, new_rhs, vid_old),
                 SewError
             );
-            try_map_err!(
+            try_or_coerce!(
                 self.attributes
                     .try_split_vertex_attributes(trans, new_lhs, new_rhs, vid_old),
                 SewError
@@ -141,13 +130,13 @@ impl<T: CoordsFloat> CMap2<T> {
         atomically_with_err(|trans| {
             let b2lhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             if b2lhs_dart_id == NULL_DART_ID {
-                try_map_err!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
+                try_or_coerce!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
             } else {
                 // fetch IDs before topology update
                 let rhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
                 let vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                 // update the topology
-                try_map_err!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
+                try_or_coerce!(self.betas.one_unlink_core(trans, lhs_dart_id), SewError);
                 // split vertices & attributes from the old ID to the new ones
                 let (new_lhs, new_rhs) = (
                     self.vertex_id_transac(trans, b2lhs_dart_id)?,

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -137,7 +137,7 @@ impl<T: CoordsFloat> CMap2<T> {
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
                         if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?
+                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?;
                         }
                     };
 
@@ -300,7 +300,7 @@ impl<T: CoordsFloat> CMap2<T> {
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
                         if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?
+                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?;
                         }
                     };
 
@@ -346,6 +346,7 @@ impl<T: CoordsFloat> CMap2<T> {
 /// 2-unsews
 impl<T: CoordsFloat> CMap2<T> {
     /// 2-unsew transactional implementation.
+    #[allow(clippy::too_many_lines)]
     pub(super) fn two_unsew(
         &self,
         trans: &mut Transaction,

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -1,6 +1,6 @@
-use fast_stm::atomically_with_err;
-
-use crate::stm::{abort, atomically, try_or_coerce, Transaction, TransactionClosureResult};
+use crate::stm::{
+    abort, atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult,
+};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
@@ -29,6 +29,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
                     SewError
                 );
+                // FIXME: merge edge attributes
             }
             // update vertex associated to b1rhs/lhs
             (true, false) => {
@@ -45,20 +46,29 @@ impl<T: CoordsFloat> CMap2<T> {
                 // merge vertices & attributes from the old IDs to the new one
                 let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
                 let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
+                try_or_coerce!(
+                    self.vertices
+                        .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    ),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    ),
+                    SewError
+                );
             }
             // update vertex associated to b1lhs/rhs
             (false, true) => {
@@ -75,20 +85,29 @@ impl<T: CoordsFloat> CMap2<T> {
                 // merge vertices & attributes from the old IDs to the new one
                 let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
                 let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
+                try_or_coerce!(
+                    self.vertices
+                        .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    ),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    ),
+                    SewError
+                );
             }
             // update both vertices making up the edge
             (false, false) => {
@@ -120,11 +139,6 @@ impl<T: CoordsFloat> CMap2<T> {
                         if lhs_vector.dot(&rhs_vector) >= T::zero() {
                             abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?
                         }
-                        assert!(
-                            lhs_vector.dot(&rhs_vector) < T::zero(),
-                            "{}",
-                            format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
-                        );
                     };
 
                 // update the topology
@@ -136,28 +150,43 @@ impl<T: CoordsFloat> CMap2<T> {
                 let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
                 let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
                 let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
-                self.vertices
-                    .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old)?;
-                self.vertices
-                    .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old)?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    lhs_vid_new,
-                    lhs_vid_old,
-                    b1rhs_vid_old,
-                )?;
-                self.attributes.try_merge_vertex_attributes(
-                    trans,
-                    rhs_vid_new,
-                    b1lhs_vid_old,
-                    rhs_vid_old,
-                )?;
-                self.attributes.try_merge_edge_attributes(
-                    trans,
-                    eid_new,
-                    lhs_eid_old,
-                    rhs_eid_old,
-                )?;
+                try_or_coerce!(
+                    self.vertices
+                        .try_merge(trans, lhs_vid_new, lhs_vid_old, b1rhs_vid_old),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.vertices
+                        .try_merge(trans, rhs_vid_new, b1lhs_vid_old, rhs_vid_old),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_vertex_attributes(
+                        trans,
+                        lhs_vid_new,
+                        lhs_vid_old,
+                        b1rhs_vid_old,
+                    ),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_vertex_attributes(
+                        trans,
+                        rhs_vid_new,
+                        b1lhs_vid_old,
+                        rhs_vid_old,
+                    ),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_eid_old,
+                        rhs_eid_old,
+                    ),
+                    SewError
+                );
             }
         }
         Ok(())
@@ -177,7 +206,11 @@ impl<T: CoordsFloat> CMap2<T> {
             match (b1lhs_dart_id == NULL_DART_ID, b1rhs_dart_id == NULL_DART_ID) {
                 // trivial case, no update needed
                 (true, true) => {
-                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    try_or_coerce!(
+                        self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
+                        SewError
+                    );
+                    // FIXME: merge edge attributes
                 }
                 // update vertex associated to b1rhs/lhs
                 (true, false) => {
@@ -187,7 +220,10 @@ impl<T: CoordsFloat> CMap2<T> {
                     let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
                     let b1rhs_vid_old = self.vertex_id_transac(trans, b1rhs_dart_id)?;
                     // update the topology
-                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    try_or_coerce!(
+                        self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
+                        SewError
+                    );
                     // merge vertices & attributes from the old IDs to the new one
                     let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
                     let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
@@ -214,7 +250,10 @@ impl<T: CoordsFloat> CMap2<T> {
                     let b1lhs_vid_old = self.vertex_id_transac(trans, b1lhs_dart_id)?;
                     let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                     // update the topology
-                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    try_or_coerce!(
+                        self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
+                        SewError
+                    );
                     // merge vertices & attributes from the old IDs to the new one
                     let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
                     let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
@@ -260,15 +299,16 @@ impl<T: CoordsFloat> CMap2<T> {
                         // dot product should be negative if the two darts have opposite direction
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
-                        assert!(
-                            lhs_vector.dot(&rhs_vector) < T::zero(),
-                            "{}",
-                            format!("Dart {lhs_dart_id} and {rhs_dart_id} do not have consistent orientation for 2-sewing"),
-                        );
+                        if lhs_vector.dot(&rhs_vector) >= T::zero() {
+                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?
+                        }
                     };
 
                     // update the topology
-                    self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)?;
+                    try_or_coerce!(
+                        self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
+                        SewError
+                    );
                     // merge vertices & attributes from the old IDs to the new one
                     let lhs_vid_new = self.vertex_id_transac(trans, lhs_dart_id)?;
                     let rhs_vid_new = self.vertex_id_transac(trans, rhs_dart_id)?;
@@ -310,7 +350,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
         let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
         let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
@@ -320,65 +360,80 @@ impl<T: CoordsFloat> CMap2<T> {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                 // split attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    ),
+                    SewError
+                );
             }
             (true, false) => {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                 let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                 // split vertex & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    ),
+                    SewError
+                );
                 let (new_lv_lhs, new_lv_rhs) = (
                     self.vertex_id_transac(trans, lhs_dart_id)?,
                     self.vertex_id_transac(trans, b1rhs_dart_id)?,
                 );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    ),
+                    SewError
+                );
             }
             (false, true) => {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                 let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                 // split vertex & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    ),
+                    SewError
+                );
                 let (new_rv_lhs, new_rv_rhs) = (
                     self.vertex_id_transac(trans, b1lhs_dart_id)?,
                     self.vertex_id_transac(trans, rhs_dart_id)?,
                 );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    ),
+                    SewError
+                );
             }
             (false, false) => {
                 // fetch IDs before topology update
@@ -386,15 +441,18 @@ impl<T: CoordsFloat> CMap2<T> {
                 let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
                 let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                 // split vertices & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes.try_split_edge_attributes(
-                    trans,
-                    lhs_dart_id,
-                    rhs_dart_id,
-                    eid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_edge_attributes(
+                        trans,
+                        lhs_dart_id,
+                        rhs_dart_id,
+                        eid_old,
+                    ),
+                    SewError
+                );
                 let (new_lv_lhs, new_lv_rhs) = (
                     self.vertex_id_transac(trans, lhs_dart_id)?,
                     self.vertex_id_transac(trans, b1rhs_dart_id)?,
@@ -403,26 +461,32 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.vertex_id_transac(trans, b1lhs_dart_id)?,
                     self.vertex_id_transac(trans, rhs_dart_id)?,
                 );
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_lv_lhs,
-                    new_lv_rhs,
-                    lhs_vid_old,
-                )?;
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    new_rv_lhs,
-                    new_rv_rhs,
-                    rhs_vid_old,
-                )?;
+                try_or_coerce!(
+                    self.attributes.try_split_vertex_attributes(
+                        trans,
+                        new_lv_lhs,
+                        new_lv_rhs,
+                        lhs_vid_old,
+                    ),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_split_vertex_attributes(
+                        trans,
+                        new_rv_lhs,
+                        new_rv_rhs,
+                        rhs_vid_old,
+                    ),
+                    SewError
+                );
             }
         }
         Ok(())
     }
 
     /// 2-unsew implementation.
-    pub(super) fn force_two_unsew(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| {
+    pub(super) fn force_two_unsew(&self, lhs_dart_id: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             let rhs_dart_id = self.betas[(2, lhs_dart_id)].read(trans)?;
             let b1lhs_dart_id = self.betas[(1, lhs_dart_id)].read(trans)?;
             let b1rhs_dart_id = self.betas[(1, rhs_dart_id)].read(trans)?;
@@ -432,7 +496,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     // fetch IDs before topology update
                     let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                     // split attributes from the old ID to the new ones
                     self.attributes.split_edge_attributes(
                         trans,
@@ -446,7 +510,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                     let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                     // split vertex & attributes from the old ID to the new ones
                     self.attributes.split_edge_attributes(
                         trans,
@@ -470,7 +534,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     let eid_old = self.edge_id_transac(trans, lhs_dart_id)?;
                     let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                     // split vertex & attributes from the old ID to the new ones
                     self.attributes.split_edge_attributes(
                         trans,
@@ -495,7 +559,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     let lhs_vid_old = self.vertex_id_transac(trans, lhs_dart_id)?;
                     let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, lhs_dart_id)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, lhs_dart_id), SewError);
                     // split vertices & attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes.split_edge_attributes(
@@ -527,6 +591,6 @@ impl<T: CoordsFloat> CMap2<T> {
                 }
             }
             Ok(())
-        });
+        })
     }
 }

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -1,12 +1,10 @@
 // ------ IMPORTS
 
-use fast_stm::{atomically_with_err, TransactionError};
-
 use crate::{
     attributes::{AttrSparseVec, AttributeError},
-    cmap::VertexIdType,
+    cmap::{LinkError, SewError, VertexIdType},
     prelude::{AttributeBind, AttributeUpdate, CMap2, CMapBuilder, Orbit2, OrbitPolicy, Vertex2},
-    stm::{atomically, StmError},
+    stm::{atomically, atomically_with_err, StmError, TransactionError},
 };
 
 // ------ CONTENT
@@ -17,9 +15,9 @@ use crate::{
 fn example_test() {
     // build a triangle
     let mut map: CMap2<f64> = CMapBuilder::default().n_darts(3).build().unwrap();
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 1);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 1).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (1.0, 0.0));
     map.force_write_vertex(3, (0.0, 1.0));
@@ -36,9 +34,9 @@ fn example_test() {
 
     // build a second triangle
     map.add_free_darts(3);
-    map.force_link::<1>(4, 5);
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 4);
+    map.force_link::<1>(4, 5).unwrap();
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 4).unwrap();
     map.force_write_vertex(4, (0.0, 2.0));
     map.force_write_vertex(5, (2.0, 0.0));
     map.force_write_vertex(6, (1.0, 1.0));
@@ -53,7 +51,7 @@ fn example_test() {
     assert_eq!(face.next(), None);
 
     // sew both triangles
-    map.force_sew::<2>(2, 4);
+    map.force_sew::<2>(2, 4).unwrap();
 
     // checks
     assert_eq!(map.beta::<2>(2), 4);
@@ -79,17 +77,17 @@ fn example_test() {
     assert_eq!(map.force_read_vertex(3).unwrap(), Vertex2::from((0.0, 1.0)));
 
     // separate the diagonal from the rest
-    map.force_unsew::<1>(1);
-    map.force_unsew::<1>(2);
-    map.force_unsew::<1>(6);
-    map.force_unsew::<1>(4);
+    map.force_unsew::<1>(1).unwrap();
+    map.force_unsew::<1>(2).unwrap();
+    map.force_unsew::<1>(6).unwrap();
+    map.force_unsew::<1>(4).unwrap();
     // break up & remove the diagonal
-    map.force_unsew::<2>(2); // this makes dart 2 and 4 free
+    map.force_unsew::<2>(2).unwrap(); // this makes dart 2 and 4 free
     map.remove_free_dart(2);
     map.remove_free_dart(4);
     // sew the square back up
-    map.force_sew::<1>(1, 5);
-    map.force_sew::<1>(6, 3);
+    map.force_sew::<1>(1, 5).unwrap();
+    map.force_sew::<1>(6, 3).unwrap();
 
     // i-cells
     let faces: Vec<_> = map.iter_faces().collect();
@@ -263,13 +261,13 @@ fn remove_dart_twice() {
 #[test]
 fn two_sew_complete() {
     let mut map: CMap2<f64> = CMap2::new(4);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(3, 4);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0));
     map.force_write_vertex(3, (1.0, 1.0));
     map.force_write_vertex(4, (1.0, 0.0));
-    map.force_sew::<2>(1, 3);
+    map.force_sew::<2>(1, 3).unwrap();
     assert_eq!(map.force_read_vertex(1).unwrap(), Vertex2::from((0.5, 0.0)));
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
 }
@@ -277,21 +275,45 @@ fn two_sew_complete() {
 #[test]
 fn two_sew_incomplete() {
     let mut map: CMap2<f64> = CMap2::new(3);
-    map.force_link::<1>(1, 2);
+    map.force_link::<1>(1, 2).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0));
     map.force_write_vertex(3, (1.0, 1.0));
-    map.force_sew::<2>(1, 3);
+    map.force_sew::<2>(1, 3).unwrap();
     // missing beta1 image for dart 3
     assert_eq!(map.force_read_vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
-    map.force_unsew::<2>(1);
+    map.force_unsew::<2>(1).unwrap();
     assert_eq!(map.add_free_dart(), 4);
-    map.force_link::<1>(3, 4);
-    map.force_sew::<2>(1, 3);
+    map.force_link::<1>(3, 4).unwrap();
+    map.force_sew::<2>(1, 3).unwrap();
     // missing vertex for dart 4
     assert_eq!(map.force_read_vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.5, 1.0)));
+}
+
+#[test]
+fn link_twice() {
+    let mut map: CMap2<f64> = CMap2::new(3);
+    assert!(map.force_link::<1>(1, 2).is_ok());
+    assert!(map
+        .force_link::<1>(1, 3)
+        .is_err_and(|e| e == LinkError::NonFreeBase(1, 1, 3)));
+    assert!(map
+        .force_link::<1>(3, 2)
+        .is_err_and(|e| e == LinkError::NonFreeImage(0, 3, 2)));
+}
+
+#[test]
+fn sew_twice() {
+    let mut map: CMap2<f64> = CMap2::new(3);
+    assert!(map.force_link::<2>(1, 3).is_ok());
+    map.force_write_vertex(3, (0.0, 0.0));
+    map.force_write_vertex(2, (0.0, 0.0));
+    assert!(map.force_sew::<1>(1, 2).is_ok());
+    assert!(map
+        .force_sew::<1>(1, 2)
+        .is_err_and(|e| e == SewError::FailedLink(LinkError::NonFreeBase(1, 1, 2))));
 }
 
 #[test]
@@ -299,58 +321,70 @@ fn two_sew_no_b1() {
     let mut map: CMap2<f64> = CMap2::new(2);
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (1.0, 1.0));
-    map.force_sew::<2>(1, 2);
+    map.force_sew::<2>(1, 2).unwrap();
     assert_eq!(map.force_read_vertex(1).unwrap(), Vertex2::from((0.0, 0.0)));
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((1.0, 1.0)));
 }
 
 #[test]
-// #[should_panic] // FIXME: find a way to test what's printed?
 fn two_sew_no_attributes() {
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.force_sew::<2>(1, 2); // should panic
+    let mut map: CMap2<f64> = CMap2::new(3);
+    map.force_link::<2>(1, 3).unwrap();
+    let res = atomically_with_err(|trans| map.sew::<1>(trans, 1, 2));
+    assert!(res.is_err_and(|e| e
+        == SewError::FailedAttributeOp(AttributeError::InsufficientData(
+            "merge",
+            std::any::type_name::<Vertex2<f64>>()
+        ))));
+    assert!(map.force_sew::<1>(1, 2).is_ok());
 }
 
 #[test]
-// #[should_panic] // FIXME: find a way to test what's printed?
 fn two_sew_no_attributes_bis() {
     let mut map: CMap2<f64> = CMap2::new(4);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(3, 4);
-    map.force_sew::<2>(1, 3); // panic
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
+    let res = atomically_with_err(|trans| map.sew::<2>(trans, 1, 3));
+    assert!(res.is_err_and(|e| e
+        == SewError::FailedAttributeOp(AttributeError::InsufficientData(
+            "merge",
+            std::any::type_name::<Vertex2<f64>>()
+        ))));
+    assert!(map.force_sew::<2>(1, 3).is_ok());
 }
 
 #[test]
-#[should_panic(expected = "Dart 1 and 3 do not have consistent orientation for 2-sewing")]
 fn two_sew_bad_orientation() {
     let mut map: CMap2<f64> = CMap2::new(4);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(3, 4);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0)); // 1->2 goes up
     map.force_write_vertex(3, (1.0, 0.0));
     map.force_write_vertex(4, (1.0, 1.0)); // 3->4 also goes up
-    map.force_sew::<2>(1, 3); // panic
+    assert!(map
+        .force_sew::<2>(1, 3)
+        .is_err_and(|e| e == SewError::BadGeometry(2, 1, 3)));
 }
 
 #[test]
 fn one_sew_complete() {
     let mut map: CMap2<f64> = CMap2::new(3);
-    map.force_link::<2>(1, 2);
+    map.force_link::<2>(1, 2).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0));
     map.force_write_vertex(3, (0.0, 2.0));
-    map.force_sew::<1>(1, 3);
+    map.force_sew::<1>(1, 3).unwrap();
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.0, 1.5)));
 }
 
 #[test]
 fn one_sew_incomplete_attributes() {
     let mut map: CMap2<f64> = CMap2::new(3);
-    map.force_link::<2>(1, 2);
+    map.force_link::<2>(1, 2).unwrap();
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0));
-    map.force_sew::<1>(1, 3);
+    map.force_sew::<1>(1, 3).unwrap();
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
 }
 
@@ -359,22 +393,20 @@ fn one_sew_incomplete_beta() {
     let mut map: CMap2<f64> = CMap2::new(3);
     map.force_write_vertex(1, (0.0, 0.0));
     map.force_write_vertex(2, (0.0, 1.0));
-    map.force_sew::<1>(1, 2);
+    map.force_sew::<1>(1, 2).unwrap();
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex2::from((0.0, 1.0)));
 }
 #[test]
-// #[should_panic] // FIXME: find a way to test what's printed?
 fn one_sew_no_attributes() {
-    let mut map: CMap2<f64> = CMap2::new(2);
-    map.force_sew::<1>(1, 2); // should panic
-}
-
-#[test]
-// #[should_panic] // FIXME: find a way to test what's printed?
-fn one_sew_no_attributes_bis() {
     let mut map: CMap2<f64> = CMap2::new(3);
-    map.force_link::<2>(1, 2);
-    map.force_sew::<1>(1, 3); // panic
+    map.force_link::<2>(1, 3).unwrap();
+    let res = atomically_with_err(|trans| map.sew::<1>(trans, 1, 2));
+    assert!(res.is_err_and(|e| e
+        == SewError::FailedAttributeOp(AttributeError::InsufficientData(
+            "merge",
+            std::any::type_name::<Vertex2<f64>>()
+        ))));
+    assert!(map.force_sew::<1>(1, 2).is_ok());
 }
 
 // --- IO
@@ -395,29 +427,29 @@ fn io_write() {
     //  1---2---6
     let mut cmap: CMap2<f32> = CMap2::new(16);
     // bottom left square
-    cmap.force_link::<1>(1, 2);
-    cmap.force_link::<1>(2, 3);
-    cmap.force_link::<1>(3, 4);
-    cmap.force_link::<1>(4, 1);
+    cmap.force_link::<1>(1, 2).unwrap();
+    cmap.force_link::<1>(2, 3).unwrap();
+    cmap.force_link::<1>(3, 4).unwrap();
+    cmap.force_link::<1>(4, 1).unwrap();
     // bottom right triangles
-    cmap.force_link::<1>(5, 6);
-    cmap.force_link::<1>(6, 7);
-    cmap.force_link::<1>(7, 5);
-    cmap.force_link::<2>(7, 8);
-    cmap.force_link::<1>(8, 9);
-    cmap.force_link::<1>(9, 10);
-    cmap.force_link::<1>(10, 8);
+    cmap.force_link::<1>(5, 6).unwrap();
+    cmap.force_link::<1>(6, 7).unwrap();
+    cmap.force_link::<1>(7, 5).unwrap();
+    cmap.force_link::<2>(7, 8).unwrap();
+    cmap.force_link::<1>(8, 9).unwrap();
+    cmap.force_link::<1>(9, 10).unwrap();
+    cmap.force_link::<1>(10, 8).unwrap();
     // top polygon
-    cmap.force_link::<1>(11, 12);
-    cmap.force_link::<1>(12, 13);
-    cmap.force_link::<1>(13, 14);
-    cmap.force_link::<1>(14, 15);
-    cmap.force_link::<1>(15, 16);
-    cmap.force_link::<1>(16, 11);
+    cmap.force_link::<1>(11, 12).unwrap();
+    cmap.force_link::<1>(12, 13).unwrap();
+    cmap.force_link::<1>(13, 14).unwrap();
+    cmap.force_link::<1>(14, 15).unwrap();
+    cmap.force_link::<1>(15, 16).unwrap();
+    cmap.force_link::<1>(16, 11).unwrap();
     // assemble
-    cmap.force_link::<2>(2, 10);
-    cmap.force_link::<2>(3, 11);
-    cmap.force_link::<2>(9, 12);
+    cmap.force_link::<2>(2, 10).unwrap();
+    cmap.force_link::<2>(3, 11).unwrap();
+    cmap.force_link::<2>(9, 12).unwrap();
 
     // insert vertices
     cmap.force_write_vertex(1, (0.0, 0.0));
@@ -486,8 +518,8 @@ fn sew_ordering() {
     loom::model(|| {
         // setup the map
         let map: CMap2<f64> = CMapBuilder::default().n_darts(5).build().unwrap();
-        map.force_link::<2>(1, 2);
-        map.force_link::<1>(4, 5);
+        map.force_link::<2>(1, 2).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
         map.force_write_vertex(2, Vertex2(1.0, 1.0));
         map.force_write_vertex(3, Vertex2(1.0, 2.0));
         map.force_write_vertex(5, Vertex2(2.0, 2.0));
@@ -502,13 +534,9 @@ fn sew_ordering() {
         // 1-sew before 2-sew: (1.5, 1.75)
         // 2-sew before 1-sew: (1.25, 1.5)
 
-        let t1 = loom::thread::spawn(move || {
-            m1.force_sew::<1>(1, 3);
-        });
-
-        let t2 = loom::thread::spawn(move || {
-            m2.force_sew::<2>(3, 4);
-        });
+        // retry ops until they can be validated
+        let t1 = loom::thread::spawn(move || while let Err(_) = m1.force_sew::<1>(1, 3) {});
+        let t2 = loom::thread::spawn(move || while let Err(_) = m2.force_sew::<2>(3, 4) {});
 
         t1.join().unwrap();
         t2.join().unwrap();
@@ -622,10 +650,10 @@ fn unsew_ordering() {
             .add_attribute::<Weight>()
             .build()
             .unwrap();
-        map.force_link::<2>(1, 2);
-        map.force_link::<2>(3, 4);
-        map.force_link::<1>(1, 3);
-        map.force_link::<1>(4, 5);
+        map.force_link::<2>(1, 2).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
+        map.force_link::<1>(1, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
         map.force_write_vertex(2, Vertex2(0.0, 0.0));
         map.force_write_attribute(2, Weight(33));
         let arc = loom::sync::Arc::new(map);
@@ -639,13 +667,9 @@ fn unsew_ordering() {
         // 1-unsew before 2-unsew: (W2, W3, W5) = (17, 8, 8)
         // 2-unsew before 1-unsew: (W2, W3, W5) = (9, 8, 16)
 
-        let t1 = loom::thread::spawn(move || {
-            m1.force_unsew::<1>(1);
-        });
-
-        let t2 = loom::thread::spawn(move || {
-            m2.force_unsew::<2>(3);
-        });
+        // retry ops until they can be validated
+        let t1 = loom::thread::spawn(move || while let Err(_) = m1.force_unsew::<1>(1) {});
+        let t2 = loom::thread::spawn(move || while let Err(_) = m2.force_unsew::<2>(3) {});
 
         t1.join().unwrap();
         t2.join().unwrap();

--- a/honeycomb-core/src/cmap/dim3/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/links/mod.rs
@@ -2,11 +2,10 @@ mod one;
 mod three;
 mod two;
 
-use crate::stm::{StmClosureResult, Transaction};
-
 use crate::{
-    cmap::{CMap3, DartIdType},
+    cmap::{CMap3, DartIdType, LinkError},
     prelude::CoordsFloat,
+    stm::{Transaction, TransactionClosureResult},
 };
 
 /// # **Link operations**
@@ -45,7 +44,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -91,7 +90,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -107,7 +106,11 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to [`link`][Self::link], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_link<const I: u8>(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
+    pub fn force_link<const I: u8>(
+        &self,
+        lhs_dart_id: DartIdType,
+        rhs_dart_id: DartIdType,
+    ) -> Result<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -123,7 +126,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to [`unlink`][Self::unlink], but internally uses a transaction
     /// that will be retried until validated.
-    pub fn force_unlink<const I: u8>(&self, lhs_dart_id: DartIdType) {
+    pub fn force_unlink<const I: u8>(&self, lhs_dart_id: DartIdType) -> Result<(), LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim3/links/one.rs
+++ b/honeycomb-core/src/cmap/dim3/links/one.rs
@@ -1,5 +1,7 @@
 //! 1D link implementations
 
+use fast_stm::abort;
+
 use crate::{
     cmap::{CMap3, DartIdType, LinkError, NULL_DART_ID},
     prelude::CoordsFloat,
@@ -50,7 +52,10 @@ impl<T: CoordsFloat> CMap3<T> {
             self.beta_transac::<3>(trans, rd)?,
         );
         if b3_ld != NULL_DART_ID && b3_rd != NULL_DART_ID {
-            assert!(self.beta_transac::<1>(trans, b3_rd)? == b3_ld);
+            if self.beta_transac::<1>(trans, b3_rd)? != b3_ld {
+                // FIXME: add dedicated variant ~LinkError::DivergentStructures ?
+                abort(LinkError::AsymmetricalFaces(ld, rd))?;
+            }
             self.betas.one_unlink_core(trans, b3_rd)?;
         }
         Ok(())

--- a/honeycomb-core/src/cmap/dim3/links/three.rs
+++ b/honeycomb-core/src/cmap/dim3/links/three.rs
@@ -3,7 +3,7 @@
 use crate::{
     cmap::{CMap3, DartIdType, LinkError, NULL_DART_ID},
     prelude::CoordsFloat,
-    stm::{abort, atomically_with_err, Transaction, TransactionClosureResult},
+    stm::{atomically_with_err, Transaction, TransactionClosureResult},
 };
 
 /// 3-links
@@ -70,9 +70,7 @@ impl<T: CoordsFloat> CMap3<T> {
         ld: DartIdType,
     ) -> TransactionClosureResult<(), LinkError> {
         let rd = self.beta_transac::<3>(trans, ld)?;
-        if rd == NULL_DART_ID {
-            abort(LinkError::AlreadyFree(3, ld))?
-        }
+
         self.betas.three_unlink_core(trans, ld)?;
         let (mut lside, mut rside) = (
             self.beta_transac::<1>(trans, ld)?,

--- a/honeycomb-core/src/cmap/dim3/links/two.rs
+++ b/honeycomb-core/src/cmap/dim3/links/two.rs
@@ -1,10 +1,9 @@
 //! 2D link implementations
 
-use crate::stm::{atomically, StmClosureResult, Transaction};
-
 use crate::{
-    cmap::{CMap3, DartIdType},
+    cmap::{CMap3, DartIdType, LinkError},
     prelude::CoordsFloat,
+    stm::{atomically_with_err, Transaction, TransactionClosureResult},
 };
 
 /// 2-links
@@ -15,13 +14,17 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
     /// 2-link operation.
-    pub(crate) fn force_two_link(&self, lhs_dart_id: DartIdType, rhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id));
+    pub(crate) fn force_two_link(
+        &self,
+        lhs_dart_id: DartIdType,
+        rhs_dart_id: DartIdType,
+    ) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id))
     }
 }
 
@@ -32,12 +35,12 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmClosureResult<()> {
+    ) -> TransactionClosureResult<(), LinkError> {
         self.betas.two_unlink_core(trans, lhs_dart_id)
     }
 
     /// 2-unlink operation.
-    pub(crate) fn force_two_unlink(&self, lhs_dart_id: DartIdType) {
-        atomically(|trans| self.betas.two_unlink_core(trans, lhs_dart_id));
+    pub(crate) fn force_two_unlink(&self, lhs_dart_id: DartIdType) -> Result<(), LinkError> {
+        atomically_with_err(|trans| self.betas.two_unlink_core(trans, lhs_dart_id))
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/mod.rs
@@ -115,6 +115,7 @@ impl<T: CoordsFloat> CMap3<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// `I`-sew operator.
     ///
     /// This variant is equivalent to [`sew`][Self::sew], but internally uses a transaction that
@@ -131,6 +132,7 @@ impl<T: CoordsFloat> CMap3<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     /// `I`-unsew operator.
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that

--- a/honeycomb-core/src/cmap/dim3/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/mod.rs
@@ -2,11 +2,10 @@ mod one;
 mod three;
 mod two;
 
-use crate::stm::Transaction;
-
 use crate::{
-    cmap::{CMap3, CMapResult, DartIdType},
+    cmap::{CMap3, DartIdType, SewError},
     prelude::CoordsFloat,
+    stm::{Transaction, TransactionClosureResult},
 };
 
 /// # **Sew operations**
@@ -52,7 +51,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -64,6 +63,7 @@ impl<T: CoordsFloat> CMap3<T> {
         }
     }
 
+    /// `I`-unsew operator.
     ///
     /// # Description
     ///
@@ -84,7 +84,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// The second dart ID is fetched using `I` and `ld`.
     ///
-    /// # Errors
+    /// # Errors    
     ///
     /// This variant will abort the unsew operation and raise an error if:
     /// - the transaction cannot be completed,
@@ -99,7 +99,11 @@ impl<T: CoordsFloat> CMap3<T> {
     /// The method may panic if:
     /// - `I >= 4` or `I == 0`,
     /// - `ld` is already `I`-free.
-    pub fn unsew<const I: u8>(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
+    pub fn unsew<const I: u8>(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> TransactionClosureResult<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -115,7 +119,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to [`sew`][Self::sew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_sew<const I: u8>(&self, ld: DartIdType, rd: DartIdType) {
+    pub fn force_sew<const I: u8>(&self, ld: DartIdType, rd: DartIdType) -> Result<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -131,7 +135,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn force_unsew<const I: u8>(&self, ld: DartIdType) {
+    pub fn force_unsew<const I: u8>(&self, ld: DartIdType) -> Result<(), SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim3/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/one.rs
@@ -1,11 +1,10 @@
 //! 1D sew implementations
 
-use crate::stm::{atomically, Transaction};
-
 use crate::{
     attributes::UnknownAttributeStorage,
-    cmap::{CMap3, CMapResult, DartIdType, NULL_DART_ID, NULL_VERTEX_ID},
-    prelude::CoordsFloat,
+    cmap::{CMap3, DartIdType, SewError, NULL_DART_ID, NULL_VERTEX_ID},
+    geometry::CoordsFloat,
+    stm::{atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult},
 };
 
 #[doc(hidden)]
@@ -17,7 +16,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         // the main difference with 2D implementation is the beta 3 image check
         // if both darts have a b3 image, then we need to 1-link b3(rd) to b3(ld) as well
         // this is handled by `one_link`, but we need to merge old vertex data
@@ -32,21 +31,27 @@ impl<T: CoordsFloat> CMap3<T> {
         };
         let vid_r_old = self.vertex_id_transac(trans, rd)?;
 
-        self.one_link(trans, ld, rd)?;
+        try_or_coerce!(self.one_link(trans, ld, rd), SewError);
 
         if vid_l_old != NULL_VERTEX_ID {
             let new_vid = vid_r_old.min(vid_l_old); // is this correct?
-            self.vertices
-                .try_merge(trans, new_vid, vid_l_old, vid_r_old)?;
-            self.attributes
-                .try_merge_vertex_attributes(trans, new_vid, vid_l_old, vid_r_old)?;
+            try_or_coerce!(
+                self.vertices
+                    .try_merge(trans, new_vid, vid_l_old, vid_r_old),
+                SewError
+            );
+            try_or_coerce!(
+                self.attributes
+                    .try_merge_vertex_attributes(trans, new_vid, vid_l_old, vid_r_old),
+                SewError
+            );
         }
         Ok(())
     }
 
     /// 1-sew operation.
-    pub(crate) fn force_one_sew(&self, ld: DartIdType, rd: DartIdType) {
-        atomically(|trans| {
+    pub(crate) fn force_one_sew(&self, ld: DartIdType, rd: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             // the main difference with 2D implementation is the beta 3 image check
             // if both darts have a b3 image, then we need to 1-link b3(rd) to b3(ld) as well
             // this is handled by `one_link`, but we need to merge old vertex data
@@ -61,7 +66,7 @@ impl<T: CoordsFloat> CMap3<T> {
             };
             let vid_r_old = self.vertex_id_transac(trans, rd)?;
 
-            self.one_link(trans, ld, rd)?;
+            try_or_coerce!(self.one_link(trans, ld, rd), SewError);
 
             if vid_l_old != NULL_VERTEX_ID {
                 let new_vid = vid_r_old.min(vid_l_old); // is this correct?
@@ -70,18 +75,22 @@ impl<T: CoordsFloat> CMap3<T> {
                     .merge_vertex_attributes(trans, new_vid, vid_l_old, vid_r_old)?;
             }
             Ok(())
-        });
+        })
     }
 }
 
 /// 1-unsews
 impl<T: CoordsFloat> CMap3<T> {
     /// 1-unsew transactional operation.
-    pub(crate) fn one_unsew(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
+    pub(crate) fn one_unsew(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> TransactionClosureResult<(), SewError> {
         let rd = self.beta_transac::<1>(trans, ld)?;
         let vid_old = self.vertex_id_transac(trans, rd)?;
 
-        self.one_unlink(trans, ld)?;
+        try_or_coerce!(self.one_unlink(trans, ld), SewError);
         let b2ld = self.beta_transac::<2>(trans, ld)?;
         let b3ld = self.beta_transac::<3>(trans, ld)?;
 
@@ -99,21 +108,27 @@ impl<T: CoordsFloat> CMap3<T> {
         let vid_r_new = self.vertex_id_transac(trans, rd)?;
         // perf: branch miss vs redundancy
         if vid_l_new != vid_r_new {
-            self.vertices
-                .try_split(trans, vid_l_new, vid_r_new, vid_old)?;
-            self.attributes
-                .try_split_vertex_attributes(trans, vid_l_new, vid_r_new, vid_old)?;
+            try_or_coerce!(
+                self.vertices
+                    .try_split(trans, vid_l_new, vid_r_new, vid_old),
+                SewError
+            );
+            try_or_coerce!(
+                self.attributes
+                    .try_split_vertex_attributes(trans, vid_l_new, vid_r_new, vid_old),
+                SewError
+            );
         }
         Ok(())
     }
 
     /// 1-unsew operation.
-    pub(crate) fn force_one_unsew(&self, ld: DartIdType) {
-        atomically(|trans| {
+    pub(crate) fn force_one_unsew(&self, ld: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             let rd = self.beta_transac::<1>(trans, ld)?;
             let vid_old = self.vertex_id_transac(trans, rd)?;
 
-            self.one_unlink(trans, ld)?;
+            try_or_coerce!(self.one_unlink(trans, ld), SewError);
             let b2ld = self.beta_transac::<2>(trans, ld)?;
             let b3ld = self.beta_transac::<3>(trans, ld)?;
             let vid_l_new = self.vertex_id_transac(
@@ -135,6 +150,6 @@ impl<T: CoordsFloat> CMap3<T> {
                     .split_vertex_attributes(trans, vid_l_new, vid_r_new, vid_old)?;
             }
             Ok(())
-        });
+        })
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -1,13 +1,12 @@
 //! 3D sew implementations
 
-use crate::stm::{atomically, Transaction};
-
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
     cmap::{
-        CMap3, CMapResult, DartIdType, EdgeIdType, Orbit3, OrbitPolicy, VertexIdType, NULL_DART_ID,
+        CMap3, DartIdType, EdgeIdType, Orbit3, OrbitPolicy, SewError, VertexIdType, NULL_DART_ID,
     },
-    prelude::CoordsFloat,
+    geometry::CoordsFloat,
+    stm::{abort, atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult},
 };
 
 /// 3-sews
@@ -18,7 +17,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         // using these custom orbits, I can get both dart of all sides, directly ordered
         // for the merges
         let l_side = Orbit3::new(self, OrbitPolicy::Custom(&[1, 0]), ld);
@@ -52,36 +51,91 @@ impl<T: CoordsFloat> CMap3<T> {
             }
         }
 
+        // FIXME: we only check orientation of the arg darts
+        // ideally, we want to check every sewn pair
+        {
+            let (l, r) = (ld, rd);
+            let (b1l, b2l, b1r, b2r) = (
+                self.beta_transac::<1>(trans, l)?,
+                self.beta_transac::<2>(trans, l)?,
+                self.beta_transac::<1>(trans, r)?,
+                self.beta_transac::<2>(trans, r)?,
+            );
+            let (vid_l, vid_r, vid_b1l, vid_b1r) = (
+                self.vertex_id_transac(trans, l)?,
+                self.vertex_id_transac(trans, r)?,
+                self.vertex_id_transac(trans, if b1l == NULL_DART_ID { b2l } else { b1l })?,
+                self.vertex_id_transac(trans, if b1r == NULL_DART_ID { b2r } else { b1r })?,
+            );
+
+            if let (
+                // (lhs/b1rhs) vertices
+                Some(l_vertex),
+                Some(b1r_vertex),
+                // (b1lhs/rhs) vertices
+                Some(b1l_vertex),
+                Some(r_vertex),
+            ) = (
+                // (lhs/b1rhs)
+                self.vertices.read(trans, vid_l)?,
+                self.vertices.read(trans, vid_b1r)?,
+                // (b1lhs/rhs)
+                self.vertices.read(trans, vid_b1l)?,
+                self.vertices.read(trans, vid_r)?,
+            ) {
+                let lhs_vector = b1l_vertex - l_vertex;
+                let rhs_vector = b1r_vertex - r_vertex;
+                // dot product should be negative if the two darts have opposite direction
+                // we could also put restriction on the angle made by the two darts to prevent
+                // drastic deformation
+                if lhs_vector.dot(&rhs_vector) < T::zero() {
+                    abort(SewError::BadGeometry(3, ld, rd))?
+                }
+            };
+        }
+
         // (*): these branch corresponds to incomplete merges (at best),
         //      or incorrect structure (at worst). that's not a problem
         //      because `three_link` will detect inconsistencies
-        self.three_link(trans, ld, rd)?;
+        try_or_coerce!(self.three_link(trans, ld, rd), SewError);
 
         // merge face, edge, vertex attributes
-        self.attributes
-            .try_merge_face_attributes(trans, l_face.min(r_face), l_face, r_face)?;
+        try_or_coerce!(
+            self.attributes
+                .try_merge_face_attributes(trans, l_face.min(r_face), l_face, r_face),
+            SewError
+        );
 
         for (eid_l, eid_r) in edges.into_iter().filter(|&(eid_l, eid_r)| {
             eid_l != eid_r && eid_l != NULL_DART_ID && eid_r != NULL_DART_ID
         }) {
-            self.attributes
-                .try_merge_edge_attributes(trans, eid_l.min(eid_r), eid_l, eid_r)?;
+            try_or_coerce!(
+                self.attributes
+                    .try_merge_edge_attributes(trans, eid_l.min(eid_r), eid_l, eid_r),
+                SewError
+            );
         }
         for (vid_l, vid_r) in vertices.into_iter().filter(|&(vid_l, vid_r)| {
             vid_l != vid_r && vid_l != NULL_DART_ID && vid_r != NULL_DART_ID
         }) {
-            self.vertices
-                .try_merge(trans, vid_l.min(vid_r), vid_l, vid_r)?;
-            self.attributes
-                .try_merge_vertex_attributes(trans, vid_l.min(vid_r), vid_l, vid_r)?;
+            try_or_coerce!(
+                self.vertices
+                    .try_merge(trans, vid_l.min(vid_r), vid_l, vid_r),
+                SewError
+            );
+            try_or_coerce!(
+                self.attributes
+                    .try_merge_vertex_attributes(trans, vid_l.min(vid_r), vid_l, vid_r),
+                SewError
+            );
         }
 
         Ok(())
     }
 
     /// 3-sew operation.
-    pub(crate) fn force_three_sew(&self, ld: DartIdType, rd: DartIdType) {
-        atomically(|trans| {
+    pub(crate) fn force_three_sew(&self, ld: DartIdType, rd: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             // using these custom orbits, I can get both dart of all sides, directly ordered
             // for the merges
             let l_side = Orbit3::new(self, OrbitPolicy::Custom(&[1, 0]), ld);
@@ -151,18 +205,16 @@ impl<T: CoordsFloat> CMap3<T> {
                     // dot product should be negative if the two darts have opposite direction
                     // we could also put restriction on the angle made by the two darts to prevent
                     // drastic deformation
-                    assert!(
-                        lhs_vector.dot(&rhs_vector) < T::zero(),
-                        "{}",
-                        format!("Dart {l} and {r} do not have consistent orientation for 3-sewing"),
-                    );
+                    if lhs_vector.dot(&rhs_vector) < T::zero() {
+                        abort(SewError::BadGeometry(3, ld, rd))?
+                    }
                 };
             }
 
             // (*): these branch corresponds to incomplete merges (at best),
             //      or incorrect structure (at worst). that's not a problem
             //      because `three_link` will detect inconsistencies
-            self.three_link(trans, ld, rd)?;
+            try_or_coerce!(self.three_link(trans, ld, rd), SewError);
 
             // merge face, edge, vertex attributes
             self.attributes
@@ -182,20 +234,95 @@ impl<T: CoordsFloat> CMap3<T> {
             }
 
             Ok(())
-        });
+        })
     }
 }
 
 /// 3-unsews
 impl<T: CoordsFloat> CMap3<T> {
     /// 3-unsew operation.
-    pub(crate) fn three_unsew(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
+    pub(crate) fn three_unsew(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> TransactionClosureResult<(), SewError> {
         let rd = self.beta_transac::<3>(trans, ld)?;
-        if rd == NULL_DART_ID {
-            // ?
-            Ok(())
-        } else {
-            self.unlink::<3>(trans, ld)?;
+
+        try_or_coerce!(self.unlink::<3>(trans, ld), SewError);
+
+        let l_side = Orbit3::new(self, OrbitPolicy::Custom(&[1, 0]), ld);
+        let r_side = Orbit3::new(self, OrbitPolicy::Custom(&[0, 1]), rd);
+
+        // faces
+        let l_face = l_side.clone().min().expect("E: unreachable");
+        let r_face = r_side.clone().min().expect("E: unreachable");
+        try_or_coerce!(
+            self.attributes
+                .try_split_face_attributes(trans, l_face, r_face, l_face.max(r_face)),
+            SewError
+        );
+
+        for (l, r) in l_side.zip(r_side) {
+            // edge
+            let (eid_l, eid_r) = (
+                self.edge_id_transac(trans, l)?,
+                self.edge_id_transac(trans, r)?,
+            );
+            try_or_coerce!(
+                self.attributes
+                    .try_split_edge_attributes(trans, eid_l, eid_r, eid_l.max(eid_r)),
+                SewError
+            );
+
+            // vertices
+            let b1l = self.beta_transac::<1>(trans, l)?;
+            let b2l = self.beta_transac::<2>(trans, l)?;
+            let (vid_l, vid_r) = (
+                self.vertex_id_transac(trans, if b1l == NULL_DART_ID { b2l } else { b1l })?,
+                self.vertex_id_transac(trans, r)?,
+            );
+            try_or_coerce!(
+                self.vertices
+                    .try_split(trans, vid_l, vid_r, vid_l.max(vid_r)),
+                SewError
+            );
+            try_or_coerce!(
+                self.attributes
+                    .try_split_vertex_attributes(trans, vid_l, vid_r, vid_l.max(vid_r)),
+                SewError
+            );
+            if self.beta_transac::<0>(trans, l)? == NULL_DART_ID {
+                let b1r = self.beta_transac::<1>(trans, r)?;
+                let b2r = self.beta_transac::<2>(trans, r)?;
+                let (lvid_l, lvid_r) = (
+                    self.vertex_id_transac(trans, l)?,
+                    self.vertex_id_transac(trans, if b1r == NULL_DART_ID { b2r } else { b1r })?,
+                );
+                try_or_coerce!(
+                    self.vertices
+                        .try_split(trans, lvid_l, lvid_r, lvid_l.max(lvid_r)),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes.try_split_vertex_attributes(
+                        trans,
+                        lvid_l,
+                        lvid_r,
+                        lvid_l.max(lvid_r),
+                    ),
+                    SewError
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// 3-unsew operation.
+    pub(crate) fn force_three_unsew(&self, ld: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
+            let rd = self.beta_transac::<3>(trans, ld)?;
+
+            try_or_coerce!(self.unlink::<3>(trans, ld), SewError);
 
             let l_side = Orbit3::new(self, OrbitPolicy::Custom(&[1, 0]), ld);
             let r_side = Orbit3::new(self, OrbitPolicy::Custom(&[0, 1]), rd);
@@ -204,7 +331,7 @@ impl<T: CoordsFloat> CMap3<T> {
             let l_face = l_side.clone().min().expect("E: unreachable");
             let r_face = r_side.clone().min().expect("E: unreachable");
             self.attributes
-                .try_split_face_attributes(trans, l_face, r_face, l_face.max(r_face))?;
+                .split_face_attributes(trans, l_face, r_face, l_face.max(r_face))?;
 
             for (l, r) in l_side.zip(r_side) {
                 // edge
@@ -213,7 +340,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     self.edge_id_transac(trans, r)?,
                 );
                 self.attributes
-                    .try_split_edge_attributes(trans, eid_l, eid_r, eid_l.max(eid_r))?;
+                    .split_edge_attributes(trans, eid_l, eid_r, eid_l.max(eid_r))?;
 
                 // vertices
                 let b1l = self.beta_transac::<1>(trans, l)?;
@@ -222,14 +349,9 @@ impl<T: CoordsFloat> CMap3<T> {
                     self.vertex_id_transac(trans, if b1l == NULL_DART_ID { b2l } else { b1l })?,
                     self.vertex_id_transac(trans, r)?,
                 );
-                self.vertices
-                    .try_split(trans, vid_l, vid_r, vid_l.max(vid_r))?;
-                self.attributes.try_split_vertex_attributes(
-                    trans,
-                    vid_l,
-                    vid_r,
-                    vid_l.max(vid_r),
-                )?;
+                self.vertices.split(trans, vid_l, vid_r, vid_l.max(vid_r))?;
+                self.attributes
+                    .split_vertex_attributes(trans, vid_l, vid_r, vid_l.max(vid_r))?;
                 if self.beta_transac::<0>(trans, l)? == NULL_DART_ID {
                     let b1r = self.beta_transac::<1>(trans, r)?;
                     let b2r = self.beta_transac::<2>(trans, r)?;
@@ -238,8 +360,8 @@ impl<T: CoordsFloat> CMap3<T> {
                         self.vertex_id_transac(trans, if b1r == NULL_DART_ID { b2r } else { b1r })?,
                     );
                     self.vertices
-                        .try_split(trans, lvid_l, lvid_r, lvid_l.max(lvid_r))?;
-                    self.attributes.try_split_vertex_attributes(
+                        .split(trans, lvid_l, lvid_r, lvid_l.max(lvid_r))?;
+                    self.attributes.split_vertex_attributes(
                         trans,
                         lvid_l,
                         lvid_r,
@@ -248,73 +370,6 @@ impl<T: CoordsFloat> CMap3<T> {
                 }
             }
             Ok(())
-        }
-    }
-
-    /// 3-unsew operation.
-    pub(crate) fn force_three_unsew(&self, ld: DartIdType) {
-        atomically(|trans| {
-            let rd = self.beta_transac::<3>(trans, ld)?;
-            if rd == NULL_DART_ID {
-                // ?
-                Ok(())
-            } else {
-                self.unlink::<3>(trans, ld)?;
-
-                let l_side = Orbit3::new(self, OrbitPolicy::Custom(&[1, 0]), ld);
-                let r_side = Orbit3::new(self, OrbitPolicy::Custom(&[0, 1]), rd);
-
-                // faces
-                let l_face = l_side.clone().min().expect("E: unreachable");
-                let r_face = r_side.clone().min().expect("E: unreachable");
-                self.attributes
-                    .split_face_attributes(trans, l_face, r_face, l_face.max(r_face))?;
-
-                for (l, r) in l_side.zip(r_side) {
-                    // edge
-                    let (eid_l, eid_r) = (
-                        self.edge_id_transac(trans, l)?,
-                        self.edge_id_transac(trans, r)?,
-                    );
-                    self.attributes
-                        .split_edge_attributes(trans, eid_l, eid_r, eid_l.max(eid_r))?;
-
-                    // vertices
-                    let b1l = self.beta_transac::<1>(trans, l)?;
-                    let b2l = self.beta_transac::<2>(trans, l)?;
-                    let (vid_l, vid_r) = (
-                        self.vertex_id_transac(trans, if b1l == NULL_DART_ID { b2l } else { b1l })?,
-                        self.vertex_id_transac(trans, r)?,
-                    );
-                    self.vertices.split(trans, vid_l, vid_r, vid_l.max(vid_r))?;
-                    self.attributes.split_vertex_attributes(
-                        trans,
-                        vid_l,
-                        vid_r,
-                        vid_l.max(vid_r),
-                    )?;
-                    if self.beta_transac::<0>(trans, l)? == NULL_DART_ID {
-                        let b1r = self.beta_transac::<1>(trans, r)?;
-                        let b2r = self.beta_transac::<2>(trans, r)?;
-                        let (lvid_l, lvid_r) = (
-                            self.vertex_id_transac(trans, l)?,
-                            self.vertex_id_transac(
-                                trans,
-                                if b1r == NULL_DART_ID { b2r } else { b1r },
-                            )?,
-                        );
-                        self.vertices
-                            .split(trans, lvid_l, lvid_r, lvid_l.max(lvid_r))?;
-                        self.attributes.split_vertex_attributes(
-                            trans,
-                            lvid_l,
-                            lvid_r,
-                            lvid_l.max(lvid_r),
-                        )?;
-                    }
-                }
-                Ok(())
-            }
-        });
+        })
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -88,7 +88,7 @@ impl<T: CoordsFloat> CMap3<T> {
                 // dot product should be negative if the two darts have opposite direction
                 // we could also put restriction on the angle made by the two darts to prevent
                 // drastic deformation
-                if lhs_vector.dot(&rhs_vector) < T::zero() {
+                if lhs_vector.dot(&rhs_vector) >= T::zero() {
                     abort(SewError::BadGeometry(3, ld, rd))?
                 }
             };
@@ -205,7 +205,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     // dot product should be negative if the two darts have opposite direction
                     // we could also put restriction on the angle made by the two darts to prevent
                     // drastic deformation
-                    if lhs_vector.dot(&rhs_vector) < T::zero() {
+                    if lhs_vector.dot(&rhs_vector) >= T::zero() {
                         abort(SewError::BadGeometry(3, ld, rd))?
                     }
                 };

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -89,7 +89,7 @@ impl<T: CoordsFloat> CMap3<T> {
                 // we could also put restriction on the angle made by the two darts to prevent
                 // drastic deformation
                 if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                    abort(SewError::BadGeometry(3, ld, rd))?
+                    abort(SewError::BadGeometry(3, ld, rd))?;
                 }
             };
         }
@@ -206,7 +206,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     // we could also put restriction on the angle made by the two darts to prevent
                     // drastic deformation
                     if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                        abort(SewError::BadGeometry(3, ld, rd))?
+                        abort(SewError::BadGeometry(3, ld, rd))?;
                     }
                 };
             }

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -112,13 +112,9 @@ impl<T: CoordsFloat> CMap3<T> {
                     // dot product should be negative if the two darts have opposite direction
                     // we could also put restriction on the angle made by the two darts to prevent
                     // drastic deformation
-                    assert!(
-                        lhs_vector.dot(&rhs_vector) < T::zero(),
-                        "{}",
-                        format!(
-                            "Dart {ld} and {rd} do not have consistent orientation for 2-sewing"
-                        ),
-                    );
+                    if lhs_vector.dot(&rhs_vector) >= T::zero() {
+                        abort(SewError::BadGeometry(2, ld, rd))?
+                    }
                 };
 
                 // update the topology
@@ -237,7 +233,7 @@ impl<T: CoordsFloat> CMap3<T> {
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
                         if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                            abort(SewError::BadGeometry(3, ld, rd))?
+                            abort(SewError::BadGeometry(2, ld, rd))?
                         }
                     };
 

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -9,6 +9,7 @@ use crate::{
 
 /// 2-sews
 impl<T: CoordsFloat> CMap3<T> {
+    #[allow(clippy::too_many_lines)]
     /// 2-sew transactional operation.
     pub(crate) fn two_sew(
         &self,
@@ -113,7 +114,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     // we could also put restriction on the angle made by the two darts to prevent
                     // drastic deformation
                     if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                        abort(SewError::BadGeometry(2, ld, rd))?
+                        abort(SewError::BadGeometry(2, ld, rd))?;
                     }
                 };
 
@@ -233,7 +234,7 @@ impl<T: CoordsFloat> CMap3<T> {
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
                         if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                            abort(SewError::BadGeometry(2, ld, rd))?
+                            abort(SewError::BadGeometry(2, ld, rd))?;
                         }
                     };
 
@@ -383,7 +384,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     // split attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes
-                        .split_edge_attributes(trans, ld, rd, eid_old);
+                        .split_edge_attributes(trans, ld, rd, eid_old)?;
                 }
                 (true, false) => {
                     // fetch IDs before topology update

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -1,11 +1,10 @@
 //! 2D sew implementations
 
-use crate::stm::{atomically, Transaction};
-
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},
-    cmap::{CMap3, CMapResult, DartIdType, NULL_DART_ID},
-    prelude::CoordsFloat,
+    cmap::{CMap3, DartIdType, SewError, NULL_DART_ID},
+    geometry::CoordsFloat,
+    stm::{abort, atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult},
 };
 
 /// 2-sews
@@ -16,14 +15,15 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), SewError> {
         let b1ld = self.betas[(1, ld)].read(trans)?;
         let b1rd = self.betas[(1, rd)].read(trans)?;
         // match (is lhs 1-free, is rhs 1-free)
         match (b1ld == NULL_DART_ID, b1rd == NULL_DART_ID) {
             // trivial case, no update needed
             (true, true) => {
-                self.betas.two_link_core(trans, ld, rd)?;
+                try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
+                // FIXME: merge edge attributes
             }
             // update vertex associated to b1rhs/lhs
             (true, false) => {
@@ -33,15 +33,24 @@ impl<T: CoordsFloat> CMap3<T> {
                 let vid_l = self.vertex_id_transac(trans, ld)?;
                 let vid_b1r = self.vertex_id_transac(trans, b1rd)?;
                 // update the topology
-                self.betas.two_link_core(trans, ld, rd)?;
+                try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                 // merge vertices & attributes from the old IDs to the new one
                 let vid_l_new = self.vertex_id_transac(trans, ld)?;
                 let eid_new = self.edge_id_transac(trans, ld)?;
-                self.vertices.try_merge(trans, vid_l_new, vid_l, vid_b1r)?;
-                self.attributes
-                    .try_merge_vertex_attributes(trans, vid_l_new, vid_l, vid_b1r)?;
-                self.attributes
-                    .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r)?;
+                try_or_coerce!(
+                    self.vertices.try_merge(trans, vid_l_new, vid_l, vid_b1r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_vertex_attributes(trans, vid_l_new, vid_l, vid_b1r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r),
+                    SewError
+                );
             }
             // update vertex associated to b1lhs/rhs
             (false, true) => {
@@ -51,15 +60,24 @@ impl<T: CoordsFloat> CMap3<T> {
                 let vid_b1l = self.vertex_id_transac(trans, b1ld)?;
                 let vid_r = self.vertex_id_transac(trans, rd)?;
                 // update the topology
-                self.betas.two_link_core(trans, ld, rd)?;
+                try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                 // merge vertices & attributes from the old IDs to the new one
                 let vid_r_new = self.vertex_id_transac(trans, rd)?;
                 let eid_new = self.edge_id_transac(trans, ld)?;
-                self.vertices.try_merge(trans, vid_r_new, vid_b1l, vid_r)?;
-                self.attributes
-                    .try_merge_vertex_attributes(trans, vid_r_new, vid_b1l, vid_r)?;
-                self.attributes
-                    .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r)?;
+                try_or_coerce!(
+                    self.vertices.try_merge(trans, vid_r_new, vid_b1l, vid_r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_vertex_attributes(trans, vid_r_new, vid_b1l, vid_r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r),
+                    SewError
+                );
             }
             // update both vertices making up the edge
             (false, false) => {
@@ -104,34 +122,50 @@ impl<T: CoordsFloat> CMap3<T> {
                 };
 
                 // update the topology
-                self.betas.two_link_core(trans, ld, rd)?;
+                try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                 // merge vertices & attributes from the old IDs to the new one
                 let vid_l_new = self.vertex_id_transac(trans, ld)?;
                 let vid_r_new = self.vertex_id_transac(trans, rd)?;
                 let eid_new = self.edge_id_transac(trans, ld)?;
-                self.vertices.try_merge(trans, vid_l_new, vid_l, vid_b1r)?;
-                self.vertices.try_merge(trans, vid_r_new, vid_b1l, vid_r)?;
-                self.attributes
-                    .try_merge_vertex_attributes(trans, vid_l_new, vid_l, vid_b1r)?;
-                self.attributes
-                    .try_merge_vertex_attributes(trans, vid_r_new, vid_b1l, vid_r)?;
-                self.attributes
-                    .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r)?;
+                try_or_coerce!(
+                    self.vertices.try_merge(trans, vid_l_new, vid_l, vid_b1r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.vertices.try_merge(trans, vid_r_new, vid_b1l, vid_r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_vertex_attributes(trans, vid_l_new, vid_l, vid_b1r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_vertex_attributes(trans, vid_r_new, vid_b1l, vid_r),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r),
+                    SewError
+                );
             }
         }
         Ok(())
     }
 
     /// 2-sew operation.
-    pub(crate) fn force_two_sew(&self, ld: DartIdType, rd: DartIdType) {
-        atomically(|trans| {
+    pub(crate) fn force_two_sew(&self, ld: DartIdType, rd: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             let b1ld = self.betas[(1, ld)].read(trans)?;
             let b1rd = self.betas[(1, rd)].read(trans)?;
             // match (is lhs 1-free, is rhs 1-free)
             match (b1ld == NULL_DART_ID, b1rd == NULL_DART_ID) {
                 // trivial case, no update needed
                 (true, true) => {
-                    self.betas.two_link_core(trans, ld, rd)?;
+                    try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
+                    // FIXME: merge edge attributes
                 }
                 // update vertex associated to b1rhs/lhs
                 (true, false) => {
@@ -141,7 +175,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     let vid_l = self.vertex_id_transac(trans, ld)?;
                     let vid_b1r = self.vertex_id_transac(trans, b1rd)?;
                     // update the topology
-                    self.betas.two_link_core(trans, ld, rd)?;
+                    try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                     // merge vertices & attributes from the old IDs to the new one
                     let vid_l_new = self.vertex_id_transac(trans, ld)?;
                     let eid_new = self.edge_id_transac(trans, ld)?;
@@ -159,7 +193,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     let vid_b1l = self.vertex_id_transac(trans, b1ld)?;
                     let vid_r = self.vertex_id_transac(trans, rd)?;
                     // update the topology
-                    self.betas.two_link_core(trans, ld, rd)?;
+                    try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                     // merge vertices & attributes from the old IDs to the new one
                     let vid_r_new = self.vertex_id_transac(trans, rd)?;
                     let eid_new = self.edge_id_transac(trans, ld)?;
@@ -202,17 +236,13 @@ impl<T: CoordsFloat> CMap3<T> {
                         // dot product should be negative if the two darts have opposite direction
                         // we could also put restriction on the angle made by the two darts to prevent
                         // drastic deformation
-                        assert!(
-                            lhs_vector.dot(&rhs_vector) < T::zero(),
-                            "{}",
-                            format!(
-                            "Dart {ld} and {rd} do not have consistent orientation for 2-sewing"
-                        ),
-                        );
+                        if lhs_vector.dot(&rhs_vector) >= T::zero() {
+                            abort(SewError::BadGeometry(3, ld, rd))?
+                        }
                     };
 
                     // update the topology
-                    self.betas.two_link_core(trans, ld, rd)?;
+                    try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
                     // merge vertices & attributes from the old IDs to the new one
                     let vid_l_new = self.vertex_id_transac(trans, ld)?;
                     let vid_r_new = self.vertex_id_transac(trans, rd)?;
@@ -228,14 +258,18 @@ impl<T: CoordsFloat> CMap3<T> {
                 }
             }
             Ok(())
-        });
+        })
     }
 }
 
 /// 2-unsews
 impl<T: CoordsFloat> CMap3<T> {
     /// 2-unsew transactional operation.
-    pub(crate) fn two_unsew(&self, trans: &mut Transaction, ld: DartIdType) -> CMapResult<()> {
+    pub(crate) fn two_unsew(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> TransactionClosureResult<(), SewError> {
         let rd = self.betas[(2, ld)].read(trans)?;
         let b1ld = self.betas[(1, ld)].read(trans)?;
         let b1rd = self.betas[(1, rd)].read(trans)?;
@@ -245,45 +279,60 @@ impl<T: CoordsFloat> CMap3<T> {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, ld)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, ld)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                 // split attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes
-                    .try_split_edge_attributes(trans, ld, rd, eid_old)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_edge_attributes(trans, ld, rd, eid_old),
+                    SewError
+                );
             }
             (true, false) => {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, ld)?;
                 let vid_l = self.vertex_id_transac(trans, ld)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, ld)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                 // split vertex & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes
-                    .try_split_edge_attributes(trans, ld, rd, eid_old)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_edge_attributes(trans, ld, rd, eid_old),
+                    SewError
+                );
                 let (vid_l_newl, vid_l_newr) = (
                     self.vertex_id_transac(trans, ld)?,
                     self.vertex_id_transac(trans, b1rd)?,
                 );
-                self.attributes
-                    .try_split_vertex_attributes(trans, vid_l_newl, vid_l_newr, vid_l)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_vertex_attributes(trans, vid_l_newl, vid_l_newr, vid_l),
+                    SewError
+                );
             }
             (false, true) => {
                 // fetch IDs before topology update
                 let eid_old = self.edge_id_transac(trans, ld)?;
                 let vid_r = self.vertex_id_transac(trans, rd)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, ld)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                 // split vertex & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes
-                    .try_split_edge_attributes(trans, ld, rd, eid_old)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_edge_attributes(trans, ld, rd, eid_old),
+                    SewError
+                );
                 let (vid_r_newl, vid_r_newr) = (
                     self.vertex_id_transac(trans, b1ld)?,
                     self.vertex_id_transac(trans, rd)?,
                 );
-                self.attributes
-                    .try_split_vertex_attributes(trans, vid_r_newl, vid_r_newr, vid_r)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_vertex_attributes(trans, vid_r_newl, vid_r_newr, vid_r),
+                    SewError
+                );
             }
             (false, false) => {
                 // fetch IDs before topology update
@@ -291,11 +340,14 @@ impl<T: CoordsFloat> CMap3<T> {
                 let vid_l = self.vertex_id_transac(trans, ld)?;
                 let vid_r = self.vertex_id_transac(trans, rd)?;
                 // update the topology
-                self.betas.two_unlink_core(trans, ld)?;
+                try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                 // split vertices & attributes from the old ID to the new ones
                 // FIXME: VertexIdentifier should be cast to DartIdentifier
-                self.attributes
-                    .try_split_edge_attributes(trans, ld, rd, eid_old)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_edge_attributes(trans, ld, rd, eid_old),
+                    SewError
+                );
                 let (vid_l_newl, vid_l_newr) = (
                     self.vertex_id_transac(trans, ld)?,
                     self.vertex_id_transac(trans, b1rd)?,
@@ -304,18 +356,24 @@ impl<T: CoordsFloat> CMap3<T> {
                     self.vertex_id_transac(trans, b1ld)?,
                     self.vertex_id_transac(trans, rd)?,
                 );
-                self.attributes
-                    .try_split_vertex_attributes(trans, vid_l_newl, vid_l_newr, vid_l)?;
-                self.attributes
-                    .try_split_vertex_attributes(trans, vid_r_newl, vid_r_newr, vid_r)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_vertex_attributes(trans, vid_l_newl, vid_l_newr, vid_l),
+                    SewError
+                );
+                try_or_coerce!(
+                    self.attributes
+                        .try_split_vertex_attributes(trans, vid_r_newl, vid_r_newr, vid_r),
+                    SewError
+                );
             }
         }
         Ok(())
     }
 
     /// 2-unsew operation.
-    pub(crate) fn force_two_unsew(&self, ld: DartIdType) {
-        atomically(|trans| {
+    pub(crate) fn force_two_unsew(&self, ld: DartIdType) -> Result<(), SewError> {
+        atomically_with_err(|trans| {
             let rd = self.betas[(2, ld)].read(trans)?;
             let b1ld = self.betas[(1, ld)].read(trans)?;
             let b1rd = self.betas[(1, rd)].read(trans)?;
@@ -325,18 +383,18 @@ impl<T: CoordsFloat> CMap3<T> {
                     // fetch IDs before topology update
                     let eid_old = self.edge_id_transac(trans, ld)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, ld)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                     // split attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes
-                        .split_edge_attributes(trans, ld, rd, eid_old)?;
+                        .split_edge_attributes(trans, ld, rd, eid_old);
                 }
                 (true, false) => {
                     // fetch IDs before topology update
                     let eid_old = self.edge_id_transac(trans, ld)?;
                     let vid_l = self.vertex_id_transac(trans, ld)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, ld)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                     // split vertex & attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes
@@ -353,7 +411,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     let eid_old = self.edge_id_transac(trans, ld)?;
                     let vid_r = self.vertex_id_transac(trans, rd)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, ld)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                     // split vertex & attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes
@@ -371,7 +429,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     let vid_l = self.vertex_id_transac(trans, ld)?;
                     let vid_r = self.vertex_id_transac(trans, rd)?;
                     // update the topology
-                    self.betas.two_unlink_core(trans, ld)?;
+                    try_or_coerce!(self.betas.two_unlink_core(trans, ld), SewError);
                     // split vertices & attributes from the old ID to the new ones
                     // FIXME: VertexIdentifier should be cast to DartIdentifier
                     self.attributes
@@ -391,6 +449,6 @@ impl<T: CoordsFloat> CMap3<T> {
                 }
             }
             Ok(())
-        });
+        })
     }
 }

--- a/honeycomb-core/src/cmap/dim3/tests.rs
+++ b/honeycomb-core/src/cmap/dim3/tests.rs
@@ -556,13 +556,9 @@ fn sew_ordering() {
         // this will result in a single vertex being defined, of ID 2
         // depending on the order of execution of the sews, the value may change
 
-        let t1 = loom::thread::spawn(move || {
-            m1.force_sew::<1>(1, 3);
-        });
+        let t1 = loom::thread::spawn(move || while let Err(_) = m1.force_sew::<1>(1, 3) {});
 
-        let t2 = loom::thread::spawn(move || {
-            m2.force_sew::<2>(3, 4);
-        });
+        let t2 = loom::thread::spawn(move || while let Err(_) = m2.force_sew::<2>(3, 4) {});
 
         t1.join().unwrap();
         t2.join().unwrap();
@@ -586,8 +582,8 @@ fn sew_ordering_with_transactions() {
     loom::model(|| {
         // setup the map
         let map: CMap3<f64> = CMap3::new(5);
-        map.force_link::<2>(1, 2);
-        map.force_link::<2>(3, 4);
+        map.force_link::<2>(1, 2).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
         // only one vertex is defined
         // the idea is to use CMapError, along with transaction control to ensure
         // we don't proceed with a sew on no value
@@ -698,10 +694,10 @@ fn unsew_ordering() {
         let mut map: CMap3<f64> = CMap3::new(5);
         map.attributes.add_storage::<Weight>(6);
 
-        map.force_link::<2>(1, 2);
-        map.force_link::<2>(3, 4);
-        map.force_link::<1>(1, 3);
-        map.force_link::<1>(4, 5);
+        map.force_link::<2>(1, 2).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
+        map.force_link::<1>(1, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
         map.force_write_vertex(2, Vertex3(0.0, 0.0, 0.0));
         map.force_write_attribute(2, Weight(33));
         let arc = loom::sync::Arc::new(map);
@@ -712,13 +708,9 @@ fn unsew_ordering() {
         // - 2-unsew 3 and 4 (t2)
         // this will result in different weights, defined on IDs 2, 3, and 5
 
-        let t1 = loom::thread::spawn(move || {
-            m1.force_unsew::<1>(1);
-        });
+        let t1 = loom::thread::spawn(move || while let Err(_) = m1.force_unsew::<1>(1) {});
 
-        let t2 = loom::thread::spawn(move || {
-            m2.force_unsew::<2>(3);
-        });
+        let t2 = loom::thread::spawn(move || while let Err(_) = m2.force_unsew::<2>(3) {});
 
         t1.join().unwrap();
         t2.join().unwrap();

--- a/honeycomb-core/src/cmap/dim3/tests.rs
+++ b/honeycomb-core/src/cmap/dim3/tests.rs
@@ -4,7 +4,7 @@ use fast_stm::{atomically_with_err, TransactionError};
 
 use crate::{
     attributes::{AttrSparseVec, AttributeBind, AttributeError, AttributeUpdate},
-    cmap::{CMap3, DartIdType, Orbit3, OrbitPolicy, VertexIdType},
+    cmap::{CMap3, DartIdType, Orbit3, OrbitPolicy, SewError, VertexIdType},
     geometry::Vertex3,
     stm::{atomically, StmError, TVar},
 };
@@ -17,28 +17,28 @@ fn example_test() {
     let mut map: CMap3<f64> = CMap3::new(12); // 3*4 darts
 
     // face z- (base)
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 1);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 1).unwrap();
     // face y-
-    map.force_link::<1>(4, 5);
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 4);
+    map.force_link::<1>(4, 5).unwrap();
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 4).unwrap();
     // face x-
-    map.force_link::<1>(7, 8);
-    map.force_link::<1>(8, 9);
-    map.force_link::<1>(9, 7);
+    map.force_link::<1>(7, 8).unwrap();
+    map.force_link::<1>(8, 9).unwrap();
+    map.force_link::<1>(9, 7).unwrap();
     // face x+/y+
-    map.force_link::<1>(10, 11);
-    map.force_link::<1>(11, 12);
-    map.force_link::<1>(12, 10);
+    map.force_link::<1>(10, 11).unwrap();
+    map.force_link::<1>(11, 12).unwrap();
+    map.force_link::<1>(12, 10).unwrap();
     // link triangles to get the tet
-    map.force_link::<2>(1, 4);
-    map.force_link::<2>(2, 7);
-    map.force_link::<2>(3, 10);
-    map.force_link::<2>(5, 12);
-    map.force_link::<2>(6, 8);
-    map.force_link::<2>(9, 11);
+    map.force_link::<2>(1, 4).unwrap();
+    map.force_link::<2>(2, 7).unwrap();
+    map.force_link::<2>(3, 10).unwrap();
+    map.force_link::<2>(5, 12).unwrap();
+    map.force_link::<2>(6, 8).unwrap();
+    map.force_link::<2>(9, 11).unwrap();
 
     // putting this in a scope to force dropping the iterator before the next mutable borrow
     {
@@ -59,28 +59,28 @@ fn example_test() {
 
     let _ = map.add_free_darts(12);
     // face z- (base)
-    map.force_link::<1>(13, 14);
-    map.force_link::<1>(14, 15);
-    map.force_link::<1>(15, 13);
+    map.force_link::<1>(13, 14).unwrap();
+    map.force_link::<1>(14, 15).unwrap();
+    map.force_link::<1>(15, 13).unwrap();
     // face x-/y-
-    map.force_link::<1>(16, 17);
-    map.force_link::<1>(17, 18);
-    map.force_link::<1>(18, 16);
+    map.force_link::<1>(16, 17).unwrap();
+    map.force_link::<1>(17, 18).unwrap();
+    map.force_link::<1>(18, 16).unwrap();
     // face y+
-    map.force_link::<1>(19, 20);
-    map.force_link::<1>(20, 21);
-    map.force_link::<1>(21, 19);
+    map.force_link::<1>(19, 20).unwrap();
+    map.force_link::<1>(20, 21).unwrap();
+    map.force_link::<1>(21, 19).unwrap();
     // face x+
-    map.force_link::<1>(22, 23);
-    map.force_link::<1>(23, 24);
-    map.force_link::<1>(24, 22);
+    map.force_link::<1>(22, 23).unwrap();
+    map.force_link::<1>(23, 24).unwrap();
+    map.force_link::<1>(24, 22).unwrap();
     // link triangles to get the tet
-    map.force_link::<2>(13, 16);
-    map.force_link::<2>(14, 19);
-    map.force_link::<2>(15, 22);
-    map.force_link::<2>(17, 24);
-    map.force_link::<2>(18, 20);
-    map.force_link::<2>(21, 23);
+    map.force_link::<2>(13, 16).unwrap();
+    map.force_link::<2>(14, 19).unwrap();
+    map.force_link::<2>(15, 22).unwrap();
+    map.force_link::<2>(17, 24).unwrap();
+    map.force_link::<2>(18, 20).unwrap();
+    map.force_link::<2>(21, 23).unwrap();
 
     map.force_write_vertex(13, (2.5, 1.5, 0.0));
     map.force_write_vertex(14, (1.5, 2.0, 0.0));
@@ -118,7 +118,7 @@ fn example_test() {
     );
 
     assert_eq!(map.n_vertices(), 8);
-    map.force_sew::<3>(10, 16);
+    map.force_sew::<3>(10, 16).unwrap();
     assert_eq!(map.n_vertices(), 5);
 
     // this results in a quad-base pyramid
@@ -165,21 +165,21 @@ fn example_test() {
         let ld = map.beta::<2>(dart);
         let rd = map.beta::<2>(b3d);
 
-        map.force_unsew::<2>(dart);
-        map.force_unsew::<2>(b3d);
-        map.force_sew::<2>(ld, rd);
+        map.force_unsew::<2>(dart).unwrap();
+        map.force_unsew::<2>(b3d).unwrap();
+        map.force_sew::<2>(ld, rd).unwrap();
     }
     rebuild_edge(&map, 10);
     rebuild_edge(&map, 11);
     rebuild_edge(&map, 12);
 
     // delete old face components
-    map.force_unsew::<1>(10);
-    map.force_unsew::<1>(11);
-    map.force_unsew::<1>(12);
-    map.force_unsew::<3>(10);
-    map.force_unsew::<3>(11);
-    map.force_unsew::<3>(12);
+    map.force_unsew::<1>(10).unwrap();
+    map.force_unsew::<1>(11).unwrap();
+    map.force_unsew::<1>(12).unwrap();
+    map.force_unsew::<3>(10).unwrap();
+    map.force_unsew::<3>(11).unwrap();
+    map.force_unsew::<3>(12).unwrap();
     map.remove_free_dart(10);
     map.remove_free_dart(11);
     map.remove_free_dart(12);
@@ -428,30 +428,30 @@ fn remove_dart_twice() {
 fn one_sew() {
     let map: CMap3<f64> = CMap3::new(8);
     // map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 4);
-    map.force_link::<1>(4, 1);
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
+    map.force_link::<1>(4, 1).unwrap();
     map.force_write_vertex(1, Vertex3(0.0, 0.0, 0.0));
     map.force_write_vertex(2, Vertex3(1.0, 0.0, 0.0));
     map.force_write_vertex(3, Vertex3(1.0, 1.0, 0.0));
     map.force_write_vertex(4, Vertex3(0.0, 1.0, 0.0));
 
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 7);
-    map.force_link::<1>(7, 8);
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 7).unwrap();
+    map.force_link::<1>(7, 8).unwrap();
     // map.force_link::<1>(8, 5);
     map.force_write_vertex(5, Vertex3(0.5, 0.0, 1.0));
     map.force_write_vertex(6, Vertex3(0.0, 0.0, 1.0));
     map.force_write_vertex(7, Vertex3(0.0, 1.0, 1.0));
     map.force_write_vertex(8, Vertex3(1.0, 1.0, 1.0));
 
-    map.force_sew::<3>(1, 5);
+    map.force_sew::<3>(1, 5).unwrap();
     assert_eq!(map.beta::<3>(1), 5);
     assert_eq!(map.beta::<3>(2), 8);
     assert_eq!(map.beta::<3>(3), 7);
     assert_eq!(map.beta::<3>(4), 6);
 
-    map.force_sew::<1>(1, 2);
+    map.force_sew::<1>(1, 2).unwrap();
 
     assert_eq!(map.beta::<1>(1), 2);
     assert_eq!(map.beta::<1>(8), 5);
@@ -462,25 +462,25 @@ fn one_sew() {
 #[test]
 fn three_sew() {
     let map: CMap3<f64> = CMap3::new(8);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 4);
-    map.force_link::<1>(4, 1);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
+    map.force_link::<1>(4, 1).unwrap();
     map.force_write_vertex(1, Vertex3(0.0, 0.0, 0.0));
     map.force_write_vertex(2, Vertex3(1.0, 0.0, 0.0));
     map.force_write_vertex(3, Vertex3(1.0, 1.0, 0.0));
     map.force_write_vertex(4, Vertex3(0.0, 1.0, 0.0));
 
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 7);
-    map.force_link::<1>(7, 8);
-    map.force_link::<1>(8, 5);
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 7).unwrap();
+    map.force_link::<1>(7, 8).unwrap();
+    map.force_link::<1>(8, 5).unwrap();
     map.force_write_vertex(5, Vertex3(0.0, 0.0, 1.0));
     map.force_write_vertex(6, Vertex3(0.0, 1.0, 1.0));
     map.force_write_vertex(7, Vertex3(1.0, 1.0, 1.0));
     map.force_write_vertex(8, Vertex3(1.0, 0.0, 1.0));
 
-    map.force_sew::<3>(1, 8);
+    map.force_sew::<3>(1, 8).unwrap();
     assert_eq!(map.force_read_vertex(1).unwrap(), Vertex3(0.0, 0.0, 0.5));
     assert_eq!(map.force_read_vertex(2).unwrap(), Vertex3(1.0, 0.0, 0.5));
     assert_eq!(map.force_read_vertex(3).unwrap(), Vertex3(1.0, 1.0, 0.5));
@@ -488,17 +488,16 @@ fn three_sew() {
 }
 
 #[test]
-#[should_panic(expected = "Dart 1 and 5 do not have consistent orientation for 2-sewing")]
 fn two_sew_bad_orientation() {
     let map: CMap3<f64> = CMap3::new(8);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 4);
-    map.force_link::<1>(4, 1);
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 7);
-    map.force_link::<1>(7, 8);
-    map.force_link::<1>(8, 5);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
+    map.force_link::<1>(4, 1).unwrap();
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 7).unwrap();
+    map.force_link::<1>(7, 8).unwrap();
+    map.force_link::<1>(8, 5).unwrap();
     map.force_write_vertex(1, Vertex3(0.0, 0.0, 0.0));
     map.force_write_vertex(2, Vertex3(1.0, 0.0, 0.0));
     map.force_write_vertex(3, Vertex3(1.0, 1.0, 0.0));
@@ -507,21 +506,22 @@ fn two_sew_bad_orientation() {
     map.force_write_vertex(6, Vertex3(1.0, 0.0, 1.0));
     map.force_write_vertex(7, Vertex3(1.0, 1.0, 1.0));
     map.force_write_vertex(8, Vertex3(0.0, 1.0, 1.0));
-    map.force_sew::<2>(1, 5); // panic due to inconsistent orientation
+    assert!(map
+        .force_sew::<2>(1, 5)
+        .is_err_and(|e| e == SewError::BadGeometry(2, 1, 5)));
 }
 
 #[test]
-#[should_panic(expected = "Dart 1 and 5 do not have consistent orientation for 3-sewing")]
 fn three_sew_bad_orientation() {
     let map: CMap3<f64> = CMap3::new(8);
-    map.force_link::<1>(1, 2);
-    map.force_link::<1>(2, 3);
-    map.force_link::<1>(3, 4);
-    map.force_link::<1>(4, 1);
-    map.force_link::<1>(5, 6);
-    map.force_link::<1>(6, 7);
-    map.force_link::<1>(7, 8);
-    map.force_link::<1>(8, 5);
+    map.force_link::<1>(1, 2).unwrap();
+    map.force_link::<1>(2, 3).unwrap();
+    map.force_link::<1>(3, 4).unwrap();
+    map.force_link::<1>(4, 1).unwrap();
+    map.force_link::<1>(5, 6).unwrap();
+    map.force_link::<1>(6, 7).unwrap();
+    map.force_link::<1>(7, 8).unwrap();
+    map.force_link::<1>(8, 5).unwrap();
     map.force_write_vertex(1, Vertex3(0.0, 0.0, 0.0));
     map.force_write_vertex(2, Vertex3(1.0, 0.0, 0.0));
     map.force_write_vertex(3, Vertex3(1.0, 1.0, 0.0));
@@ -530,7 +530,9 @@ fn three_sew_bad_orientation() {
     map.force_write_vertex(6, Vertex3(1.0, 0.0, 1.0));
     map.force_write_vertex(7, Vertex3(1.0, 1.0, 1.0));
     map.force_write_vertex(8, Vertex3(0.0, 1.0, 1.0));
-    map.force_sew::<3>(1, 5); // panic due to inconsistent orientation
+    assert!(map
+        .force_sew::<3>(1, 5)
+        .is_err_and(|e| e == SewError::BadGeometry(3, 1, 5)));
 }
 
 // --- PARALLEL
@@ -540,8 +542,8 @@ fn sew_ordering() {
     loom::model(|| {
         // setup the map
         let map: CMap3<f64> = CMap3::new(5);
-        map.force_link::<2>(1, 2);
-        map.force_link::<1>(4, 5);
+        map.force_link::<2>(1, 2).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
         map.force_write_vertex(2, Vertex3(1.0, 1.0, 1.0));
         map.force_write_vertex(3, Vertex3(1.0, 2.0, 1.0));
         map.force_write_vertex(5, Vertex3(2.0, 2.0, 1.0));

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -14,6 +14,9 @@ pub enum LinkError {
     /// The dart is already free.
     #[error("cannot unlink {1}: b{0}({1}) == NULL")]
     AlreadyFree(u8, DartIdType),
+    /// The two orbits being linked have different structures.
+    #[error("cannot 3-link {0} and {1}: faces do not have the same structure")]
+    AsymmetricalFaces(DartIdType, DartIdType),
 }
 
 /// Sew operation error enum

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -1,6 +1,6 @@
 //! Main error type
 
-use crate::{cmap::DartIdType, stm::StmError};
+use crate::{attributes::AttributeError, cmap::DartIdType};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum LinkError {
@@ -15,12 +15,12 @@ pub enum LinkError {
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SewError {
     /// Geometry predicate failed verification.
-    #[error("operation incompatible with map geometry: {0}")]
-    BadGeometry(&'static str),
+    #[error("cannot {0}-sew darts {1} and {2} due to geometry predicates")]
+    BadGeometry(u8, DartIdType, DartIdType),
     /// Dart link failed.
     #[error("inner link failed: {0}")]
     FailedLink(#[from] LinkError),
     /// Attribute operation failed.
     #[error("attribute operation failed: {0}")]
-    FailedAttributeOp(&'static str),
+    FailedAttributeOp(#[from] AttributeError),
 }

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -2,51 +2,25 @@
 
 use crate::{cmap::DartIdType, stm::StmError};
 
-/// Convenience type alias
-pub type CMapResult<T> = Result<T, CMapError>;
-
-/// # Map-level error enum.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum CMapError {
-    /// STM transaction failed.
-    #[error("transaction failed")]
-    FailedTransaction(#[from] StmError),
-    /// Attribute merge failed due to missing value(s).
-    #[error("attribute merge failed: {0}")]
-    FailedAttributeMerge(&'static str),
-    /// Attribute split failed due to missing value.
-    #[error("attribute split failed: {0}")]
-    FailedAttributeSplit(&'static str),
-    /// Geometry predicate failed verification.
-    #[error("operation incompatible with map geometry: {0}")]
-    IncorrectGeometry(&'static str),
-    /// Accessed attribute isn't in the map storage.
-    #[error("unknown attribute: {0}")]
-    UnknownAttribute(&'static str),
-}
-
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum LinkError {
-    // FailedTransaction(/*#[from]*/ StmError),
-    #[error("cannot link {0} to {1}: b1({0}) != NULL")]
-    NonFreeBase(DartIdType, DartIdType),
-    #[error("cannot link {0} to {1}: b0({1}) != NULL")]
-    NonFreeImage(DartIdType, DartIdType),
+    #[error("cannot link {1} to {2}: b{0}({1}) != NULL")]
+    NonFreeBase(u8, DartIdType, DartIdType),
+    #[error("cannot link {1} to {2}: b{0}({2}) != NULL")]
+    NonFreeImage(u8, DartIdType, DartIdType),
+    #[error("cannot unlink {1}: b{0}({1}) == NULL")]
+    AlreadyFree(u8, DartIdType),
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SewError {
-    // FailedTransaction(/*#[from]*/ StmError),
     /// Geometry predicate failed verification.
     #[error("operation incompatible with map geometry: {0}")]
     BadGeometry(&'static str),
     /// Dart link failed.
     #[error("inner link failed: {0}")]
-    FailedLink(LinkError),
-    /// Attribute merge failed due to missing value(s).
-    #[error("attribute merge failed: {0}")]
-    FailedMerge(&'static str),
-    /// Attribute split failed due to missing value.
-    #[error("attribute split failed: {0}")]
-    FailedSplit(&'static str),
+    FailedLink(#[from] LinkError),
+    /// Attribute operation failed.
+    #[error("attribute operation failed: {0}")]
+    FailedAttributeOp(&'static str),
 }

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -1,6 +1,6 @@
 //! Main error type
 
-use stm::StmError;
+use crate::{cmap::DartIdType, stm::StmError};
 
 /// Convenience type alias
 pub type CMapResult<T> = Result<T, CMapError>;
@@ -31,4 +31,30 @@ impl From<StmError> for CMapError {
     fn from(value: StmError) -> Self {
         Self::FailedTransaction(value)
     }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LinkError {
+    // FailedTransaction(/*#[from]*/ StmError),
+    #[error("cannot link {0} to {1}: b1({0}) != NULL")]
+    NonFreeBase(DartIdType, DartIdType),
+    #[error("cannot link {0} to {1}: b0({1}) != NULL")]
+    NonFreeImage(DartIdType, DartIdType),
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SewError {
+    // FailedTransaction(/*#[from]*/ StmError),
+    /// Geometry predicate failed verification.
+    #[error("operation incompatible with map geometry: {0}")]
+    BadGeometry(&'static str),
+    /// Dart link failed.
+    #[error("inner link failed: {0}")]
+    FailedLink(LinkError),
+    /// Attribute merge failed due to missing value(s).
+    #[error("attribute merge failed: {0}")]
+    FailedMerge(&'static str),
+    /// Attribute split failed due to missing value.
+    #[error("attribute split failed: {0}")]
+    FailedSplit(&'static str),
 }

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -2,16 +2,21 @@
 
 use crate::{attributes::AttributeError, cmap::DartIdType};
 
+/// Link operation error enum
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum LinkError {
+    /// The base dart is not free.
     #[error("cannot link {1} to {2}: b{0}({1}) != NULL")]
     NonFreeBase(u8, DartIdType, DartIdType),
+    /// The image dart is not free
     #[error("cannot link {1} to {2}: b{0}({2}) != NULL")]
     NonFreeImage(u8, DartIdType, DartIdType),
+    /// The dart is already free.
     #[error("cannot unlink {1}: b{0}({1}) == NULL")]
     AlreadyFree(u8, DartIdType),
 }
 
+/// Sew operation error enum
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SewError {
     /// Geometry predicate failed verification.

--- a/honeycomb-core/src/cmap/mod.rs
+++ b/honeycomb-core/src/cmap/mod.rs
@@ -2,7 +2,7 @@
 
 mod builder;
 mod components;
-mod dim2; // FIXME:simplify docs
+mod dim2;
 #[allow(missing_docs, clippy::missing_errors_doc, clippy::missing_panics_doc)] // FIXME:write docs
 mod dim3;
 mod error;

--- a/honeycomb-core/src/cmap/mod.rs
+++ b/honeycomb-core/src/cmap/mod.rs
@@ -17,4 +17,4 @@ pub use components::{
 };
 pub use dim2::{orbits::Orbit2, structure::CMap2};
 pub use dim3::{orbits::Orbit3, structure::CMap3};
-pub use error::{CMapError, CMapResult};
+pub use error::{LinkError, SewError};

--- a/honeycomb-core/src/geometry/dim2/vertex.rs
+++ b/honeycomb-core/src/geometry/dim2/vertex.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains all code used to model vertices.
 
+use crate::attributes::AttributeError;
 use crate::prelude::{AttributeBind, AttributeUpdate, OrbitPolicy, Vector2, VertexIdType};
 use crate::{attributes::AttrSparseVec, geometry::CoordsFloat};
 
@@ -180,12 +181,17 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex2<T>> for Vertex2<T> {
 }
 
 impl<T: CoordsFloat> AttributeUpdate for Vertex2<T> {
-    fn merge(attr1: Self, attr2: Self) -> Self {
-        Self::average(&attr1, &attr2)
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        Ok(Self::average(&attr1, &attr2))
     }
 
-    fn split(attr: Self) -> (Self, Self) {
-        (attr, attr)
+    fn split(attr: Self) -> Result<(Self, Self), AttributeError> {
+        Ok((attr, attr))
+    }
+
+    // override default impl
+    fn merge_incomplete(attr: Self) -> Result<Self, AttributeError> {
+        Ok(attr)
     }
 }
 

--- a/honeycomb-core/src/geometry/dim3/vertex.rs
+++ b/honeycomb-core/src/geometry/dim3/vertex.rs
@@ -3,6 +3,7 @@
 //! This module contains all code used to model vertices.
 
 use super::super::Vector3;
+use crate::attributes::AttributeError;
 use crate::prelude::{AttributeBind, AttributeUpdate, OrbitPolicy, Vertex2, VertexIdType};
 use crate::{attributes::AttrSparseVec, geometry::CoordsFloat};
 
@@ -196,12 +197,16 @@ impl<T: CoordsFloat> std::ops::Sub<Vertex3<T>> for Vertex3<T> {
 }
 
 impl<T: CoordsFloat> AttributeUpdate for Vertex3<T> {
-    fn merge(attr1: Self, attr2: Self) -> Self {
-        Self::average(&attr1, &attr2)
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        Ok(Self::average(&attr1, &attr2))
     }
 
-    fn split(attr: Self) -> (Self, Self) {
-        (attr, attr)
+    fn split(attr: Self) -> Result<(Self, Self), AttributeError> {
+        Ok((attr, attr))
+    }
+
+    fn merge_incomplete(attr: Self) -> Result<Self, AttributeError> {
+        Ok(attr)
     }
 }
 

--- a/honeycomb-core/src/prelude.rs
+++ b/honeycomb-core/src/prelude.rs
@@ -2,8 +2,8 @@
 
 pub use crate::attributes::{AttributeBind, AttributeUpdate};
 pub use crate::cmap::{
-    BuilderError, CMap2, CMap3, CMapBuilder, CMapResult, DartIdType, EdgeIdType, FaceIdType,
-    GridDescriptor, Orbit2, OrbitPolicy, VertexIdType, VolumeIdType, NULL_DART_ID, NULL_EDGE_ID,
-    NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
+    BuilderError, CMap2, CMap3, CMapBuilder, DartIdType, EdgeIdType, FaceIdType, GridDescriptor,
+    LinkError, Orbit2, OrbitPolicy, SewError, VertexIdType, VolumeIdType, NULL_DART_ID,
+    NULL_EDGE_ID, NULL_FACE_ID, NULL_VERTEX_ID, NULL_VOLUME_ID,
 };
 pub use crate::geometry::{CoordsError, CoordsFloat, Vector2, Vertex2};

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -7,8 +7,7 @@
 // ------ IMPORTS
 
 use crate::grisubal::GrisubalError;
-use honeycomb_core::attributes::AttrSparseVec;
-use honeycomb_core::cmap::CMapResult;
+use honeycomb_core::attributes::{AttrSparseVec, AttributeError};
 use honeycomb_core::prelude::{
     AttributeBind, AttributeUpdate, CoordsFloat, DartIdType, OrbitPolicy, Vertex2,
 };
@@ -252,19 +251,23 @@ pub enum Boundary {
 }
 
 impl AttributeUpdate for Boundary {
-    fn merge(attr1: Self, attr2: Self) -> Self {
-        if attr1 == attr2 {
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        Ok(if attr1 == attr2 {
             attr1
         } else {
             Boundary::None
-        }
+        })
     }
 
-    fn split(_attr: Self) -> (Self, Self) {
+    fn split(_attr: Self) -> Result<(Self, Self), AttributeError> {
         unreachable!()
     }
 
-    fn merge_from_none() -> CMapResult<Self> {
+    fn merge_incomplete(attr: Self) -> Result<Self, AttributeError> {
+        Ok(attr)
+    }
+
+    fn merge_from_none() -> Result<Self, AttributeError> {
         Ok(Boundary::None)
     }
 }

--- a/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
+++ b/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
@@ -5,9 +5,9 @@
 // ------ IMPORTS
 
 use crate::grisubal::model::{Boundary, MapEdge};
-use crate::splits::{splitn_edge_transac, SplitEdgeError};
+use crate::splits::splitn_edge_transac;
 use honeycomb_core::prelude::{CMap2, CoordsFloat, DartIdType};
-use honeycomb_core::stm::atomically;
+use honeycomb_core::stm::atomically_with_err;
 
 // ------ CONTENT
 
@@ -52,37 +52,34 @@ pub(crate) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[
         // remove deprecated connectivities & save what data is necessary
         let b1_start_old = cmap.beta::<1>(*start);
         let b0_end_old = cmap.beta::<0>(*end);
-        cmap.force_unlink::<1>(*start);
-        cmap.force_unlink::<1>(b0_end_old);
+        cmap.force_unlink::<1>(*start).unwrap();
+        cmap.force_unlink::<1>(b0_end_old).unwrap();
 
         let &[d_new, b2_d_new] = &dslice[0..2] else {
             unreachable!()
         };
-        cmap.force_link::<2>(d_new, b2_d_new);
+        cmap.force_link::<2>(d_new, b2_d_new).unwrap();
 
         // rebuild - this is the final construct if there are no intermediates
-        cmap.force_link::<1>(*start, d_new);
-        cmap.force_link::<1>(b2_d_new, b1_start_old);
-        cmap.force_link::<1>(d_new, *end);
-        cmap.force_link::<1>(b0_end_old, b2_d_new);
+        cmap.force_link::<1>(*start, d_new).unwrap();
+        cmap.force_link::<1>(b2_d_new, b1_start_old).unwrap();
+        cmap.force_link::<1>(d_new, *end).unwrap();
+        cmap.force_link::<1>(b0_end_old, b2_d_new).unwrap();
 
         if !intermediates.is_empty() {
             // create the topology components
             let edge_id = cmap.edge_id(d_new);
             let new_darts = &dslice[2..];
-            atomically(|trans| {
-                if let Err(SplitEdgeError::FailedTransaction(e)) = splitn_edge_transac(
+            atomically_with_err(|trans| {
+                splitn_edge_transac(
                     cmap,
                     trans,
                     edge_id,
                     new_darts,
                     &vec![T::from(0.5).unwrap(); intermediates.len()],
-                ) {
-                    Err(e)
-                } else {
-                    Ok(())
-                }
-            });
+                )
+            })
+            .unwrap();
             // replace placeholder vertices
             let mut dart_id = cmap.beta::<1>(edge_id as DartIdType);
             for v in intermediates {

--- a/honeycomb-kernels/src/splits/mod.rs
+++ b/honeycomb-kernels/src/splits/mod.rs
@@ -14,16 +14,20 @@ mod edge_single;
 
 pub use edge_multiple::{splitn_edge, splitn_edge_transac};
 pub use edge_single::{split_edge, split_edge_transac};
-use honeycomb_core::stm::StmError;
+
+use honeycomb_core::{
+    attributes::AttributeError,
+    cmap::{LinkError, SewError},
+};
 
 // ------ CONTENT
 
 /// Error-modeling enum for edge-splitting routines.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum SplitEdgeError {
-    /// STM transaction failed.
-    #[error("transaction failed")]
-    FailedTransaction(/*#[from]*/ StmError),
+    /// A core operation failed.
+    #[error("core operation failed: {0}")]
+    FailedCoreOp(#[from] SewError),
     /// Relative position of the new vertex isn't located on the edge.
     #[error("vertex placement for split is not in ]0;1[")]
     VertexBound,
@@ -39,9 +43,15 @@ pub enum SplitEdgeError {
     WrongAmountDarts(usize, usize),
 }
 
-impl From<StmError> for SplitEdgeError {
-    fn from(value: StmError) -> Self {
-        Self::FailedTransaction(value)
+impl From<LinkError> for SplitEdgeError {
+    fn from(value: LinkError) -> Self {
+        Self::FailedCoreOp(value.into())
+    }
+}
+
+impl From<AttributeError> for SplitEdgeError {
+    fn from(value: AttributeError) -> Self {
+        Self::FailedCoreOp(value.into())
     }
 }
 

--- a/honeycomb-kernels/src/splits/tests.rs
+++ b/honeycomb-kernels/src/splits/tests.rs
@@ -19,13 +19,13 @@ mod standard {
         //  1         2         3         4
         //    ---1-->   ---2-->   ---3-->
         let mut map: CMap2<f64> = newmap(6);
-        map.force_link::<1>(1, 2);
-        map.force_link::<1>(2, 3);
-        map.force_link::<1>(4, 5);
-        map.force_link::<1>(5, 6);
-        map.force_link::<2>(1, 6);
-        map.force_link::<2>(2, 5);
-        map.force_link::<2>(3, 4);
+        map.force_link::<1>(1, 2).unwrap();
+        map.force_link::<1>(2, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
+        map.force_link::<1>(5, 6).unwrap();
+        map.force_link::<2>(1, 6).unwrap();
+        map.force_link::<2>(2, 5).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         map.force_write_vertex(3, (2.0, 0.0));
@@ -61,7 +61,7 @@ mod standard {
         //  1         2
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
@@ -89,7 +89,7 @@ mod standard {
         // before
         //  1 -----> 2 ->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<1>(1, 2);
+        map.force_link::<1>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
@@ -108,7 +108,7 @@ mod standard {
         //  1         ?
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         // map.force_write_vertex(2, (1.0, 0.0)); missing vertex!
         // split
@@ -124,13 +124,13 @@ mod standard {
         //  1         2         3         4
         //    ---1-->   ---2-->   ---3-->
         let mut map: CMap2<f64> = newmap(6);
-        map.force_link::<1>(1, 2);
-        map.force_link::<1>(2, 3);
-        map.force_link::<1>(4, 5);
-        map.force_link::<1>(5, 6);
-        map.force_link::<2>(1, 6);
-        map.force_link::<2>(2, 5);
-        map.force_link::<2>(3, 4);
+        map.force_link::<1>(1, 2).unwrap();
+        map.force_link::<1>(2, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
+        map.force_link::<1>(5, 6).unwrap();
+        map.force_link::<2>(1, 6).unwrap();
+        map.force_link::<2>(2, 5).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         map.force_write_vertex(3, (2.0, 0.0));
@@ -174,7 +174,7 @@ mod standard {
         //  1         2
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
@@ -211,7 +211,7 @@ mod standard {
         // before
         //  1 -----> 2 ->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<1>(1, 2);
+        map.force_link::<1>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
@@ -245,7 +245,7 @@ mod standard {
         //  1         ?
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         // map.force_write_vertex(2, (1.0, 0.0)); missing vertex!
         // split
@@ -255,7 +255,7 @@ mod standard {
 }
 
 mod noalloc {
-    use honeycomb_core::stm::atomically;
+    use honeycomb_core::stm::atomically_with_err;
 
     use super::*;
 
@@ -266,32 +266,21 @@ mod noalloc {
         //  1         2         3         4
         //    ---1-->   ---2-->   ---3-->
         let mut map: CMap2<f64> = newmap(6);
-        map.force_link::<1>(1, 2);
-        map.force_link::<1>(2, 3);
-        map.force_link::<1>(4, 5);
-        map.force_link::<1>(5, 6);
-        map.force_link::<2>(1, 6);
-        map.force_link::<2>(2, 5);
-        map.force_link::<2>(3, 4);
+        map.force_link::<1>(1, 2).unwrap();
+        map.force_link::<1>(2, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
+        map.force_link::<1>(5, 6).unwrap();
+        map.force_link::<2>(1, 6).unwrap();
+        map.force_link::<2>(2, 5).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         map.force_write_vertex(3, (2.0, 0.0));
         map.force_write_vertex(4, (3.0, 0.0));
         // split
         let nds = map.add_free_darts(2);
-        let res = atomically(|trans| {
-            if let Err(e) = split_edge_transac(&map, trans, 2, (nds, nds + 1), None) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
-        });
+        let res =
+            atomically_with_err(|trans| split_edge_transac(&map, trans, 2, (nds, nds + 1), None));
         assert!(res.is_ok());
         // after
         //    <--6---   <8- <5-   <--4---
@@ -322,23 +311,13 @@ mod noalloc {
         //  1         2
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
         let nds = map.add_free_darts(2);
-        let res = atomically(|trans| {
-            if let Err(e) = split_edge_transac(&map, trans, 1, (nds, nds + 1), Some(0.6)) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+        let res = atomically_with_err(|trans| {
+            split_edge_transac(&map, trans, 1, (nds, nds + 1), Some(0.6))
         });
         assert!(res.is_ok());
         // after
@@ -364,23 +343,13 @@ mod noalloc {
         // before
         //  1 -----> 2 ->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<1>(1, 2);
+        map.force_link::<1>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
         let nd = map.add_free_dart(); // a single dart is enough in this case
-        let res = atomically(|trans| {
-            if let Err(e) = split_edge_transac(&map, trans, 1, (nd, NULL_DART_ID), None) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+        let res = atomically_with_err(|trans| {
+            split_edge_transac(&map, trans, 1, (nd, NULL_DART_ID), None)
         });
         assert!(res.is_ok());
         // after
@@ -397,24 +366,13 @@ mod noalloc {
         //  1         ?
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         // map.force_write_vertex(2, (1.0, 0.0)); missing vertex!
         // split
         let nds = map.add_free_darts(2);
-        let res = atomically(|trans| {
-            if let Err(e) = split_edge_transac(&map, trans, 1, (nds, nds + 1), None) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
-        });
+        let res =
+            atomically_with_err(|trans| split_edge_transac(&map, trans, 1, (nds, nds + 1), None));
         assert!(res.is_err_and(|e| e == SplitEdgeError::UndefinedEdge));
     }
 
@@ -427,13 +385,13 @@ mod noalloc {
         //  1         2         3         4
         //    ---1-->   ---2-->   ---3-->
         let mut map: CMap2<f64> = newmap(6);
-        map.force_link::<1>(1, 2);
-        map.force_link::<1>(2, 3);
-        map.force_link::<1>(4, 5);
-        map.force_link::<1>(5, 6);
-        map.force_link::<2>(1, 6);
-        map.force_link::<2>(2, 5);
-        map.force_link::<2>(3, 4);
+        map.force_link::<1>(1, 2).unwrap();
+        map.force_link::<1>(2, 3).unwrap();
+        map.force_link::<1>(4, 5).unwrap();
+        map.force_link::<1>(5, 6).unwrap();
+        map.force_link::<2>(1, 6).unwrap();
+        map.force_link::<2>(2, 5).unwrap();
+        map.force_link::<2>(3, 4).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         map.force_write_vertex(3, (2.0, 0.0));
@@ -441,18 +399,8 @@ mod noalloc {
         // split
         let nds = map.add_free_darts(6);
         let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-        let res = atomically(|trans| {
-            if let Err(e) = splitn_edge_transac(&map, trans, 2, &new_darts, &[0.25, 0.50, 0.75]) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+        let res = atomically_with_err(|trans| {
+            splitn_edge_transac(&map, trans, 2, &new_darts, &[0.25, 0.50, 0.75])
         });
         assert!(res.is_ok());
         // after
@@ -487,24 +435,14 @@ mod noalloc {
         //  1         2
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
         let nds = map.add_free_darts(6);
         let new_darts = (nds..nds + 6).collect::<Vec<_>>();
-        let res = atomically(|trans| {
-            if let Err(e) = splitn_edge_transac(&map, trans, 1, &new_darts, &[0.25, 0.50, 0.75]) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+        let res = atomically_with_err(|trans| {
+            splitn_edge_transac(&map, trans, 1, &new_darts, &[0.25, 0.50, 0.75])
         });
         assert!(res.is_ok());
         // after
@@ -537,13 +475,13 @@ mod noalloc {
         // before
         //  1 -----> 2 ->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<1>(1, 2);
+        map.force_link::<1>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         map.force_write_vertex(2, (1.0, 0.0));
         // split
         let nds = map.add_free_darts(3);
-        let res = atomically(|trans| {
-            if let Err(e) = splitn_edge_transac(
+        let res = atomically_with_err(|trans| {
+            splitn_edge_transac(
                 &map,
                 trans,
                 1,
@@ -556,17 +494,7 @@ mod noalloc {
                     NULL_DART_ID,
                 ],
                 &[0.25, 0.50, 0.75],
-            ) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+            )
         });
         assert!(res.is_ok());
         // after
@@ -593,29 +521,19 @@ mod noalloc {
         //  1         ?
         //    ---1-->
         let mut map: CMap2<f64> = newmap(2);
-        map.force_link::<2>(1, 2);
+        map.force_link::<2>(1, 2).unwrap();
         map.force_write_vertex(1, (0.0, 0.0));
         // map.force_write_vertex(2, (1.0, 0.0)); missing vertex!
         // split
         let nds = map.add_free_darts(6);
-        let res = atomically(|trans| {
-            if let Err(e) = splitn_edge_transac(
+        let res = atomically_with_err(|trans| {
+            splitn_edge_transac(
                 &map,
                 trans,
                 1,
                 &[nds, nds + 1, nds + 2, nds + 3, nds + 4, nds + 5],
                 &[0.25, 0.50, 0.75],
-            ) {
-                match e {
-                    SplitEdgeError::FailedTransaction(stme) => Err(stme),
-                    SplitEdgeError::UndefinedEdge
-                    | SplitEdgeError::VertexBound
-                    | SplitEdgeError::InvalidDarts(_)
-                    | SplitEdgeError::WrongAmountDarts(_, _) => Ok(Err(e)),
-                }
-            } else {
-                Ok(Ok(()))
-            }
+            )
         });
         assert!(res.is_err_and(|e| e == SplitEdgeError::UndefinedEdge));
     }

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -115,13 +115,13 @@ pub fn process_cell<T: CoordsFloat>(
         ndart_id += 2;
         // FIXME: using link methods only works if new identifiers are greater than all existing
         // FIXME: using sew methods in parallel could crash bc of the panic when no vertex defined
-        cmap.force_unlink::<1>(b0_d_ear1);
-        cmap.force_unlink::<1>(d_ear2);
-        cmap.force_link::<1>(d_ear2, nd1);
-        cmap.force_link::<1>(nd1, d_ear1);
-        cmap.force_link::<1>(b0_d_ear1, nd2);
-        cmap.force_link::<1>(nd2, b1_d_ear2);
-        cmap.force_link::<2>(nd1, nd2);
+        cmap.force_unlink::<1>(b0_d_ear1).unwrap();
+        cmap.force_unlink::<1>(d_ear2).unwrap();
+        cmap.force_link::<1>(d_ear2, nd1).unwrap();
+        cmap.force_link::<1>(nd1, d_ear1).unwrap();
+        cmap.force_link::<1>(b0_d_ear1, nd2).unwrap();
+        cmap.force_link::<1>(nd2, b1_d_ear2).unwrap();
+        cmap.force_link::<2>(nd1, nd2).unwrap();
 
         // edit existing vectors
         darts.remove((ear + 1) % n);

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -86,20 +86,21 @@ pub fn process_cell<T: CoordsFloat>(
         // THIS CANNOT BE PARALLELIZED AS IS
         let b0_sdart = cmap.beta::<0>(*sdart);
         let v0 = cmap.force_read_vertex(cmap.vertex_id(*sdart)).unwrap();
-        cmap.force_unsew::<1>(b0_sdart);
+        cmap.force_unsew::<1>(b0_sdart).unwrap();
         let mut d0 = *sdart;
         for sl in new_darts.chunks_exact(2) {
             let [d1, d2] = sl else { unreachable!() };
             let b1_d0 = cmap.beta::<1>(d0);
             let b1b1_d0 = cmap.beta::<1>(cmap.beta::<1>(d0));
-            cmap.force_unsew::<1>(b1_d0);
-            cmap.force_link::<2>(*d1, *d2);
-            cmap.force_link::<1>(*d2, b1b1_d0);
-            cmap.force_sew::<1>(b1_d0, *d1);
-            cmap.force_sew::<1>(*d1, d0);
+            cmap.force_unsew::<1>(b1_d0).unwrap();
+            cmap.force_link::<2>(*d1, *d2).unwrap();
+            cmap.force_link::<1>(*d2, b1b1_d0).unwrap();
+            cmap.force_sew::<1>(b1_d0, *d1).unwrap();
+            cmap.force_sew::<1>(*d1, d0).unwrap();
             d0 = *d2;
         }
-        cmap.force_sew::<1>(cmap.beta::<1>(cmap.beta::<1>(d0)), d0);
+        cmap.force_sew::<1>(cmap.beta::<1>(cmap.beta::<1>(d0)), d0)
+            .unwrap();
         cmap.force_write_vertex(cmap.vertex_id(*sdart), v0);
     } else {
         // println!("W: face {face_id} isn't fannable -- skipping triangulation");
@@ -160,20 +161,21 @@ pub fn process_convex_cell<T: CoordsFloat>(
     // THIS CANNOT BE PARALLELIZED AS IS
     let b0_sdart = cmap.beta::<0>(sdart);
     let v0 = cmap.force_read_vertex(cmap.vertex_id(sdart)).unwrap();
-    cmap.force_unsew::<1>(b0_sdart);
+    cmap.force_unsew::<1>(b0_sdart).unwrap();
     let mut d0 = sdart;
     for sl in new_darts.chunks_exact(2) {
         let [d1, d2] = sl else { unreachable!() };
         let b1_d0 = cmap.beta::<1>(d0);
         let b1b1_d0 = cmap.beta::<1>(cmap.beta::<1>(d0));
-        cmap.force_unsew::<1>(b1_d0);
-        cmap.force_link::<2>(*d1, *d2);
-        cmap.force_link::<1>(*d2, b1b1_d0);
-        cmap.force_sew::<1>(b1_d0, *d1);
-        cmap.force_sew::<1>(*d1, d0);
+        cmap.force_unsew::<1>(b1_d0).unwrap();
+        cmap.force_link::<2>(*d1, *d2).unwrap();
+        cmap.force_link::<1>(*d2, b1b1_d0).unwrap();
+        cmap.force_sew::<1>(b1_d0, *d1).unwrap();
+        cmap.force_sew::<1>(*d1, d0).unwrap();
         d0 = *d2;
     }
-    cmap.force_sew::<1>(cmap.beta::<1>(cmap.beta::<1>(d0)), d0);
+    cmap.force_sew::<1>(cmap.beta::<1>(cmap.beta::<1>(d0)), d0)
+        .unwrap();
     cmap.force_write_vertex(cmap.vertex_id(sdart), v0);
 
     Ok(())

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -13,46 +13,46 @@ fn generate_map() -> CMap2<f64> {
     let cmap: CMap2<f64> = CMapBuilder::default().n_darts(28).build().unwrap();
 
     // topology
-    cmap.force_link::<1>(1, 2);
-    cmap.force_link::<1>(2, 3);
-    cmap.force_link::<1>(3, 4);
-    cmap.force_link::<1>(4, 5);
-    cmap.force_link::<1>(5, 6);
-    cmap.force_link::<1>(6, 1);
+    cmap.force_link::<1>(1, 2).unwrap();
+    cmap.force_link::<1>(2, 3).unwrap();
+    cmap.force_link::<1>(3, 4).unwrap();
+    cmap.force_link::<1>(4, 5).unwrap();
+    cmap.force_link::<1>(5, 6).unwrap();
+    cmap.force_link::<1>(6, 1).unwrap();
 
-    cmap.force_link::<1>(7, 8);
-    cmap.force_link::<1>(8, 9);
-    cmap.force_link::<1>(9, 10);
-    cmap.force_link::<1>(10, 11);
-    cmap.force_link::<1>(11, 12);
-    cmap.force_link::<1>(12, 7);
+    cmap.force_link::<1>(7, 8).unwrap();
+    cmap.force_link::<1>(8, 9).unwrap();
+    cmap.force_link::<1>(9, 10).unwrap();
+    cmap.force_link::<1>(10, 11).unwrap();
+    cmap.force_link::<1>(11, 12).unwrap();
+    cmap.force_link::<1>(12, 7).unwrap();
 
-    cmap.force_link::<1>(13, 14);
-    cmap.force_link::<1>(14, 15);
-    cmap.force_link::<1>(15, 16);
-    cmap.force_link::<1>(16, 13);
+    cmap.force_link::<1>(13, 14).unwrap();
+    cmap.force_link::<1>(14, 15).unwrap();
+    cmap.force_link::<1>(15, 16).unwrap();
+    cmap.force_link::<1>(16, 13).unwrap();
 
-    cmap.force_link::<1>(17, 18);
-    cmap.force_link::<1>(18, 19);
-    cmap.force_link::<1>(19, 20);
-    cmap.force_link::<1>(20, 21);
-    cmap.force_link::<1>(21, 22);
-    cmap.force_link::<1>(22, 23);
-    cmap.force_link::<1>(23, 24);
-    cmap.force_link::<1>(24, 25);
-    cmap.force_link::<1>(25, 17);
+    cmap.force_link::<1>(17, 18).unwrap();
+    cmap.force_link::<1>(18, 19).unwrap();
+    cmap.force_link::<1>(19, 20).unwrap();
+    cmap.force_link::<1>(20, 21).unwrap();
+    cmap.force_link::<1>(21, 22).unwrap();
+    cmap.force_link::<1>(22, 23).unwrap();
+    cmap.force_link::<1>(23, 24).unwrap();
+    cmap.force_link::<1>(24, 25).unwrap();
+    cmap.force_link::<1>(25, 17).unwrap();
 
-    cmap.force_link::<1>(26, 27);
-    cmap.force_link::<1>(27, 28);
-    cmap.force_link::<1>(28, 26);
+    cmap.force_link::<1>(26, 27).unwrap();
+    cmap.force_link::<1>(27, 28).unwrap();
+    cmap.force_link::<1>(28, 26).unwrap();
 
-    cmap.force_link::<2>(3, 7);
-    cmap.force_link::<2>(4, 13);
-    cmap.force_link::<2>(10, 27);
-    cmap.force_link::<2>(11, 26);
-    cmap.force_link::<2>(12, 14);
-    cmap.force_link::<2>(15, 17);
-    cmap.force_link::<2>(18, 28);
+    cmap.force_link::<2>(3, 7).unwrap();
+    cmap.force_link::<2>(4, 13).unwrap();
+    cmap.force_link::<2>(10, 27).unwrap();
+    cmap.force_link::<2>(11, 26).unwrap();
+    cmap.force_link::<2>(12, 14).unwrap();
+    cmap.force_link::<2>(15, 17).unwrap();
+    cmap.force_link::<2>(18, 28).unwrap();
 
     // geometry
     cmap.force_write_vertex(1, (1.0, 0.0));


### PR DESCRIPTION
### Description

**Scope**:  good luck

**Type of change**: refactor

**Content description**:

core crate:
- change the `fast-stm` revision used to have access to the `try_or_coerce!` convenience macro
- replace `CMapError` with the following errors:
	- `LinkError`
	- `AttributeError`
	- `SewError`
- change `AttributeUpdate` associated functions return types to allow errors in each (under the form of an `AttributeError`), update `Vertex2` and `Vertex3` impls
- change the default implementation behavior of `AttributeUpdate::merge_incomplete` to fail
- change transactional methods return types  from `CMapResult` to `TransactionalClosureResult`
- replace inner invariant assertions (e.g. dart is 1-free before a 1-link op) with conditional calls to `abort`
- `force_` variants of link and sew ops now return a `Result` to accommodate the replacement of assertions

kernels crate:
- update `SplitEdgeError`
- update `splits` routines; I did the bare minimum since I want to work on generalized cell insertion at some point
- update `grisubal`

others:
- fix warnings in other crates
- fix all tests


### Additional information

- [x] Breaking change

auto coercion isn't implemented from our errors (e.g. `LinkError`) to `TransactionError::Abort(E)` in order to force user code to acknowledge possible failure points, and think about retry / cancel policies w.r.t. deadlocks / infinite wait scenarios

I haven't modified the prelude of the core crate beacuse I intend to delete it while I sort all other imports.

### Necessary follow-up

- unify behavior between regular and `force` variants (== turn `force` variants into simple wrappers)
    -  remove unused methods from trait impl after this
- remove attribute doctests in favor of a UG page, like the one existing for STM
- add error explanation in the doc
- add properties ensured by transactions in the doc

