### PR TITLE
feat(render): use white background & unlit i-cells to improve visuals

### DIFF
--- a/honeycomb-render/src/app.rs
+++ b/honeycomb-render/src/app.rs
@@ -1,6 +1,5 @@
 use crate::capture::{Capture, CaptureList};
 use crate::plugins::{CapturePlugin, GuiPlugin, OptionsPlugin, ScenePlugin};
-use bevy::pbr::PbrPlugin;
 use bevy::prelude::App as BevyApp;
 use bevy::prelude::*;
 use honeycomb_core::prelude::{CMap2, CoordsFloat};
@@ -40,14 +39,11 @@ impl Default for App {
         app.insert_resource(Msaa::Sample4)
             .insert_resource(ClearColor(Color::srgb(0.9, 0.9, 0.9)));
         // plugins
-        app.add_plugins(DefaultPlugins.set(PbrPlugin {
-            prepass_enabled: false,
-            ..default()
-        }))
-        .add_plugins(OptionsPlugin)
-        .add_plugins(GuiPlugin)
-        .add_plugins(ScenePlugin)
-        .add_plugins(CapturePlugin);
+        app.add_plugins(DefaultPlugins)
+            .add_plugins(OptionsPlugin)
+            .add_plugins(GuiPlugin)
+            .add_plugins(ScenePlugin)
+            .add_plugins(CapturePlugin);
         Self {
             app,
             capture_list: CaptureList(Vec::new()),

--- a/honeycomb-render/src/app.rs
+++ b/honeycomb-render/src/app.rs
@@ -1,5 +1,6 @@
 use crate::capture::{Capture, CaptureList};
 use crate::plugins::{CapturePlugin, GuiPlugin, OptionsPlugin, ScenePlugin};
+use bevy::pbr::PbrPlugin;
 use bevy::prelude::App as BevyApp;
 use bevy::prelude::*;
 use honeycomb_core::prelude::{CMap2, CoordsFloat};
@@ -36,13 +37,17 @@ impl Default for App {
     fn default() -> Self {
         let mut app = BevyApp::new();
         // resource
-        app.insert_resource(Msaa::Sample4);
+        app.insert_resource(Msaa::Sample4)
+            .insert_resource(ClearColor(Color::srgb(0.9, 0.9, 0.9)));
         // plugins
-        app.add_plugins(DefaultPlugins)
-            .add_plugins(OptionsPlugin)
-            .add_plugins(GuiPlugin)
-            .add_plugins(ScenePlugin)
-            .add_plugins(CapturePlugin);
+        app.add_plugins(DefaultPlugins.set(PbrPlugin {
+            prepass_enabled: false,
+            ..default()
+        }))
+        .add_plugins(OptionsPlugin)
+        .add_plugins(GuiPlugin)
+        .add_plugins(ScenePlugin)
+        .add_plugins(CapturePlugin);
         Self {
             app,
             capture_list: CaptureList(Vec::new()),

--- a/honeycomb-render/src/capture/system.rs
+++ b/honeycomb-render/src/capture/system.rs
@@ -64,7 +64,7 @@ pub fn populate_darts(
                     body.clone(),
                     PbrBundle {
                         mesh: meshes.add(Cylinder::new(
-                            dart_width.0,
+                            dart_width.0 / 2.,
                             // FIXME: clunky
                             len * (1. - dart_shrink.0.abs()),
                         )),
@@ -134,9 +134,11 @@ pub fn populate_vertices(
     vertex_width: Res<VertexWidth>,
 ) {
     let vertex_handle = meshes.add(Sphere::new(vertex_width.0 / 2.));
-    let vertex_mat = materials.add(Color::Srgba(Srgba::from_u8_array(
-        vertex_render_color.1.to_array(),
-    )));
+    let vertex_mat = materials.add(StandardMaterial {
+        unlit: true,
+        base_color: Color::Srgba(Srgba::from_u8_array(vertex_render_color.1.to_array())),
+        ..default()
+    });
     for capture in &captures.0 {
         let vertices = &capture.vertex_vals;
         let visibility =
@@ -183,9 +185,11 @@ pub fn populate_edges(
     edge_render_color: Res<EdgeRenderColor>,
     edge_width: Res<EdgeWidth>,
 ) {
-    let edge_mat = materials.add(Color::Srgba(Srgba::from_u8_array(
-        edge_render_color.1.to_array(),
-    )));
+    let edge_mat = materials.add(StandardMaterial {
+        unlit: true,
+        base_color: Color::Srgba(Srgba::from_u8_array(edge_render_color.1.to_array())),
+        ..default()
+    });
     for capture in &captures.0 {
         let vertices = &capture.vertex_vals;
         let visibility =

--- a/honeycomb-render/src/render/mod.rs
+++ b/honeycomb-render/src/render/mod.rs
@@ -8,6 +8,7 @@ use crate::resources::{
     DartHeadMul, DartRenderColor, DartShrink, DartWidth, EdgeRenderColor, EdgeWidth,
     VertexRenderColor, VertexWidth,
 };
+use bevy::input::common_conditions::input_just_released;
 use bevy::prelude::*;
 use bevy_mod_outline::OutlinePlugin;
 use bevy_mod_picking::selection::SelectionPluginSettings;
@@ -42,7 +43,8 @@ impl Plugin for ScenePlugin {
             )
                 .run_if(
                     resource_changed::<FocusedCapture>
-                        .and_then(not(resource_added::<FocusedCapture>)),
+                        .and_then(not(resource_added::<FocusedCapture>))
+                        .and_then(input_just_released(MouseButton::Left)),
                 ),
         );
 
@@ -59,9 +61,11 @@ impl Plugin for ScenePlugin {
             update::dart_heads_handle.run_if(
                 resource_changed::<DartWidth>
                     .and_then(not(resource_added::<DartWidth>))
+                    .and_then(input_just_released(MouseButton::Left))
                     .or_else(
                         resource_changed::<DartHeadMul>
-                            .and_then(not(resource_added::<DartHeadMul>)),
+                            .and_then(not(resource_added::<DartHeadMul>))
+                            .and_then(input_just_released(MouseButton::Left)),
                     ),
             ),
         );
@@ -70,15 +74,21 @@ impl Plugin for ScenePlugin {
             update::dart_bodies_handles.run_if(
                 resource_changed::<DartWidth>
                     .and_then(not(resource_added::<DartWidth>))
+                    .and_then(input_just_released(MouseButton::Left))
                     .or_else(
-                        resource_changed::<DartShrink>.and_then(not(resource_added::<DartShrink>)),
+                        resource_changed::<DartShrink>
+                            .and_then(not(resource_added::<DartShrink>))
+                            .and_then(input_just_released(MouseButton::Left)),
                     ),
             ),
         );
         app.add_systems(
             Update,
-            (update::dart_heads_transform, update::dart_bodies_transform)
-                .run_if(resource_changed::<DartShrink>.and_then(not(resource_added::<DartShrink>))),
+            (update::dart_heads_transform, update::dart_bodies_transform).run_if(
+                resource_changed::<DartShrink>
+                    .and_then(not(resource_added::<DartShrink>))
+                    .and_then(input_just_released(MouseButton::Left)),
+            ),
         );
 
         // vertex updates
@@ -92,7 +102,9 @@ impl Plugin for ScenePlugin {
         app.add_systems(
             Update,
             update::vertices_handle.run_if(
-                resource_changed::<VertexWidth>.and_then(not(resource_added::<VertexWidth>)),
+                resource_changed::<VertexWidth>
+                    .and_then(not(resource_added::<VertexWidth>))
+                    .and_then(input_just_released(MouseButton::Left)),
             ),
         );
         // edge updates
@@ -105,8 +117,11 @@ impl Plugin for ScenePlugin {
         );
         app.add_systems(
             Update,
-            update::edges_handle
-                .run_if(resource_changed::<EdgeWidth>.and_then(not(resource_added::<EdgeWidth>))),
+            update::edges_handle.run_if(
+                resource_changed::<EdgeWidth>
+                    .and_then(not(resource_added::<EdgeWidth>))
+                    .and_then(input_just_released(MouseButton::Left)),
+            ),
         );
     }
 }

--- a/honeycomb-render/src/render/scene.rs
+++ b/honeycomb-render/src/render/scene.rs
@@ -1,19 +1,6 @@
 use crate::components::PanOrbitCamera;
 use bevy::prelude::*;
 
-macro_rules! spawn_plight {
-    ($cmd: ident, $x: expr, $y: expr, $z: expr) => {
-        $cmd.spawn(PointLightBundle {
-            point_light: PointLight {
-                shadows_enabled: true,
-                ..default()
-            },
-            transform: Transform::from_xyz($x, $y, $z),
-            ..default()
-        });
-    };
-}
-
 /// Scene setup routine.
 pub fn setup_scene(mut commands: Commands) {
     let camera_transform = Transform::from_xyz(0.0, 0.0, 5.0);
@@ -28,10 +15,4 @@ pub fn setup_scene(mut commands: Commands) {
             ..default()
         },
     ));
-
-    spawn_plight!(commands, 0.0, 0.0, 6.0);
-    spawn_plight!(commands, 10.0, 0.0, 4.0);
-    spawn_plight!(commands, 0.0, 10.0, 4.0);
-    spawn_plight!(commands, -10.0, 0.0, 4.0);
-    spawn_plight!(commands, 0.0, -10.0, 4.0);
 }

--- a/honeycomb-render/src/render/update.rs
+++ b/honeycomb-render/src/render/update.rs
@@ -20,7 +20,7 @@ pub fn dart_mat_handle(
     render_color: Res<DartRenderColor>,
 ) {
     let mat = materials.get_mut(&handle.0).expect("unreachable");
-    *mat = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array())).into();
+    mat.base_color = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array()));
 }
 
 /// Dart render color and status update system.
@@ -175,7 +175,7 @@ pub fn vertices_mat_handle(
     render_color: Res<VertexRenderColor>,
 ) {
     let mat = materials.get_mut(&handle.0).expect("unreachable");
-    *mat = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array())).into();
+    mat.base_color = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array()));
 }
 
 // --- edges
@@ -220,5 +220,5 @@ pub fn edges_mat_handle(
     render_color: Res<EdgeRenderColor>,
 ) {
     let mat = materials.get_mut(&handle.0).expect("unreachable");
-    *mat = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array())).into();
+    mat.base_color = Color::Srgba(Srgba::from_u8_array(render_color.1.to_array()));
 }


### PR DESCRIPTION
### Description

**Scope**:  core / kernels / repository / ...

**Type of change**: feat / fix / doc / refactor / ...

**Content description**:

- title 
- limit draggable render params update to click release for perf
- remove point lights (seems to drastically improve perf too)

#### Before

<img width="1392" alt="Capture d’écran 2025-02-10 à 22 19 02" src="https://github.com/user-attachments/assets/b0cd68a2-b352-4d0f-80a6-394ea2e83b9b" />

#### After

<img width="1392" alt="Capture d’écran 2025-02-10 à 22 17 01" src="https://github.com/user-attachments/assets/8ff1cf5d-b4e4-4d0a-aea0-58b7f96068ac" />

### Necessary follow-up

- remove docked menu in favor of a draggable window with keybinds
- make a binary that taks a cmap file as arg?
- add `From<CMap3>` impl for `Capture`


