### PR TITLE
chore: clean and order imports

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -19,8 +19,8 @@ cfg-if.workspace = true
 honeycomb.workspace = true
 rayon.workspace = true
 
+
 [dev-dependencies]
-honeycomb-core.workspace = true
 criterion = { workspace = true, features = ["html_reports"] }
 iai-callgrind.workspace = true
 rand = { workspace = true, features = ["small_rng"] }

--- a/benches/benches/builder/grid_size.rs
+++ b/benches/benches/builder/grid_size.rs
@@ -1,10 +1,7 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use honeycomb::prelude::CMap2;
+use honeycomb::prelude::{CMap2, CMapBuilder};
+
 use honeycomb_benches::FloatType;
-use honeycomb_core::cmap::CMapBuilder;
-// ------ CONTENT
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("builder-grid-size");

--- a/benches/benches/builder/time.rs
+++ b/benches/benches/builder/time.rs
@@ -1,10 +1,7 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use honeycomb::prelude::CMap2;
+use honeycomb::prelude::{CMap2, CMapBuilder};
+
 use honeycomb_benches::FloatType;
-use honeycomb_core::cmap::CMapBuilder;
-// ------ CONTENT
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // passing args to cargo bench filters bench instead of actually reading args;

--- a/benches/benches/core/cmap2/basic_ops.rs
+++ b/benches/benches/core/cmap2/basic_ops.rs
@@ -9,19 +9,14 @@
 //!
 //! Each benchmark is repeated on CMap2 of different sizes.
 
-// ------ IMPORTS
-
 use std::hint::black_box;
 
-use honeycomb_core::cmap::{CMap2, CMapBuilder, DartIdType};
-use honeycomb_core::geometry::Vertex2;
+use honeycomb::prelude::{CMap2, CMapBuilder, DartIdType, Vertex2};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
 
 use honeycomb_benches::FloatType;
-
-// ------ CONTENT
 
 // --- common
 

--- a/benches/benches/core/cmap2/constructors.rs
+++ b/benches/benches/core/cmap2/constructors.rs
@@ -11,18 +11,14 @@
 //!
 //! Each benchmark is repeated on CMap2 of different sizes.
 
-// ------ IMPORTS
-
 use std::hint::black_box;
 
-use honeycomb_core::cmap::{CMap2, CMapBuilder};
+use honeycomb::core::cmap::{CMap2, CMapBuilder};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
 
 use honeycomb_benches::FloatType;
-
-// ------ CONTENT
 
 // --- common
 

--- a/benches/benches/core/cmap2/fetch_icells.rs
+++ b/benches/benches/core/cmap2/fetch_icells.rs
@@ -1,11 +1,7 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use honeycomb::prelude::CMap2;
-use honeycomb_benches::FloatType;
-use honeycomb_core::cmap::CMapBuilder;
+use honeycomb::core::cmap::{CMap2, CMapBuilder};
 
-// ------ CONTENT
+use honeycomb_benches::FloatType;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let n_square = 512;

--- a/benches/benches/core/cmap2/link_and_sew.rs
+++ b/benches/benches/core/cmap2/link_and_sew.rs
@@ -10,18 +10,14 @@
 //!
 //! Each benchmark is repeated on CMap2 of different sizes.
 
-// ------ IMPORTS
-
 use std::hint::black_box;
 
-use honeycomb_core::cmap::{CMap2, CMapBuilder};
+use honeycomb::core::cmap::{CMap2, CMapBuilder};
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, FlamegraphConfig, LibraryBenchmarkConfig,
 };
 
 use honeycomb_benches::FloatType;
-
-// ------ CONTENT
 
 // --- common
 

--- a/benches/benches/grisubal/grid_size.rs
+++ b/benches/benches/grisubal/grid_size.rs
@@ -1,13 +1,10 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use honeycomb::prelude::{
     grisubal::{grisubal, Clip},
     CMap2,
 };
-use honeycomb_benches::FloatType;
 
-// ------ CONTENT
+use honeycomb_benches::FloatType;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // passing args to cargo bench filters bench instead of actually reading args;

--- a/benches/benches/grisubal/time.rs
+++ b/benches/benches/grisubal/time.rs
@@ -1,13 +1,10 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use honeycomb::prelude::{
     grisubal::{grisubal, Clip},
     CMap2,
 };
-use honeycomb_benches::FloatType;
 
-// ------ CONTENT
+use honeycomb_benches::FloatType;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // passing args to cargo bench filters bench instead of actually reading args;

--- a/benches/benches/triangulate/quads.rs
+++ b/benches/benches/triangulate/quads.rs
@@ -1,13 +1,10 @@
-// ------ IMPORTS
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use honeycomb::prelude::{
     triangulation::{earclip_cell, fan_cell, TriangulateError},
     CMap2, CMapBuilder, DartIdType, Orbit2, OrbitPolicy,
 };
-use honeycomb_benches::FloatType;
 
