### PR TITLE
fix(core): merge edge attributes in 2-sew between isolated darts

### DIFF
--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -1,3 +1,4 @@
+use crate::cmap::EdgeIdType;
 use crate::stm::{abort, try_or_coerce, Transaction, TransactionClosureResult};
 
 use crate::{
@@ -27,7 +28,16 @@ impl<T: CoordsFloat> CMap2<T> {
                     self.betas.two_link_core(trans, lhs_dart_id, rhs_dart_id),
                     SewError
                 );
-                // FIXME: merge edge attributes
+                let eid_new = self.edge_id_transac(trans, lhs_dart_id)?;
+                try_or_coerce!(
+                    self.attributes.try_merge_edge_attributes(
+                        trans,
+                        eid_new,
+                        lhs_dart_id as EdgeIdType,
+                        rhs_dart_id as EdgeIdType,
+                    ),
+                    SewError
+                );
             }
             // update vertex associated to b1rhs/lhs
             (true, false) => {

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -23,8 +23,15 @@ impl<T: CoordsFloat> CMap3<T> {
         match (b1ld == NULL_DART_ID, b1rd == NULL_DART_ID) {
             // trivial case, no update needed
             (true, true) => {
+                let eid_l = self.edge_id_transac(trans, ld)?;
+                let eid_r = self.edge_id_transac(trans, b1rd)?;
                 try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);
-                // FIXME: merge edge attributes
+                let eid_new = self.edge_id_transac(trans, ld)?;
+                try_or_coerce!(
+                    self.attributes
+                        .try_merge_edge_attributes(trans, eid_new, eid_l, eid_r),
+                    SewError
+                );
             }
             // update vertex associated to b1rhs/lhs
             (true, false) => {


### PR DESCRIPTION
### Description

**Scope**:  core

**Type of change**: fix

**Content description**: 

edge attributes weren't merge if there were no vertices to merge on both sides of the edge (i.e. both darts were isolated)

