### PR TITLE
refactor!(core): replace the STM implementation by our fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ cfg-if = "1"
 itertools = "0.14.0"
 rayon = "1.10.0"
 rustversion = "1.0.18"
-thiserror = "2.0.3"
+thiserror = "2.0.11"
 
 # core
 downcast-rs = "2.0.1"
 loom = "0.7.2"
 num-traits = "0.2.19"
-stm = "0.4.0"
+fast-stm = { git = "https://github.com/imrn99/fast-stm", rev = "8eccd2bf1e7e785c9cbca0a4f84e61171f675df0" }
 vtkio = { version = "0.7.0-rc1", default-features = false }
 
 # benchmarks

--- a/honeycomb-core/Cargo.toml
+++ b/honeycomb-core/Cargo.toml
@@ -21,7 +21,7 @@ downcast-rs.workspace = true
 itertools.workspace = true
 loom.workspace= true
 num-traits.workspace = true
-stm.workspace = true
+fast-stm.workspace = true
 thiserror.workspace = true
 vtkio.workspace = true
 

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -5,7 +5,7 @@
 
 // ------ IMPORTS
 
-use stm::{StmResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction};
 
 use super::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage};
 use crate::{
@@ -330,7 +330,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.vertices.values() {
             storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -357,7 +357,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.edges.values() {
             storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -384,7 +384,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.faces.values() {
             storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
         }
@@ -582,7 +582,7 @@ impl AttrStorageManager {
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.merge(trans, id_out, id_in_lhs, id_in_rhs)
@@ -694,7 +694,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.vertices.values() {
             storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
@@ -721,7 +721,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.edges.values() {
             storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
@@ -748,7 +748,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         for storage in self.faces.values() {
             storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
         }
@@ -946,7 +946,7 @@ impl AttrStorageManager {
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.split(trans, id_out_lhs, id_out_rhs, id_in)
@@ -1023,7 +1023,7 @@ impl AttrStorageManager {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.read(trans, id)
@@ -1065,7 +1065,7 @@ impl AttrStorageManager {
         trans: &mut Transaction,
         id: A::IdentifierType,
         val: A,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.write(trans, id, val)
@@ -1105,7 +1105,7 @@ impl AttrStorageManager {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.remove(trans, id)

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -1,7 +1,7 @@
 // ------ IMPORTS
 
+use crate::stm::{atomically, StmError, Transaction, TransactionControl};
 use loom::sync::Arc;
-use stm::{atomically, StmError, Transaction, TransactionControl};
 
 use super::{
     AttrSparseVec, AttrStorageManager, AttributeBind, AttributeStorage, AttributeUpdate,

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -5,6 +5,7 @@
 
 // ------ IMPORTS
 
+use crate::stm::{atomically, StmClosureResult, Transaction};
 use crate::{
     cmap::{CMapError, CMapResult},
     prelude::{DartIdType, OrbitPolicy},
@@ -12,7 +13,6 @@ use crate::{
 use downcast_rs::{impl_downcast, Downcast};
 use std::any::{type_name, Any};
 use std::fmt::Debug;
-use stm::{atomically, StmResult, Transaction};
 
 // ------ CONTENT
 
@@ -250,7 +250,7 @@ pub trait UnknownAttributeStorage: Any + Debug + Downcast {
         out: DartIdType,
         lhs_inp: DartIdType,
         rhs_inp: DartIdType,
-    ) -> StmResult<()>;
+    ) -> StmClosureResult<()>;
 
     #[allow(clippy::missing_errors_doc)]
     /// Split attribute to specified indices
@@ -280,7 +280,7 @@ pub trait UnknownAttributeStorage: Any + Debug + Downcast {
         lhs_out: DartIdType,
         rhs_out: DartIdType,
         inp: DartIdType,
-    ) -> StmResult<()>;
+    ) -> StmClosureResult<()>;
 
     // force
 
@@ -371,7 +371,7 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn read(&self, trans: &mut Transaction, id: A::IdentifierType) -> StmResult<Option<A>>;
+    fn read(&self, trans: &mut Transaction, id: A::IdentifierType) -> StmClosureResult<Option<A>>;
 
     #[allow(clippy::missing_errors_doc)]
     /// Write the value of an element at a given index and return the old value.
@@ -393,8 +393,12 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn write(&self, trans: &mut Transaction, id: A::IdentifierType, val: A)
-        -> StmResult<Option<A>>;
+    fn write(
+        &self,
+        trans: &mut Transaction,
+        id: A::IdentifierType,
+        val: A,
+    ) -> StmClosureResult<Option<A>>;
 
     #[allow(clippy::missing_errors_doc)]
     /// Remove the value at a given index and return it.
@@ -415,7 +419,8 @@ pub trait AttributeStorage<A: AttributeBind>: UnknownAttributeStorage {
     /// The method:
     /// - should panic if the index lands out of bounds
     /// - may panic if the index cannot be converted to `usize`
-    fn remove(&self, trans: &mut Transaction, id: A::IdentifierType) -> StmResult<Option<A>>;
+    fn remove(&self, trans: &mut Transaction, id: A::IdentifierType)
+        -> StmClosureResult<Option<A>>;
 
     /// Read the value of an element at a given index.
     ///

--- a/honeycomb-core/src/cmap/components/betas.rs
+++ b/honeycomb-core/src/cmap/components/betas.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Index, IndexMut};
 
-use stm::{StmError, TVar, Transaction};
+use crate::stm::{StmError, TVar, Transaction};
 
 use crate::cmap::NULL_DART_ID;
 

--- a/honeycomb-core/src/cmap/components/unused.rs
+++ b/honeycomb-core/src/cmap/components/unused.rs
@@ -5,7 +5,7 @@ use std::{
     slice::Iter,
 };
 
-use stm::TVar;
+use crate::stm::TVar;
 
 use super::identifiers::DartIdType;
 

--- a/honeycomb-core/src/cmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/basic_ops.rs
@@ -12,9 +12,9 @@
 use crate::prelude::{
     CMap2, DartIdType, EdgeIdType, FaceIdType, Orbit2, OrbitPolicy, VertexIdType, NULL_DART_ID,
 };
+use crate::stm::{atomically, StmClosureResult, Transaction};
 use crate::{attributes::UnknownAttributeStorage, geometry::CoordsFloat};
 use itertools::Itertools;
-use stm::{atomically, StmResult, Transaction};
 
 // ------ CONTENT
 
@@ -158,7 +158,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         dart_id: DartIdType,
-    ) -> StmResult<DartIdType> {
+    ) -> StmClosureResult<DartIdType> {
         assert!(I < 3);
         self.betas[(I, dart_id)].read(trans)
     }
@@ -179,7 +179,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         i: u8,
         dart_id: DartIdType,
-    ) -> StmResult<DartIdType> {
+    ) -> StmClosureResult<DartIdType> {
         assert!(i < 3);
         match i {
             0 => self.beta_transac::<0>(trans, dart_id),
@@ -242,7 +242,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         dart_id: DartIdType,
-    ) -> StmResult<VertexIdType> {
+    ) -> StmClosureResult<VertexIdType> {
         // min encountered / current dart
         let mut min = dart_id;
         let mut crt = self.betas[(1, self.betas[(2, dart_id)].read(trans)?)].read(trans)?;
@@ -286,7 +286,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         dart_id: DartIdType,
-    ) -> StmResult<EdgeIdType> {
+    ) -> StmClosureResult<EdgeIdType> {
         // optimizing this one bc I'm tired
         let b2 = self.beta_transac::<2>(trans, dart_id)?;
         if b2 == NULL_DART_ID {
@@ -317,7 +317,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         dart_id: DartIdType,
-    ) -> StmResult<FaceIdType> {
+    ) -> StmClosureResult<FaceIdType> {
         // min encountered / current dart
         let mut min = dart_id;
         let mut crt = self.beta_transac::<1>(trans, dart_id)?;

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORT
 
-use stm::{StmResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction};
 
 use crate::prelude::{AttributeBind, AttributeUpdate, CMap2, Vertex2, VertexIdType};
 use crate::{
@@ -46,7 +46,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         vertex_id: VertexIdType,
-    ) -> StmResult<Option<Vertex2<T>>> {
+    ) -> StmClosureResult<Option<Vertex2<T>>> {
         self.vertices.read(trans, vertex_id)
     }
 
@@ -78,7 +78,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         vertex_id: VertexIdType,
         vertex: impl Into<Vertex2<T>>,
-    ) -> StmResult<Option<Vertex2<T>>> {
+    ) -> StmClosureResult<Option<Vertex2<T>>> {
         self.vertices.write(trans, vertex_id, vertex.into())
     }
 
@@ -104,7 +104,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         vertex_id: VertexIdType,
-    ) -> StmResult<Option<Vertex2<T>>> {
+    ) -> StmClosureResult<Option<Vertex2<T>>> {
         self.vertices.remove(trans, vertex_id)
     }
 
@@ -166,7 +166,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.read_attribute::<A>(trans, id)
     }
 
@@ -198,7 +198,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         id: A::IdentifierType,
         val: A,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.write_attribute::<A>(trans, id, val)
     }
 
@@ -224,7 +224,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.remove_attribute::<A>(trans, id)
     }
 

--- a/honeycomb-core/src/cmap/dim2/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/links/mod.rs
@@ -1,7 +1,7 @@
 mod one;
 mod two;
 
-use stm::{StmResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap2, DartIdType},
@@ -44,7 +44,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -85,7 +85,11 @@ impl<T: CoordsFloat> CMap2<T> {
     /// The method may panic if:
     /// - `I >= 3` or `I == 0`,
     /// - `ld` is already `I`-free.
-    pub fn unlink<const I: u8>(&self, trans: &mut Transaction, ld: DartIdType) -> StmResult<()> {
+    pub fn unlink<const I: u8>(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> StmClosureResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/links/one.rs
+++ b/honeycomb-core/src/cmap/dim2/links/one.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, StmResult, Transaction};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap2, DartIdType},
@@ -14,7 +14,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.one_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
@@ -32,7 +32,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.one_unlink_core(trans, lhs_dart_id)
     }
 

--- a/honeycomb-core/src/cmap/dim2/links/two.rs
+++ b/honeycomb-core/src/cmap/dim2/links/two.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, StmResult, Transaction};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap2, DartIdType},
@@ -14,7 +14,7 @@ impl<T: CoordsFloat> CMap2<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
@@ -32,7 +32,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.two_unlink_core(trans, lhs_dart_id)
     }
 

--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -1,7 +1,7 @@
 mod one;
 mod two;
 
-use stm::Transaction;
+use crate::stm::Transaction;
 
 use crate::{
     cmap::{CMap2, CMapResult, DartIdType},

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, Transaction};
+use crate::stm::{atomically, Transaction};
 
 use crate::{
     attributes::UnknownAttributeStorage,

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -1,4 +1,4 @@
-use stm::{atomically, Transaction};
+use crate::stm::{atomically, Transaction};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -1,6 +1,6 @@
 // ------ IMPORTS
 
-use stm::atomically;
+use crate::stm::{atomically, StmError};
 
 use crate::{
     attributes::AttrSparseVec,
@@ -555,7 +555,7 @@ fn sew_ordering_with_transactions() {
                 if let Err(e) = m1.sew::<1>(trans, 1, 3) {
                     match e {
                         CMapError::FailedTransaction(e) => Err(e),
-                        CMapError::FailedAttributeMerge(_) => Err(stm::StmError::Retry),
+                        CMapError::FailedAttributeMerge(_) => Err(StmError::Retry),
                         CMapError::FailedAttributeSplit(_)
                         | CMapError::IncorrectGeometry(_)
                         | CMapError::UnknownAttribute(_) => unreachable!(),
@@ -571,7 +571,7 @@ fn sew_ordering_with_transactions() {
                 if let Err(e) = m2.sew::<2>(trans, 3, 4) {
                     match e {
                         CMapError::FailedTransaction(e) => Err(e),
-                        CMapError::FailedAttributeMerge(_) => Err(stm::StmError::Retry),
+                        CMapError::FailedAttributeMerge(_) => Err(StmError::Retry),
                         CMapError::FailedAttributeSplit(_)
                         | CMapError::IncorrectGeometry(_)
                         | CMapError::UnknownAttribute(_) => unreachable!(),
@@ -703,7 +703,7 @@ fn unsew_ordering_with_transactions() {
                 if let Err(e) = m1.unsew::<1>(trans, 1) {
                     match e {
                         CMapError::FailedTransaction(e) => Err(e),
-                        CMapError::FailedAttributeSplit(_) => Err(stm::StmError::Retry),
+                        CMapError::FailedAttributeSplit(_) => Err(StmError::Retry),
                         CMapError::FailedAttributeMerge(_)
                         | CMapError::IncorrectGeometry(_)
                         | CMapError::UnknownAttribute(_) => unreachable!(),
@@ -719,7 +719,7 @@ fn unsew_ordering_with_transactions() {
                 if let Err(e) = m2.unsew::<2>(trans, 3) {
                     match e {
                         CMapError::FailedTransaction(e) => Err(e),
-                        CMapError::FailedAttributeSplit(_) => Err(stm::StmError::Retry),
+                        CMapError::FailedAttributeSplit(_) => Err(StmError::Retry),
                         CMapError::FailedAttributeMerge(_)
                         | CMapError::IncorrectGeometry(_)
                         | CMapError::UnknownAttribute(_) => unreachable!(),

--- a/honeycomb-core/src/cmap/dim2/utils.rs
+++ b/honeycomb-core/src/cmap/dim2/utils.rs
@@ -5,7 +5,7 @@
 use super::CMAP2_BETA;
 use crate::geometry::CoordsFloat;
 use crate::prelude::{CMap2, DartIdType};
-use stm::atomically;
+use crate::stm::atomically;
 
 // ------ CONTENT
 

--- a/honeycomb-core/src/cmap/dim3/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim3/basic_ops.rs
@@ -9,9 +9,9 @@
 
 // ------ IMPORTS
 
+use crate::stm::{atomically, StmClosureResult, StmError, Transaction};
 use itertools::Itertools;
 use std::collections::{HashSet, VecDeque};
-use stm::{atomically, StmError, StmResult, Transaction};
 
 use crate::{
     attributes::UnknownAttributeStorage,
@@ -134,7 +134,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         dart_id: DartIdType,
-    ) -> StmResult<DartIdType> {
+    ) -> StmClosureResult<DartIdType> {
         assert!(I < 4);
         self.betas[(I, dart_id)].read(trans)
     }
@@ -155,7 +155,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         i: u8,
         dart_id: DartIdType,
-    ) -> StmResult<DartIdType> {
+    ) -> StmClosureResult<DartIdType> {
         assert!(i < 4);
         match i {
             0 => self.beta_transac::<0>(trans, dart_id),

--- a/honeycomb-core/src/cmap/dim3/embed.rs
+++ b/honeycomb-core/src/cmap/dim3/embed.rs
@@ -6,7 +6,7 @@
 
 // ------ IMPORT
 
-use stm::{StmResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction};
 
 use crate::prelude::{AttributeBind, AttributeUpdate, VertexIdType};
 use crate::{
@@ -48,7 +48,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         vertex_id: VertexIdType,
-    ) -> StmResult<Option<Vertex3<T>>> {
+    ) -> StmClosureResult<Option<Vertex3<T>>> {
         self.vertices.read(trans, vertex_id)
     }
 
@@ -80,7 +80,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         vertex_id: VertexIdType,
         vertex: impl Into<Vertex3<T>>,
-    ) -> StmResult<Option<Vertex3<T>>> {
+    ) -> StmClosureResult<Option<Vertex3<T>>> {
         self.vertices.write(trans, vertex_id, vertex.into())
     }
 
@@ -106,7 +106,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         vertex_id: VertexIdType,
-    ) -> StmResult<Option<Vertex3<T>>> {
+    ) -> StmClosureResult<Option<Vertex3<T>>> {
         self.vertices.remove(trans, vertex_id)
     }
 
@@ -168,7 +168,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.read_attribute::<A>(trans, id)
     }
 
@@ -200,7 +200,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         id: A::IdentifierType,
         val: A,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.write_attribute::<A>(trans, id, val)
     }
 
@@ -226,7 +226,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         id: A::IdentifierType,
-    ) -> StmResult<Option<A>> {
+    ) -> StmClosureResult<Option<A>> {
         self.attributes.remove_attribute::<A>(trans, id)
     }
 

--- a/honeycomb-core/src/cmap/dim3/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/links/mod.rs
@@ -2,7 +2,7 @@ mod one;
 mod three;
 mod two;
 
-use stm::{StmResult, Transaction};
+use crate::stm::{StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap3, DartIdType},
@@ -45,7 +45,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -91,7 +91,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim3/links/one.rs
+++ b/honeycomb-core/src/cmap/dim3/links/one.rs
@@ -1,6 +1,6 @@
 //! 1D link implementations
 
-use stm::{atomically, StmResult, Transaction};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap3, DartIdType, NULL_DART_ID},
@@ -15,7 +15,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.one_link_core(trans, ld, rd)?;
         let (b3_ld, b3_rd) = (
             self.beta_transac::<3>(trans, ld)?,
@@ -39,7 +39,11 @@ impl<T: CoordsFloat> CMap3<T> {
 /// 1-unlinks
 impl<T: CoordsFloat> CMap3<T> {
     /// 1-unlink operation.
-    pub(crate) fn one_unlink(&self, trans: &mut Transaction, ld: DartIdType) -> StmResult<()> {
+    pub(crate) fn one_unlink(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> StmClosureResult<()> {
         let rd = self.beta_transac::<1>(trans, ld)?;
         self.betas.one_unlink_core(trans, ld)?;
         let (b3_ld, b3_rd) = (

--- a/honeycomb-core/src/cmap/dim3/links/three.rs
+++ b/honeycomb-core/src/cmap/dim3/links/three.rs
@@ -1,6 +1,6 @@
 //! 3D link implementations
 
-use stm::{atomically, StmResult, Transaction};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap3, DartIdType, NULL_DART_ID},
@@ -15,7 +15,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         ld: DartIdType,
         rd: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.three_link_core(trans, ld, rd)?;
         let (mut lside, mut rside) = (
             self.beta_transac::<1>(trans, ld)?,
@@ -65,7 +65,11 @@ impl<T: CoordsFloat> CMap3<T> {
 /// 3-unlinks
 impl<T: CoordsFloat> CMap3<T> {
     /// 3-unlink operation.
-    pub(crate) fn three_unlink(&self, trans: &mut Transaction, ld: DartIdType) -> StmResult<()> {
+    pub(crate) fn three_unlink(
+        &self,
+        trans: &mut Transaction,
+        ld: DartIdType,
+    ) -> StmClosureResult<()> {
         let rd = self.beta_transac::<3>(trans, ld)?;
         self.betas.three_unlink_core(trans, ld)?;
         let (mut lside, mut rside) = (

--- a/honeycomb-core/src/cmap/dim3/links/two.rs
+++ b/honeycomb-core/src/cmap/dim3/links/two.rs
@@ -1,6 +1,6 @@
 //! 2D link implementations
 
-use stm::{atomically, StmResult, Transaction};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 use crate::{
     cmap::{CMap3, DartIdType},
@@ -15,7 +15,7 @@ impl<T: CoordsFloat> CMap3<T> {
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
         rhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id)
     }
 
@@ -32,7 +32,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         trans: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> StmResult<()> {
+    ) -> StmClosureResult<()> {
         self.betas.two_unlink_core(trans, lhs_dart_id)
     }
 

--- a/honeycomb-core/src/cmap/dim3/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/mod.rs
@@ -2,7 +2,7 @@ mod one;
 mod three;
 mod two;
 
-use stm::Transaction;
+use crate::stm::Transaction;
 
 use crate::{
     cmap::{CMap3, CMapResult, DartIdType},

--- a/honeycomb-core/src/cmap/dim3/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/one.rs
@@ -1,6 +1,6 @@
 //! 1D sew implementations
 
-use stm::{atomically, Transaction};
+use crate::stm::{atomically, Transaction};
 
 use crate::{
     attributes::UnknownAttributeStorage,

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -1,6 +1,6 @@
 //! 3D sew implementations
 
-use stm::{atomically, Transaction};
+use crate::stm::{atomically, Transaction};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -1,6 +1,6 @@
 //! 2D sew implementations
 
-use stm::{atomically, Transaction};
+use crate::stm::{atomically, Transaction};
 
 use crate::{
     attributes::{AttributeStorage, UnknownAttributeStorage},

--- a/honeycomb-core/src/cmap/dim3/tests.rs
+++ b/honeycomb-core/src/cmap/dim3/tests.rs
@@ -1,6 +1,6 @@
 // ------ IMPORTS
 
-use stm::{atomically, StmError, TVar};
+use crate::stm::{atomically, StmError, TVar};
 
 use crate::{
     attributes::{AttrSparseVec, AttributeBind, AttributeUpdate},

--- a/honeycomb-core/src/cmap/dim3/utils.rs
+++ b/honeycomb-core/src/cmap/dim3/utils.rs
@@ -7,7 +7,7 @@
 use super::CMAP3_BETA;
 use crate::geometry::CoordsFloat;
 use crate::prelude::{CMap3, DartIdType};
-use stm::atomically;
+use crate::stm::atomically;
 
 // ------ CONTENT
 

--- a/honeycomb-core/src/cmap/error.rs
+++ b/honeycomb-core/src/cmap/error.rs
@@ -1,6 +1,6 @@
 //! Main error type
 
-use stm::StmError;
+use crate::stm::StmError;
 
 /// Convenience type alias
 pub type CMapResult<T> = Result<T, CMapError>;
@@ -10,7 +10,7 @@ pub type CMapResult<T> = Result<T, CMapError>;
 pub enum CMapError {
     /// STM transaction failed.
     #[error("transaction failed")]
-    FailedTransaction(/*#[from]*/ StmError),
+    FailedTransaction(#[from] StmError),
     /// Attribute merge failed due to missing value(s).
     #[error("attribute merge failed: {0}")]
     FailedAttributeMerge(&'static str),
@@ -23,12 +23,4 @@ pub enum CMapError {
     /// Accessed attribute isn't in the map storage.
     #[error("unknown attribute: {0}")]
     UnknownAttribute(&'static str),
-}
-
-// if `StmError` derived `thiserror::Error`, this would be automatically generated
-// by the commented `#[from]` macro above
-impl From<StmError> for CMapError {
-    fn from(value: StmError) -> Self {
-        Self::FailedTransaction(value)
-    }
 }

--- a/honeycomb-core/src/lib.rs
+++ b/honeycomb-core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod cmap;
 pub mod geometry;
 
 // re-export since we use their items in the API
-pub use stm;
+pub use fast_stm as stm;
 
 /// commonly used items
 pub mod prelude;


### PR DESCRIPTION
### Description

**Scope**:  core

**Type of change**: refactor

**Content description**:

this is motivated by issue encountered implementing #269. our implementation allows custom errors to be used and passed through transactions. this is necessary as transactions can operate on invalid data (though they are not validated at the end).

this PR is mostly noise due to items being renamed. there are no fundamental changes in implementation, these will come in a separate PR (#273 ?).

### Additional information

- swap `stm` for [`fast-stm`](https://github.com/imrn99/fast-stm)
- PRs with changes of the fork:
	- https://github.com/imrn99/fast-stm/pull/4
	- https://github.com/imrn99/fast-stm/pull/3