-// ------ CONTENT
+use honeycomb_benches::FloatType;
 
 const PATH: &str = "../examples/quads.vtk";
 

--- a/honeycomb-core/src/attributes/collections.rs
+++ b/honeycomb-core/src/attributes/collections.rs
@@ -3,7 +3,7 @@
 //! This module contains all code used to describe custom collections used to store attributes
 //! (see [`AttributeBind`], [`AttributeUpdate`]).
 
-// ------ IMPORTS
+use num_traits::ToPrimitive;
 
 use crate::attributes::{
     AttributeBind, AttributeError, AttributeStorage, AttributeUpdate, UnknownAttributeStorage,
@@ -12,10 +12,6 @@ use crate::cmap::DartIdType;
 use crate::stm::{
     abort, atomically, StmClosureResult, TVar, Transaction, TransactionClosureResult,
 };
-
-use num_traits::ToPrimitive;
-
-// ------ CONTENT
 
 /// Custom storage structure
 ///

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -3,8 +3,6 @@
 //! this module contains all code used to implement a manager struct, used to handle generic
 //! attributes embedded in a given combinatorial map.
 
-// ------ IMPORTS
-
 use std::{any::TypeId, collections::HashMap};
 
 use crate::attributes::{
@@ -12,8 +10,6 @@ use crate::attributes::{
 };
 use crate::cmap::{DartIdType, OrbitPolicy};
 use crate::stm::{StmClosureResult, Transaction, TransactionClosureResult};
-
-// ------ CONTENT
 
 // convenience macros
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -1,5 +1,3 @@
-// ------ IMPORTS
-
 use std::any::Any;
 
 use loom::sync::Arc;
@@ -13,8 +11,6 @@ use crate::{
     geometry::Vertex2,
     stm::{atomically, StmError, Transaction, TransactionControl},
 };
-
-// ------ CONTENT
 
 // --- basic structure implementation
 

--- a/honeycomb-core/src/attributes/traits.rs
+++ b/honeycomb-core/src/attributes/traits.rs
@@ -3,19 +3,15 @@
 //! This module contains all code used to handle attribute genericity in the context of mesh
 //! representation through combinatorial maps embedded data.
 
-// ------ IMPORTS
-
-use crate::attributes::AttributeError;
-use crate::cmap::{DartIdType, OrbitPolicy};
-use crate::stm::{atomically, StmClosureResult, Transaction};
+use std::any::{type_name, Any};
+use std::fmt::Debug;
 
 use downcast_rs::{impl_downcast, Downcast};
 use fast_stm::TransactionClosureResult;
 
-use std::any::{type_name, Any};
-use std::fmt::Debug;
-
-// ------ CONTENT
+use crate::attributes::AttributeError;
+use crate::cmap::{DartIdType, OrbitPolicy};
+use crate::stm::{atomically, StmClosureResult, Transaction};
 
 /// # Generic attribute trait
 ///

--- a/honeycomb-core/src/cmap/builder/mod.rs
+++ b/honeycomb-core/src/cmap/builder/mod.rs
@@ -1,18 +1,11 @@
 //! Builder implementation for combinatorial map structures.
 
-// ------ MODULE DECLARATIONS
-
 pub mod grid;
 pub mod io;
 pub mod structure;
 
-// ------ RE-EXPORTS
-
 pub use grid::GridDescriptor;
 pub use structure::{BuilderError, CMapBuilder};
 
-// ------ CONTENT
-
-// ------ TESTS
 #[cfg(test)]
 mod tests;

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -1,5 +1,3 @@
-// ------ IMPORTS
-
 use std::fs::File;
 use std::io::Read;
 
@@ -11,8 +9,6 @@ use crate::cmap::{CMap2, GridDescriptor};
 use crate::geometry::CoordsFloat;
 
 use super::io::CMapFile;
-
-// ------ CONTENT
 
 /// # Builder-level error enum
 ///

--- a/honeycomb-core/src/cmap/components/betas.rs
+++ b/honeycomb-core/src/cmap/components/betas.rs
@@ -1,13 +1,9 @@
-// ------ IMPORTS
-
 use std::ops::{Index, IndexMut};
 
 use crate::cmap::{LinkError, NULL_DART_ID};
 use crate::stm::{abort, TVar, Transaction, TransactionClosureResult};
 
 use super::identifiers::DartIdType;
-
-// ------ CONTENT
 
 /// Beta functions storage.
 ///

--- a/honeycomb-core/src/cmap/components/unused.rs
+++ b/honeycomb-core/src/cmap/components/unused.rs
@@ -1,5 +1,3 @@
-// ------ IMPORTS
-
 use std::{
     ops::{Index, IndexMut},
     slice::Iter,
@@ -8,8 +6,6 @@ use std::{
 use crate::stm::TVar;
 
 use super::identifiers::DartIdType;
-
-// ------ CONTENT
 
 /// Unused dart tracking structure.
 pub struct UnusedDarts(Vec<TVar<bool>>);

--- a/honeycomb-core/src/cmap/dim2/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim2/basic_ops.rs
@@ -7,8 +7,6 @@
 //! - Beta function interfaces
 //! - i-cell computations
 
-// ------ IMPORTS
-
 use std::collections::{HashSet, VecDeque};
 
 use crate::attributes::UnknownAttributeStorage;
@@ -17,8 +15,6 @@ use crate::cmap::{
 };
 use crate::geometry::CoordsFloat;
 use crate::stm::{atomically, StmClosureResult, Transaction};
-
-// ------ CONTENT
 
 /// **Dart-related methods**
 impl<T: CoordsFloat> CMap2<T> {

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -4,16 +4,12 @@
 //! map. This includes operations regarding vertices as well as (in the future) user-defined
 //! generic attributes
 
-// ------ IMPORT
-
 use crate::cmap::{CMap2, VertexIdType};
 use crate::stm::{StmClosureResult, Transaction};
 use crate::{
     attributes::{AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage},
     geometry::{CoordsFloat, Vertex2},
 };
-
-// ------ CONTENT
 
 /// **Built-in vertex-related methods**
 impl<T: CoordsFloat> CMap2<T> {

--- a/honeycomb-core/src/cmap/dim2/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/mod.rs
@@ -5,8 +5,6 @@
 //! The definitions are re-exported, direct interaction with this module
 //! should be minimal, if existing at all.
 
-// ------ MODULE DECLARATIONS
-
 pub mod basic_ops;
 pub mod embed;
 pub mod links;
@@ -16,12 +14,8 @@ pub mod sews;
 pub mod structure;
 pub mod utils;
 
-// ------ CONTENT
-
 /// Number of beta functions defined for [`CMap2`].
 const CMAP2_BETA: usize = 3;
-
-// ------ TESTS
 
 #[allow(unused_mut)]
 #[cfg(test)]

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -3,14 +3,10 @@
 //! This module contains all code used to model orbits, a notion defined
 //! along the structure of combinatorial maps.
 
-// ------ IMPORTS
-
 use std::collections::{BTreeSet, VecDeque};
 
 use crate::cmap::{CMap2, DartIdType, OrbitPolicy, NULL_DART_ID};
 use crate::geometry::CoordsFloat;
-
-// ------ CONTENT
 
 /// # Generic 2D orbit implementation
 ///

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -3,15 +3,11 @@
 //! This module contains the main structure definition ([`CMap2`]) as well as its constructor
 //! implementation.
 
-// ------ IMPORTS
-
 use crate::attributes::{AttrSparseVec, AttrStorageManager, UnknownAttributeStorage};
 use crate::cmap::components::{betas::BetaFunctions, unused::UnusedDarts};
 use crate::geometry::{CoordsFloat, Vertex2};
 
 use super::CMAP2_BETA;
-
-// ------ CONTENT
 
 /// # 2D combinatorial map implementation
 ///

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -1,13 +1,9 @@
-// ------ IMPORTS
-
 use crate::{
     attributes::{AttrSparseVec, AttributeBind, AttributeError, AttributeUpdate},
     cmap::{CMap2, CMapBuilder, LinkError, Orbit2, OrbitPolicy, SewError, VertexIdType},
     geometry::Vertex2,
     stm::{atomically, atomically_with_err, StmError, TransactionError},
 };
-
-// ------ CONTENT
 
 // --- GENERAL
 

--- a/honeycomb-core/src/cmap/dim2/utils.rs
+++ b/honeycomb-core/src/cmap/dim2/utils.rs
@@ -1,14 +1,10 @@
 //! [`CMap2`] utilities implementations
 
-// ------ IMPORTS
-
 use crate::cmap::{CMap2, DartIdType};
 use crate::geometry::CoordsFloat;
 use crate::stm::atomically;
 
 use super::CMAP2_BETA;
-
-// ------ CONTENT
 
 /// **Utilities**
 impl<T: CoordsFloat> CMap2<T> {

--- a/honeycomb-core/src/cmap/dim3/basic_ops.rs
+++ b/honeycomb-core/src/cmap/dim3/basic_ops.rs
@@ -7,8 +7,6 @@
 //! - Beta function interfaces
 //! - i-cell computations
 
-// ------ IMPORTS
-
 use std::collections::{HashSet, VecDeque};
 
 use crate::attributes::UnknownAttributeStorage;
@@ -18,8 +16,6 @@ use crate::cmap::{
 };
 use crate::geometry::CoordsFloat;
 use crate::stm::{atomically, StmClosureResult, StmError, Transaction};
-
-// ------ CONTENT
 
 /// **Dart-related methods**
 impl<T: CoordsFloat> CMap3<T> {

--- a/honeycomb-core/src/cmap/dim3/embed.rs
+++ b/honeycomb-core/src/cmap/dim3/embed.rs
@@ -4,16 +4,12 @@
 //! map. This includes operations regarding vertices as well as (in the future) user-defined
 //! generic attributes
 
-// ------ IMPORT
-
 use crate::attributes::{
     AttributeBind, AttributeStorage, AttributeUpdate, UnknownAttributeStorage,
 };
 use crate::cmap::{CMap3, VertexIdType};
 use crate::geometry::{CoordsFloat, Vertex3};
 use crate::stm::{StmClosureResult, Transaction};
-
-// ------ CONTENT
 
 /// ## **Built-in vertex-related methods**
 impl<T: CoordsFloat> CMap3<T> {

--- a/honeycomb-core/src/cmap/dim3/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/mod.rs
@@ -17,7 +17,5 @@ pub mod utils;
 /// Number of beta functions defined for [`CMap3`].
 const CMAP3_BETA: usize = 4;
 
-// -- tests
-
 #[cfg(test)]
 mod tests;

--- a/honeycomb-core/src/cmap/dim3/structure.rs
+++ b/honeycomb-core/src/cmap/dim3/structure.rs
@@ -3,8 +3,6 @@
 //! This module contains the main structure definition ([`CMap3`]) as well as its constructor
 //! implementation.
 
-// ------ IMPORTS
-
 use crate::{
     attributes::{AttrSparseVec, AttrStorageManager, UnknownAttributeStorage},
     cmap::components::{betas::BetaFunctions, unused::UnusedDarts},
@@ -12,8 +10,6 @@ use crate::{
 };
 
 use super::CMAP3_BETA;
-
-// ------ CONTENT
 
 /// Main map object.
 pub struct CMap3<T: CoordsFloat> {

--- a/honeycomb-core/src/cmap/dim3/tests.rs
+++ b/honeycomb-core/src/cmap/dim3/tests.rs
@@ -1,13 +1,9 @@
-// ------ IMPORTS
-
 use crate::{
     attributes::{AttrSparseVec, AttributeBind, AttributeError, AttributeUpdate},
     cmap::{CMap3, DartIdType, Orbit3, OrbitPolicy, SewError, VertexIdType},
     geometry::Vertex3,
     stm::{atomically, atomically_with_err, StmError, TVar, TransactionError},
 };
-
-// ------ CONTENT
 
 #[test]
 fn example_test() {

--- a/honeycomb-core/src/cmap/dim3/utils.rs
+++ b/honeycomb-core/src/cmap/dim3/utils.rs
@@ -2,15 +2,11 @@
 //!
 //! This module contains utility code for the [`CMap3`] structure.
 
-// ------ IMPORTS
-
 use crate::cmap::{CMap3, DartIdType};
 use crate::geometry::CoordsFloat;
 use crate::stm::atomically;
 
 use super::CMAP3_BETA;
-
-// ------ CONTENT
 
 /// **Utilities**
 impl<T: CoordsFloat> CMap3<T> {

--- a/honeycomb-core/src/geometry/dim2/tests.rs
+++ b/honeycomb-core/src/geometry/dim2/tests.rs
@@ -1,7 +1,3 @@
-// ------ IMPORTS
-
-// ------ CONTENT
-
 use crate::geometry::{CoordsFloat, Vector2};
 
 // --- common

--- a/honeycomb-core/src/geometry/dim3/tests.rs
+++ b/honeycomb-core/src/geometry/dim3/tests.rs
@@ -1,8 +1,4 @@
-// ------ IMPORTS
-
 use crate::geometry::{CoordsFloat, Vector3, Vertex3};
-
-// ------ CONTENT
 
 // --- common
 // scalar equality function

--- a/honeycomb-core/src/geometry/mod.rs
+++ b/honeycomb-core/src/geometry/mod.rs
@@ -6,14 +6,12 @@
 mod dim2;
 mod dim3;
 
+pub use dim2::{vector::Vector2, vertex::Vertex2};
+pub use dim3::{vector::Vector3, vertex::Vertex3};
+
 use std::fmt::Debug;
 use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 use thiserror::Error;
-
-//
-
-pub use dim2::{vector::Vector2, vertex::Vertex2};
-pub use dim3::{vector::Vector3, vertex::Vertex3};
 
 /// # Coordinates-level error enum
 #[derive(Error, Debug, PartialEq)]

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -50,13 +50,9 @@
 //!
 //! The `Boundary` attribute is then removed from the map before return.
 
-// ------ MODULE DECLARATIONS
-
 pub(crate) mod model;
 pub(crate) mod routines;
 pub(crate) mod timers;
-
-// ------ IMPORTS
 
 use honeycomb_core::{
     cmap::{CMap2, CMapBuilder, GridDescriptor},
@@ -75,8 +71,6 @@ use crate::grisubal::{
     },
     timers::{finish, start_timer, unsafe_time_section},
 };
-
-// ------ CONTENT
 
 /// Post-processing clip operation.
 ///
@@ -259,8 +253,6 @@ pub fn grisubal<T: CoordsFloat>(
 
     Ok(cmap)
 }
-
-// ------ TESTS
 
 #[cfg(test)]
 mod tests;

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -4,8 +4,6 @@
 //!
 //! Content description if needed
 
-// ------ IMPORTS
-
 use honeycomb_core::attributes::{AttrSparseVec, AttributeBind, AttributeError, AttributeUpdate};
 use honeycomb_core::cmap::{DartIdType, OrbitPolicy};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
@@ -15,8 +13,6 @@ use vtkio::{
 };
 
 use crate::grisubal::GrisubalError;
-
-// ------ CONTENT
 
 /// Structure used to index the overlapping grid's cases.
 ///

--- a/honeycomb-kernels/src/grisubal/routines/clip.rs
+++ b/honeycomb-kernels/src/grisubal/routines/clip.rs
@@ -1,7 +1,5 @@
 //! clipping operation routines
 
-// ------ IMPORTS
-
 use std::collections::{HashSet, VecDeque};
 
 use honeycomb_core::cmap::{CMap2, DartIdType, FaceIdType, Orbit2, OrbitPolicy, NULL_DART_ID};
@@ -9,8 +7,6 @@ use honeycomb_core::geometry::{CoordsFloat, Vertex2};
 
 use crate::grisubal::model::Boundary;
 use crate::grisubal::GrisubalError;
-
-// ------ CONTENT
 
 /// Clip content on the left side of the boundary.
 pub fn clip_left<T: CoordsFloat>(cmap: &mut CMap2<T>) -> Result<(), GrisubalError> {

--- a/honeycomb-kernels/src/grisubal/routines/compute_intersecs.rs
+++ b/honeycomb-kernels/src/grisubal/routines/compute_intersecs.rs
@@ -4,8 +4,6 @@
 //! the geometry intersected with the grid: For each segment, if both vertices
 //! do not belong to the same cell, we break it into sub-segments until it is the case.
 
-// ------ IMPORTS
-
 use std::{
     cmp::{max, min},
     collections::VecDeque,
@@ -55,8 +53,6 @@ macro_rules! up_intersec {
         (s, (($vdart.x() - $va.x()) - ($vb.x() - $va.x()) * s) / $cx)
     }};
 }
-
-// ------ CONTENT
 
 #[allow(
     clippy::too_many_lines,

--- a/honeycomb-kernels/src/grisubal/routines/compute_new_edges.rs
+++ b/honeycomb-kernels/src/grisubal/routines/compute_new_edges.rs
@@ -4,16 +4,12 @@
 //! the list of "atomic" segments to search for connections between intersections, discarding
 //! regular points and registering points of interests.
 
-// ------ IMPORTS
-
 use honeycomb_core::cmap::{CMap2, DartIdType};
 use honeycomb_core::geometry::CoordsFloat;
 
 use crate::grisubal::model::{Geometry2, GeometryVertex, MapEdge};
 
 use super::Segments;
-
-// ------ CONTENT
 
 pub(crate) fn generate_edge_data<T: CoordsFloat>(
     cmap: &CMap2<T>,

--- a/honeycomb-kernels/src/grisubal/routines/insert_intersecs.rs
+++ b/honeycomb-kernels/src/grisubal/routines/insert_intersecs.rs
@@ -2,15 +2,11 @@
 //!
 //! Insert the intersections into the map.
 
-// ------ IMPORTS
-
 use honeycomb_core::{cmap::CMap2, geometry::CoordsFloat, stm::atomically_with_err};
 
 use crate::splits::splitn_edge_transac;
 
 use super::{DartSlices, IntersectionsPerEdge};
-
-// ------ CONTENT
 
 pub(crate) fn insert_intersections<T: CoordsFloat>(
     cmap: &CMap2<T>,

--- a/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
+++ b/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
@@ -2,16 +2,12 @@
 //
 //! Use the information computed at step 4 and insert all new edges into the map.
 
-// ------ IMPORTS
-
 use honeycomb_core::cmap::{CMap2, DartIdType};
 use honeycomb_core::geometry::CoordsFloat;
 use honeycomb_core::stm::atomically_with_err;
 
 use crate::grisubal::model::{Boundary, MapEdge};
 use crate::splits::splitn_edge_transac;
-
-// ------ CONTENT
 
 pub(crate) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[MapEdge<T>]) {
     // FIXME: minimize allocs & redundant operations

--- a/honeycomb-kernels/src/grisubal/routines/mod.rs
+++ b/honeycomb-kernels/src/grisubal/routines/mod.rs
@@ -4,8 +4,6 @@
 //!
 //! Content description if needed
 
-// ------ MODULES
-
 mod clip;
 mod compute_intersecs;
 mod compute_new_edges;
@@ -13,8 +11,6 @@ mod insert_intersecs;
 mod insert_new_edges;
 mod pre_processing;
 mod process_intersecs_data;
-
-// ------ RE-EXPORTS
 
 // step 0
 pub(crate) use pre_processing::*;
@@ -37,15 +33,11 @@ pub(crate) use insert_new_edges::*;
 // optional clipping routines
 pub(crate) use clip::{clip_left, clip_right};
 
-// ------ IMPORTS
-
 use std::collections::HashMap;
 
 use honeycomb_core::cmap::{DartIdType, EdgeIdType};
 
 use crate::grisubal::model::GeometryVertex;
-
-// ------ CONTENT
 
 pub type Segments = HashMap<GeometryVertex, GeometryVertex>;
 

--- a/honeycomb-kernels/src/grisubal/routines/pre_processing.rs
+++ b/honeycomb-kernels/src/grisubal/routines/pre_processing.rs
@@ -1,9 +1,5 @@
 //! Step 0 implementation
 
-// ------ IMPORTS
-
-// ------ CONTENT
-
 use std::collections::HashSet;
 
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -1,5 +1,3 @@
-// ------ IMPORTS
-
 use honeycomb_core::cmap::{CMapBuilder, GridDescriptor, Orbit2, OrbitPolicy};
 use honeycomb_core::geometry::Vertex2;
 use vtkio::Vtk;
@@ -9,8 +7,6 @@ use crate::grisubal::routines::{
     compute_intersection_ids, generate_edge_data, generate_intersection_data,
     group_intersections_per_edge, insert_edges_in_map, insert_intersections,
 };
-
-// ------ CONTENT
 
 // --- geometry building
 

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -6,14 +6,10 @@
 //! [UG]:https://lihpc-computational-geometry.github.io/honeycomb/
 //!
 
-// ------ CUSTOM LINTS
-
 #![warn(missing_docs)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::similar_names)]
 #![allow(clippy::module_name_repetitions)]
-
-// ------ MODULE DECLARATIONS
 
 pub mod grisubal;
 pub mod splits;

--- a/honeycomb-kernels/src/splits/edge_multiple.rs
+++ b/honeycomb-kernels/src/splits/edge_multiple.rs
@@ -1,15 +1,12 @@
 //! standard and no-alloc variants of the `splitn_edge` functions
 
-// ------ IMPORTS
-
-use crate::splits::SplitEdgeError;
 use honeycomb_core::cmap::{CMap2, DartIdType, EdgeIdType, NULL_DART_ID};
 use honeycomb_core::geometry::CoordsFloat;
 use honeycomb_core::stm::{
     abort, atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult,
 };
 
-// ------ CONTENT
+use crate::splits::SplitEdgeError;
 
 #[allow(clippy::missing_errors_doc)]
 /// Split an edge into `n` segments.

--- a/honeycomb-kernels/src/splits/edge_single.rs
+++ b/honeycomb-kernels/src/splits/edge_single.rs
@@ -1,15 +1,12 @@
 //! standard and no-alloc variants of the `split_edge` functions
 
-// ------ IMPORTS
-
-use crate::splits::SplitEdgeError;
 use honeycomb_core::cmap::{CMap2, DartIdType, EdgeIdType, NULL_DART_ID};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
 use honeycomb_core::stm::{
     abort, atomically_with_err, try_or_coerce, Transaction, TransactionClosureResult,
 };
 
-// ------ CONTENT
+use crate::splits::SplitEdgeError;
 
 #[allow(clippy::missing_errors_doc)]
 /// Split an edge into two segments.

--- a/honeycomb-kernels/src/splits/mod.rs
+++ b/honeycomb-kernels/src/splits/mod.rs
@@ -5,12 +5,8 @@
 //! have "no-alloc" variants: these take additional darts as argument in order not to
 //! allocate darts during the process.
 
-// ------ MODULE DECLARATIONS
-
 mod edge_multiple;
 mod edge_single;
-
-// ------ PUBLIC RE-EXPORTS
 
 pub use edge_multiple::{splitn_edge, splitn_edge_transac};
 pub use edge_single::{split_edge, split_edge_transac};
@@ -19,8 +15,6 @@ use honeycomb_core::{
     attributes::AttributeError,
     cmap::{LinkError, SewError},
 };
-
-// ------ CONTENT
 
 /// Error-modeling enum for edge-splitting routines.
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
@@ -54,8 +48,6 @@ impl From<AttributeError> for SplitEdgeError {
         Self::FailedCoreOp(value.into())
     }
 }
-
-// ------ TESTS
 
 #[cfg(test)]
 mod tests;

--- a/honeycomb-kernels/src/splits/tests.rs
+++ b/honeycomb-kernels/src/splits/tests.rs
@@ -1,8 +1,9 @@
 // split_edge
 
-use super::*;
 use honeycomb_core::cmap::{CMap2, CMapBuilder, NULL_DART_ID};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
+
+use super::*;
 
 fn newmap<T: CoordsFloat>(n: usize) -> CMap2<T> {
     CMapBuilder::default().n_darts(n).build().unwrap()

--- a/honeycomb-kernels/src/triangulation/ear_clipping.rs
+++ b/honeycomb-kernels/src/triangulation/ear_clipping.rs
@@ -1,8 +1,9 @@
+use honeycomb_core::cmap::{CMap2, DartIdType, FaceIdType, Orbit2, OrbitPolicy};
+use honeycomb_core::geometry::CoordsFloat;
+
 use crate::triangulation::{
     check_requirements, crossp_from_verts, fetch_face_vertices, TriangulateError,
 };
-use honeycomb_core::cmap::{CMap2, DartIdType, FaceIdType, Orbit2, OrbitPolicy};
-use honeycomb_core::geometry::CoordsFloat;
 
 #[allow(clippy::missing_panics_doc)]
 /// Triangulates a face using the ear clipping method.

--- a/honeycomb-kernels/src/triangulation/fan.rs
+++ b/honeycomb-kernels/src/triangulation/fan.rs
@@ -1,8 +1,9 @@
+use honeycomb_core::cmap::{CMap2, DartIdType, FaceIdType, Orbit2, OrbitPolicy};
+use honeycomb_core::geometry::CoordsFloat;
+
 use crate::triangulation::{
     check_requirements, crossp_from_verts, fetch_face_vertices, TriangulateError,
 };
-use honeycomb_core::cmap::{CMap2, DartIdType, FaceIdType, Orbit2, OrbitPolicy};
-use honeycomb_core::geometry::CoordsFloat;
 
 #[allow(clippy::missing_panics_doc)]
 /// Triangulates a face using a fan triangulation method.

--- a/honeycomb-kernels/src/triangulation/mod.rs
+++ b/honeycomb-kernels/src/triangulation/mod.rs
@@ -11,18 +11,12 @@
 //! - ear clipping -- this method isn't algorithmically efficient, but (a) we operate on small
 //!   cells, and (b) it covers our needs (non-fannable polygons without holes)
 
-// ------ MODULE DECLARATIONS
-
 mod ear_clipping;
 mod fan;
-
-// ------ PUBLIC RE-EXPORTS
 
 pub use ear_clipping::process_cell as earclip_cell;
 pub use fan::process_cell as fan_cell;
 pub use fan::process_convex_cell as fan_convex_cell;
-
-// ------ CONTENT
 
 use honeycomb_core::cmap::{CMap2, DartIdType};
 use honeycomb_core::geometry::{CoordsFloat, Vertex2};
@@ -131,8 +125,6 @@ fn fetch_face_vertices<T: CoordsFloat>(
 fn crossp_from_verts<T: CoordsFloat>(v1: &Vertex2<T>, v2: &Vertex2<T>, v3: &Vertex2<T>) -> T {
     (v2.x() - v1.x()) * (v3.y() - v2.y()) - (v2.y() - v1.y()) * (v3.x() - v2.x())
 }
-
-// ------ TESTS
 
 #[cfg(test)]
 mod tests;

--- a/honeycomb-render/src/capture/system.rs
+++ b/honeycomb-render/src/capture/system.rs
@@ -1,13 +1,14 @@
+use bevy::color::Color;
+use bevy::prelude::*;
+use bevy_mod_outline::{OutlineBundle, OutlineVolume};
+use bevy_mod_picking::PickableBundle;
+
 use crate::capture::{CaptureList, FocusedCapture};
 use crate::resources::{
     DartHeadHandle, DartHeadMul, DartMatHandle, DartRenderColor, DartShrink, DartWidth,
     EdgeMatHandle, EdgeRenderColor, EdgeWidth, FaceMatHandle, FaceNormals, FaceRenderColor,
     FaceShrink, MapVertices, VertexHandle, VertexMatHandle, VertexRenderColor, VertexWidth,
 };
-use bevy::color::Color;
-use bevy::prelude::*;
-use bevy_mod_outline::{OutlineBundle, OutlineVolume};
-use bevy_mod_picking::PickableBundle;
 
 /// System used to generate dart entities in the ECS.
 #[allow(clippy::too_many_arguments)]

--- a/honeycomb-render/src/gui.rs
+++ b/honeycomb-render/src/gui.rs
@@ -1,10 +1,11 @@
-use crate::systems::{draw_inspected_data, draw_options};
 use bevy::prelude::*;
 use bevy::utils::HashSet;
 use bevy::window::PrimaryWindow;
 use bevy_egui::egui::{Ui, WidgetText};
 use bevy_egui::{EguiContext, EguiPlugin, EguiSet};
 use egui_dock::{DockArea, DockState, NodeIndex, Style, Tree};
+
+use crate::systems::{draw_inspected_data, draw_options};
 
 // --- plugin
 

--- a/honeycomb-render/src/inspector/tab.rs
+++ b/honeycomb-render/src/inspector/tab.rs
@@ -1,8 +1,9 @@
-use crate::capture::ecs_data::{DartBody, DartId, EdgeId, FaceId, VertexId};
-use crate::components::{Beta, Edge, Face, Vertex, Volume};
 use bevy::prelude::*;
 use bevy::utils::HashSet;
 use bevy_egui::egui;
+
+use crate::capture::ecs_data::{DartBody, DartId, EdgeId, FaceId, VertexId};
+use crate::components::{Beta, Edge, Face, Vertex, Volume};
 
 /// Inspection panel drawing function.
 pub fn draw_inspected_data(

--- a/honeycomb-render/src/options/mod.rs
+++ b/honeycomb-render/src/options/mod.rs
@@ -1,7 +1,7 @@
-use bevy::prelude::*;
-
 pub mod resource;
 pub mod tab;
+
+use bevy::prelude::*;
 
 /// Plugin handling rendering options.
 pub struct OptionsPlugin;

--- a/honeycomb-render/src/options/tab.rs
+++ b/honeycomb-render/src/options/tab.rs
@@ -1,12 +1,14 @@
+use bevy::prelude::*;
+use bevy_mod_picking::picking_core::PickingPluginsSettings;
+use bevy_mod_picking::selection::SelectionPluginSettings;
+use egui_dock::egui;
+
 use crate::resources::{
     BetaRenderColor, BetaWidth, DartHeadMul, DartRenderColor, DartShrink, DartWidth,
     EdgeRenderColor, EdgeWidth, FaceRenderColor, FaceShrink, VertexRenderColor, VertexWidth,
     VolumeRenderColor, VolumeShrink,
 };
-use bevy::prelude::*;
-use bevy_mod_picking::picking_core::PickingPluginsSettings;
-use bevy_mod_picking::selection::SelectionPluginSettings;
-use egui_dock::egui;
+
 // --- main function
 
 /// rendering options drawing function.

--- a/honeycomb-render/src/render/camera.rs
+++ b/honeycomb-render/src/render/camera.rs
@@ -1,8 +1,9 @@
-use crate::gui::{CustomTab, UiState};
 use bevy::input::mouse::{MouseMotion, MouseWheel};
 use bevy::math::vec2;
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
+
+use crate::gui::{CustomTab, UiState};
 
 /// Taken from the bevy
 /// [cheatbook](https://bevy-cheatbook.github.io/cookbook/pan-orbit-camera.html).

--- a/honeycomb-render/src/render/mod.rs
+++ b/honeycomb-render/src/render/mod.rs
@@ -3,16 +3,17 @@ pub mod picking;
 pub mod scene;
 pub mod update;
 
-use crate::capture::FocusedCapture;
-use crate::resources::{
-    DartHeadMul, DartRenderColor, DartShrink, DartWidth, EdgeRenderColor, EdgeWidth,
-    VertexRenderColor, VertexWidth,
-};
 use bevy::input::common_conditions::input_just_released;
 use bevy::prelude::*;
 use bevy_mod_outline::OutlinePlugin;
 use bevy_mod_picking::selection::SelectionPluginSettings;
 use bevy_mod_picking::DefaultPickingPlugins;
+
+use crate::capture::FocusedCapture;
+use crate::resources::{
+    DartHeadMul, DartRenderColor, DartShrink, DartWidth, EdgeRenderColor, EdgeWidth,
+    VertexRenderColor, VertexWidth,
+};
 
 /// Plugin handling scene setup and updates.
 pub struct ScenePlugin;

--- a/honeycomb-render/src/render/picking.rs
+++ b/honeycomb-render/src/render/picking.rs
@@ -1,7 +1,8 @@
-use crate::gui::UiState;
 use bevy::prelude::*;
 use bevy_mod_outline::OutlineVolume;
 use bevy_mod_picking::prelude::PickSelection;
+
+use crate::gui::UiState;
 
 /// Picking update routine.
 pub fn update_picking(

--- a/honeycomb-render/src/render/scene.rs
+++ b/honeycomb-render/src/render/scene.rs
@@ -1,5 +1,6 @@
-use crate::components::PanOrbitCamera;
 use bevy::prelude::*;
+
+use crate::components::PanOrbitCamera;
 
 /// Scene setup routine.
 pub fn setup_scene(mut commands: Commands) {

--- a/honeycomb-render/src/render/update.rs
+++ b/honeycomb-render/src/render/update.rs
@@ -1,3 +1,6 @@
+use bevy::math::{Quat, Vec3};
+use bevy::prelude::*;
+
 use crate::capture::ecs_data::{
     CaptureId, DartBody, DartHead, DartId, Edge, FaceId, FaceNormals, MapVertices, Vertex,
 };
@@ -7,8 +10,6 @@ use crate::options::resource::{
     EdgeMatHandle, EdgeRenderColor, EdgeWidth, VertexHandle, VertexMatHandle, VertexRenderColor,
     VertexWidth,
 };
-use bevy::math::{Quat, Vec3};
-use bevy::prelude::*;
 
 // --- darts
 


### PR DESCRIPTION
### Description

**Content description**:

All imports now follow this order / structure:

```
// use std:: ...

// use extern_crate:: ...

// use crate:: ...

// use super:: ... / use self:: ...
```
