### PR TITLE
refactor(core): remove dead code from attribute items

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -403,41 +403,6 @@ impl AttrStorageManager {
 
     // attribute-specific
 
-    #[allow(clippy::missing_errors_doc)]
-    /// Merge given attribute values.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    #[cfg(test)]
-    pub fn merge_attribute<A: AttributeBind + AttributeUpdate>(
-        &self,
-        trans: &mut Transaction,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmClosureResult<()> {
-        get_storage!(self, storage);
-        if let Some(st) = storage {
-            st.merge(trans, id_out, id_in_lhs, id_in_rhs)
-        } else {
-            eprintln!(
-                "W: could not update storage of attribute {} - storage not found",
-                std::any::type_name::<A>()
-            );
-            Ok(())
-        }
-    }
-
-    /*
     /// Merge given attribute values.
     ///
     /// # Errors
@@ -449,13 +414,14 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[cfg(test)]
     pub fn try_merge_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,
         id_out: DartIdType,
         id_in_lhs: DartIdType,
         id_in_rhs: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.try_merge(trans, id_out, id_in_lhs, id_in_rhs)
@@ -467,7 +433,6 @@ impl AttrStorageManager {
             Ok(())
         }
     }
-    */
 }
 
 /// Split variants.
@@ -634,7 +599,6 @@ impl AttrStorageManager {
 
     // attribute-specific
 
-    #[allow(clippy::missing_errors_doc)]
     /// Split given attribute value.
     ///
     /// # Arguments
@@ -643,33 +607,6 @@ impl AttrStorageManager {
     /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
     /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
     /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    #[cfg(test)]
-    pub fn split_attribute<A: AttributeBind + AttributeUpdate>(
-        &self,
-        trans: &mut Transaction,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmClosureResult<()> {
-        get_storage!(self, storage);
-        if let Some(st) = storage {
-            st.split(trans, id_out_lhs, id_out_rhs, id_in)
-        } else {
-            eprintln!(
-                "W: could not update storage of attribute {} - storage not found",
-                std::any::type_name::<A>()
-            );
-            Ok(())
-        }
-    }
-
-    /*
-    /// Split given attribute value.
     ///
     /// # Errors
     ///
@@ -680,13 +617,14 @@ impl AttrStorageManager {
     /// The returned error can be used in conjunction with transaction control to avoid any
     /// modifications in case of failure at attribute level. The user can then choose, through its
     /// transaction control policy, to retry or abort as he wishes.
+    #[cfg(test)]
     pub fn try_split_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         trans: &mut Transaction,
         id_out_lhs: DartIdType,
         id_out_rhs: DartIdType,
         id_in: DartIdType,
-    ) -> CMapResult<()> {
+    ) -> TransactionClosureResult<(), AttributeError> {
         get_storage!(self, storage);
         if let Some(st) = storage {
             st.try_split(trans, id_out_lhs, id_out_rhs, id_in)
@@ -698,7 +636,6 @@ impl AttrStorageManager {
             Ok(())
         }
     }
-    */
 }
 
 /// **Attribute read & write methods**
@@ -824,61 +761,6 @@ impl AttrStorageManager {
                 std::any::type_name::<A>()
             );
             Ok(None)
-        }
-    }
-
-    /// Get the value of an attribute.
-    ///
-    /// This variant is equivalent to `read_attribute`, but internally uses a transaction
-    /// that will be retried until validated.
-    pub fn force_read_attribute<A: AttributeBind>(&self, id: A::IdentifierType) -> Option<A> {
-        get_storage!(self, storage);
-        if let Some(st) = storage {
-            st.force_read(id)
-        } else {
-            eprintln!(
-                "W: could not update storage of attribute {} - storage not found",
-                std::any::type_name::<A>()
-            );
-            None
-        }
-    }
-
-    /// Set the value of an attribute, and return the old one.
-    ///
-    /// This variant is equivalent to `write_attribute`, but internally uses a transaction
-    /// that will be retried until validated.
-    pub fn force_write_attribute<A: AttributeBind>(
-        &self,
-        id: A::IdentifierType,
-        val: A,
-    ) -> Option<A> {
-        get_storage!(self, storage);
-        if let Some(st) = storage {
-            st.force_write(id, val)
-        } else {
-            eprintln!(
-                "W: could not update storage of attribute {} - storage not found",
-                std::any::type_name::<A>()
-            );
-            None
-        }
-    }
-
-    /// Remove the an item from an attribute storage, and return it.
-    ///
-    /// This variant is equivalent to `remove_attribute`, but internally uses a transaction
-    /// that will be retried until validated.
-    pub fn force_remove_attribute<A: AttributeBind>(&self, id: A::IdentifierType) -> Option<A> {
-        get_storage!(self, storage);
-        if let Some(st) = storage {
-            st.force_remove(id)
-        } else {
-            eprintln!(
-                "W: could not update storage of attribute {} - storage not found",
-                std::any::type_name::<A>()
-            );
-            None
         }
     }
 }

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -268,6 +268,14 @@ impl AttrStorageManager {
     /// Execute a merging operation on all attributes associated with a given orbit
     /// for specified cells.
     ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
+    ///
     /// # Errors
     ///
     /// This method will fail, returning an error, if:
@@ -305,6 +313,13 @@ impl AttrStorageManager {
 
     /// Execute a merging operation on all attributes associated with vertices for specified cells.
     ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
+    ///
     /// # Errors
     ///
     /// This method will fail, returning an error, if:
@@ -328,6 +343,13 @@ impl AttrStorageManager {
     }
 
     /// Execute a merging operation on all attributes associated with edges for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     ///
     /// # Errors
     ///
@@ -353,6 +375,13 @@ impl AttrStorageManager {
 
     /// Execute a merging operation on all attributes associated with faces for specified cells.
     ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
+    ///
     /// # Errors
     ///
     /// This method will fail, returning an error, if:
@@ -377,6 +406,13 @@ impl AttrStorageManager {
 
     /*
     /// Execute a merging operation on all attributes associated with volumes for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     ///
     /// # Errors
     ///
@@ -404,6 +440,14 @@ impl AttrStorageManager {
     // attribute-specific
 
     /// Merge given attribute values.
+    ///
+    /// # Arguments
+    ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute to merge values of.
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
+    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
     ///
     /// # Errors
     ///
@@ -442,6 +486,14 @@ impl AttrStorageManager {
     /*
     /// Execute a splitting operation on all attributes associated with a given orbit
     /// for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     ///
     /// # Errors
     ///
@@ -603,6 +655,7 @@ impl AttrStorageManager {
     ///
     /// # Arguments
     ///
+    /// - `A: AttributeBind + AttributeUpdate` -- Attribute to split value of.
     /// - `trans: &mut Transaction` -- Transaction used for synchronization.
     /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
     /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.

--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -260,162 +260,8 @@ impl AttrStorageManager {
     }
 }
 
-#[allow(unused)]
 /// Merge variants.
 impl AttrStorageManager {
-    // attribute-agnostic regular
-
-    /*
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a merging operation on all attributes associated with a given orbit
-    /// for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn merge_attributes(
-        &self,
-        trans: &mut Transaction,
-        orbit_policy: &OrbitPolicy,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
-        match orbit_policy {
-            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
-                self.merge_vertex_attributes(trans, id_out, id_in_lhs, id_in_rhs)
-            }
-            OrbitPolicy::Edge => self.merge_edge_attributes(trans, id_out, id_in_lhs, id_in_rhs),
-            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.merge_face_attributes(trans, id_out, id_in_lhs, id_in_rhs)
-            }
-            OrbitPolicy::Volume | OrbitPolicy::VolumeLinear => {
-                self.merge_volume_attributes(trans, id_out, id_in_lhs, id_in_rhs)
-            }
-            OrbitPolicy::Custom(_) => unimplemented!(),
-        }
-    }
-    */
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a merging operation on all attributes associated with vertices for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn merge_vertex_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.vertices.values() {
-            storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a merging operation on all attributes associated with edges for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn merge_edge_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.edges.values() {
-            storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a merging operation on all attributes associated with faces for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn merge_face_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.faces.values() {
-            storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
-        }
-        Ok(())
-    }
-
-    /*
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a merging operation on all attributes associated with volumes for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in_lhs: DartIdentifier` -- Identifier of one attribute value to merge.
-    /// - `id_in_rhs: DartIdentifier` -- Identifier of the other attribute value to merge.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn merge_volume_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out: DartIdType,
-        id_in_lhs: DartIdType,
-        id_in_rhs: DartIdType,
-    ) -> StmResult<()> {
-        for storage in self.volumes.values() {
-            storage.merge(trans, id_out, id_in_lhs, id_in_rhs)?;
-        }
-        Ok(())
-    }
-    */
-
     // attribute-agnostic try
 
     /*
@@ -624,163 +470,8 @@ impl AttrStorageManager {
     */
 }
 
-#[allow(unused)]
 /// Split variants.
 impl AttrStorageManager {
-    // attribute-agnostic regular
-
-    /*
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a splitting operation on all attributes associated with a given orbit
-    /// for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `orbit_policy: OrbitPolicy` -- Orbit associated with affected attributes.
-    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn split_attributes(
-        &self,
-        trans: &mut Transaction,
-        orbit_policy: &OrbitPolicy,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmResult<()> {
-        match orbit_policy {
-            OrbitPolicy::Vertex | OrbitPolicy::VertexLinear => {
-                self.split_vertex_attributes(trans, id_out_lhs, id_out_rhs, id_in)
-            }
-            OrbitPolicy::Edge => self.split_edge_attributes(trans, id_out_lhs, id_out_rhs, id_in),
-            OrbitPolicy::Face | OrbitPolicy::FaceLinear => {
-                self.split_face_attributes(trans, id_out_lhs, id_out_rhs, id_in)
-            }
-            OrbitPolicy::Volume | OrbitPolicy::VolumeLinear => {
-                self.split_volume_attributes(trans, id_out_lhs, id_out_rhs, id_in)
-            }
-            OrbitPolicy::Custom(_) => unimplemented!(),
-        }
-    }
-    */
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a splitting operation on all attributes associated with vertices
-    /// for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn split_vertex_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.vertices.values() {
-            storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a splitting operation on all attributes associated with edges for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn split_edge_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.edges.values() {
-            storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a splitting operation on all attributes associated with faces for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn split_face_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmClosureResult<()> {
-        for storage in self.faces.values() {
-            storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
-        }
-        Ok(())
-    }
-
-    /*
-    #[allow(clippy::missing_errors_doc)]
-    /// Execute a splitting operation on all attributes associated with volumes for specified cells.
-    ///
-    /// # Arguments
-    ///
-    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
-    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
-    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
-    ///
-    /// # Return / Errors
-    ///
-    /// This method is meant to be called in a context where the returned `Result` is used to
-    /// validate the transaction passed as argument. The result should not be processed manually.
-    pub fn split_volume_attributes(
-        &self,
-        trans: &mut Transaction,
-        id_out_lhs: DartIdType,
-        id_out_rhs: DartIdType,
-        id_in: DartIdType,
-    ) -> StmResult<()> {
-        for storage in self.volumes.values() {
-            storage.split(trans, id_out_lhs, id_out_rhs, id_in)?;
-        }
-        Ok(())
-    }
-    */
-
     // attribute-agnostic try
 
     /*
@@ -824,6 +515,13 @@ impl AttrStorageManager {
 
     /// Execute a splitting operation on all attributes associated with vertices for specified cells.
     ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    ///
     /// # Errors
     ///
     /// This method will fail, returning an error, if:
@@ -848,6 +546,13 @@ impl AttrStorageManager {
 
     /// Execute a splitting operation on all attributes associated with edges for specified cells.
     ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
+    ///
     /// # Errors
     ///
     /// This method will fail, returning an error, if:
@@ -871,6 +576,13 @@ impl AttrStorageManager {
     }
 
     /// Execute a splitting operation on all attributes associated with faces for specified cells.
+    ///
+    /// # Arguments
+    ///
+    /// - `trans: &mut Transaction` -- Transaction used for synchronization.
+    /// - `id_out_lhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_out_rhs: DartIdentifier` -- Identifier to write the result to.
+    /// - `id_in: DartIdentifier` -- Identifier of the attribute value to split.
     ///
     /// # Errors
     ///

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -206,17 +206,20 @@ fn test_attribute_operations() {
     let mut manager = AttrStorageManager::default();
     manager.add_storage::<Temperature>(5);
 
-    // Test set and get
-    manager.force_write_attribute(0, Temperature::from(25.0));
-    assert_eq!(
-        manager.force_read_attribute::<Temperature>(0),
-        Some(Temperature::from(25.0))
-    );
+    atomically(|t| {
+        // Test set and get
+        manager.write_attribute(t, 0, Temperature::from(25.0))?;
+        assert_eq!(
+            manager.read_attribute::<Temperature>(t, 0)?,
+            Some(Temperature::from(25.0))
+        );
 
-    // Test remove
-    let removed = manager.force_remove_attribute::<Temperature>(0);
-    assert_eq!(removed, Some(Temperature::from(25.0)));
-    assert_eq!(manager.force_read_attribute::<Temperature>(0), None);
+        // Test remove
+        let removed = manager.remove_attribute::<Temperature>(t, 0)?;
+        assert_eq!(removed, Some(Temperature::from(25.0)));
+        assert_eq!(manager.read_attribute::<Temperature>(t, 0)?, None);
+        Ok(())
+    });
 }
 
 #[test]
@@ -225,15 +228,25 @@ fn test_merge_attributes() {
     manager.add_storage::<Temperature>(5);
 
     // Setup initial values
-    manager.force_write_attribute(0, Temperature::from(20.0));
-    manager.force_write_attribute(1, Temperature::from(30.0));
+    atomically(|t| {
+        manager.write_attribute(t, 0, Temperature::from(20.0))?;
+        manager.write_attribute(t, 1, Temperature::from(30.0))?;
+        Ok(())
+    });
 
     // Test merge
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 2, 0, 1));
+    atomically(|trans| {
+        manager
+            .try_merge_attribute::<Temperature>(trans, 2, 0, 1)
+            .map_err(|_| StmError::Failure)
+    });
 
     // The exact result depends on how merge is implemented in AttributeStorage
     // Just verify that something was stored at the output location
-    assert!(manager.force_read_attribute::<Temperature>(2).is_some());
+    atomically(|t| {
+        assert!(manager.read_attribute::<Temperature>(t, 2)?.is_some());
+        Ok(())
+    });
 }
 
 #[test]
@@ -242,15 +255,22 @@ fn test_split_attributes() {
     manager.add_storage::<Temperature>(5);
 
     // Setup initial value
-    manager.force_write_attribute(0, Temperature::from(25.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(25.0)));
 
     // Test split
-    atomically(|trans| manager.split_attribute::<Temperature>(trans, 1, 2, 0));
+    atomically(|trans| {
+        manager
+            .try_split_attribute::<Temperature>(trans, 1, 2, 0)
+            .map_err(|_| StmError::Failure)
+    });
 
     // The exact results depend on how split is implemented in AttributeStorage
     // Just verify that something was stored at both output locations
-    assert!(manager.force_read_attribute::<Temperature>(1).is_some());
-    assert!(manager.force_read_attribute::<Temperature>(2).is_some());
+    atomically(|t| {
+        assert!(manager.read_attribute::<Temperature>(t, 1)?.is_some());
+        assert!(manager.read_attribute::<Temperature>(t, 2)?.is_some());
+        Ok(())
+    });
 }
 
 #[test]
@@ -278,8 +298,12 @@ fn test_orbit_specific_merges() {
     manager.add_storage::<Temperature>(5);
 
     // Setup values
-    manager.force_write_attribute(0, Temperature::from(20.0));
-    manager.force_write_attribute(1, Temperature::from(30.0));
+    atomically(|t| {
+        manager.write_attribute(t, 0, Temperature::from(20.0))?;
+        manager.write_attribute(t, 1, Temperature::from(30.0))?;
+
+        Ok(())
+    });
 
     // Test vertex-specific merge
     atomically(|trans| {
@@ -288,7 +312,10 @@ fn test_orbit_specific_merges() {
             .map_err(|_| StmError::Failure)
     });
 
-    assert!(manager.force_read_attribute::<Temperature>(2).is_some());
+    atomically(|t| {
+        assert!(manager.read_attribute::<Temperature>(t, 2)?.is_some());
+        Ok(())
+    });
 }
 
 #[test]
@@ -297,7 +324,7 @@ fn test_orbit_specific_splits() {
     manager.add_storage::<Temperature>(5);
 
     // Setup value
-    manager.force_write_attribute(0, Temperature::from(25.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(25.0)));
 
     // Test vertex-specific split
     atomically(|trans| {
@@ -306,8 +333,12 @@ fn test_orbit_specific_splits() {
             .map_err(|_| StmError::Failure)
     });
 
-    assert!(manager.force_read_attribute::<Temperature>(1).is_some());
-    assert!(manager.force_read_attribute::<Temperature>(2).is_some());
+    atomically(|t| {
+        assert!(manager.read_attribute::<Temperature>(t, 1)?.is_some());
+        assert!(manager.read_attribute::<Temperature>(t, 2)?.is_some());
+
+        Ok(())
+    });
 }
 
 // --- unit tests
@@ -324,8 +355,12 @@ fn setup_manager() -> AttrStorageManager {
 fn test_merge_vertex_attributes() {
     let manager = setup_manager();
     // Set initial values
-    manager.force_write_attribute(0, Temperature::from(20.0));
-    manager.force_write_attribute(1, Temperature::from(30.0));
+    atomically(|t| {
+        manager.write_attribute(t, 0, Temperature::from(20.0))?;
+        manager.write_attribute(t, 1, Temperature::from(30.0))?;
+
+        Ok(())
+    });
 
     atomically(|trans| {
         manager
@@ -334,7 +369,7 @@ fn test_merge_vertex_attributes() {
     });
 
     // Verify merged result
-    let merged = manager.force_read_attribute::<Temperature>(2);
+    let merged = atomically(|t| manager.read_attribute::<Temperature>(t, 2));
     assert!(merged.is_some());
     assert_eq!(merged.unwrap(), Temperature::from(25.0));
 }
@@ -344,7 +379,7 @@ fn test_split_vertex_attributes() {
     let manager = setup_manager();
 
     // Set initial value
-    manager.force_write_attribute(0, Temperature::from(20.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(20.0)));
 
     atomically(|trans| {
         manager
@@ -353,13 +388,17 @@ fn test_split_vertex_attributes() {
     });
 
     // Verify split results
-    let split1 = manager.force_read_attribute::<Temperature>(1);
-    let split2 = manager.force_read_attribute::<Temperature>(2);
+    atomically(|t| {
+        let split1 = manager.read_attribute::<Temperature>(t, 1)?;
+        let split2 = manager.read_attribute::<Temperature>(t, 2)?;
 
-    assert!(split1.is_some());
-    assert!(split2.is_some());
-    assert_eq!(split1.unwrap().val, 20.0);
-    assert_eq!(split2.unwrap().val, 20.0);
+        assert!(split1.is_some());
+        assert!(split2.is_some());
+        assert_eq!(split1.unwrap().val, 20.0);
+        assert_eq!(split2.unwrap().val, 20.0);
+
+        Ok(())
+    });
 }
 
 #[test]
@@ -368,7 +407,7 @@ fn test_write_attribute() {
 
     atomically(|trans| manager.write_attribute(trans, 0, Temperature::from(25.0)));
 
-    let value = manager.force_read_attribute::<Temperature>(0);
+    let value = atomically(|t| manager.read_attribute::<Temperature>(t, 0));
     assert!(value.is_some());
     assert_eq!(value.unwrap().val, 25.0);
 }
@@ -378,7 +417,7 @@ fn test_read_attribute() {
     let manager = setup_manager();
 
     // Set initial value
-    manager.force_write_attribute(0, Temperature::from(25.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(25.0)));
 
     let value = atomically(|trans| manager.read_attribute::<Temperature>(trans, 0));
 
@@ -391,14 +430,14 @@ fn test_remove_attribute() {
     let manager = setup_manager();
 
     // Set initial value
-    manager.force_write_attribute(0, Temperature::from(25.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(25.0)));
 
     let removed_value = atomically(|trans| manager.remove_attribute::<Temperature>(trans, 0));
 
     assert!(removed_value.is_some());
     assert_eq!(removed_value.unwrap().val, 25.0);
 
-    let value = manager.force_read_attribute::<Temperature>(0);
+    let value = atomically(|t| manager.read_attribute::<Temperature>(t, 0));
     assert!(value.is_none());
 }
 
@@ -407,12 +446,20 @@ fn test_merge_attribute() {
     let manager = setup_manager();
 
     // Set initial values
-    manager.force_write_attribute(0, Temperature::from(20.0));
-    manager.force_write_attribute(1, Temperature::from(30.0));
+    atomically(|t| {
+        manager.write_attribute(t, 0, Temperature::from(20.0))?;
+        manager.write_attribute(t, 1, Temperature::from(30.0))?;
 
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 2, 0, 1));
+        Ok(())
+    });
 
-    let merged = manager.force_read_attribute::<Temperature>(2);
+    atomically(|trans| {
+        manager
+            .try_merge_attribute::<Temperature>(trans, 2, 0, 1)
+            .map_err(|_| StmError::Failure)
+    });
+
+    let merged = atomically(|t| manager.read_attribute::<Temperature>(t, 2));
     assert!(merged.is_some());
     assert_eq!(merged.unwrap().val, 25.0); // Assuming merge averages values
 }
@@ -422,17 +469,25 @@ fn test_split_attribute() {
     let manager = setup_manager();
 
     // Set initial value
-    manager.force_write_attribute(0, Temperature::from(20.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(20.0)));
 
-    atomically(|trans| manager.split_attribute::<Temperature>(trans, 1, 2, 0));
+    atomically(|trans| {
+        manager
+            .try_split_attribute::<Temperature>(trans, 1, 2, 0)
+            .map_err(|_| StmError::Failure)
+    });
 
-    let split1 = manager.force_read_attribute::<Temperature>(1);
-    let split2 = manager.force_read_attribute::<Temperature>(2);
+    atomically(|t| {
+        let split1 = manager.read_attribute::<Temperature>(t, 1)?;
+        let split2 = manager.read_attribute::<Temperature>(t, 2)?;
 
-    assert!(split1.is_some());
-    assert!(split2.is_some());
-    assert_eq!(split1.unwrap().val, 20.0); // Assuming split copies values
-    assert_eq!(split2.unwrap().val, 20.0);
+        assert!(split1.is_some());
+        assert!(split2.is_some());
+        assert_eq!(split1.unwrap().val, 20.0); // Assuming split copies values
+        assert_eq!(split2.unwrap().val, 20.0);
+
+        Ok(())
+    });
 }
 
 #[test]
@@ -440,7 +495,7 @@ fn test_attribute_operations_with_failed_transaction() {
     let manager = setup_manager();
 
     // Set initial value
-    manager.force_write_attribute(0, Temperature::from(25.0));
+    atomically(|t| manager.write_attribute(t, 0, Temperature::from(25.0)));
 
     let _: Option<()> = Transaction::with_control(
         |_err| TransactionControl::Abort,
@@ -453,12 +508,16 @@ fn test_attribute_operations_with_failed_transaction() {
     );
 
     // Verify original values remained unchanged
-    let value0 = manager.force_read_attribute::<Temperature>(0);
-    let value1 = manager.force_read_attribute::<Temperature>(1);
+    atomically(|t| {
+        let value0 = manager.read_attribute::<Temperature>(t, 0)?;
+        let value1 = manager.read_attribute::<Temperature>(t, 1)?;
 
-    assert!(value0.is_some());
-    assert_eq!(value0.unwrap().val, 25.0);
-    assert!(value1.is_none());
+        assert!(value0.is_some());
+        assert_eq!(value0.unwrap().val, 25.0);
+        assert!(value1.is_none());
+
+        Ok(())
+    });
 }
 
 // traits
@@ -495,16 +554,19 @@ macro_rules! generate_sparse {
     ($name: ident) => {
         #[allow(unused_mut)]
         let mut $name = AttrSparseVec::<Temperature>::new(10);
-        $name.force_write(0, Temperature::from(273.0));
-        $name.force_write(1, Temperature::from(275.0));
-        $name.force_write(2, Temperature::from(277.0));
-        $name.force_write(3, Temperature::from(279.0));
-        $name.force_write(4, Temperature::from(281.0));
-        $name.force_write(5, Temperature::from(283.0));
-        $name.force_write(6, Temperature::from(285.0));
-        $name.force_write(7, Temperature::from(287.0));
-        $name.force_write(8, Temperature::from(289.0));
-        $name.force_write(9, Temperature::from(291.0));
+        atomically(|t| {
+            $name.write(t, 0, Temperature::from(273.0))?;
+            $name.write(t, 1, Temperature::from(275.0))?;
+            $name.write(t, 2, Temperature::from(277.0))?;
+            $name.write(t, 3, Temperature::from(279.0))?;
+            $name.write(t, 4, Temperature::from(281.0))?;
+            $name.write(t, 5, Temperature::from(283.0))?;
+            $name.write(t, 6, Temperature::from(285.0))?;
+            $name.write(t, 7, Temperature::from(287.0))?;
+            $name.write(t, 8, Temperature::from(289.0))?;
+            $name.write(t, 9, Temperature::from(291.0))?;
+            Ok(())
+        });
     };
 }
 
@@ -512,91 +574,154 @@ macro_rules! generate_sparse {
 fn sparse_vec_n_attributes() {
     generate_sparse!(storage);
     assert_eq!(storage.n_attributes(), 10);
-    let _ = storage.force_remove(3);
+    let _ = atomically(|t| storage.remove(t, 3));
     assert_eq!(storage.n_attributes(), 9);
     // extend does not affect the number of attributes
     storage.extend(10);
-    assert!(storage.force_read(15).is_none());
+    assert!(atomically(|t| storage.read(t, 15)).is_none());
     assert_eq!(storage.n_attributes(), 9);
 }
 
 #[test]
 fn sparse_vec_merge() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_read(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.force_read(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.force_read(8), Some(Temperature::from(289.0)));
-    storage.force_merge(8, 3, 6);
-    assert_eq!(storage.force_read(3), None);
-    assert_eq!(storage.force_read(6), None);
-    assert_eq!(storage.force_read(8), Some(Temperature::from(282.0)));
+    assert_eq!(
+        atomically(|t| storage.read(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.read(t, 6)),
+        Some(Temperature::from(285.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.read(t, 8)),
+        Some(Temperature::from(289.0))
+    );
+    atomically(|t| storage.try_merge(t, 8, 3, 6).map_err(|_| StmError::Failure));
+    assert_eq!(atomically(|t| storage.read(t, 3)), None);
+    assert_eq!(atomically(|t| storage.read(t, 6)), None);
+    assert_eq!(
+        atomically(|t| storage.read(t, 8)),
+        Some(Temperature::from(282.0))
+    );
 }
 
 #[test]
 fn sparse_vec_merge_undefined() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.force_remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.force_remove(8), Some(Temperature::from(289.0)));
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.remove(t, 6)),
+        Some(Temperature::from(285.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.remove(t, 8)),
+        Some(Temperature::from(289.0))
+    );
     // merge from two undefined value
-    storage.force_merge(8, 3, 6);
-    assert_eq!(storage.force_read(3), None);
-    assert_eq!(storage.force_read(6), None);
-    assert_eq!(storage.force_read(8), Some(Temperature::from(0.0)));
+    atomically(|t| storage.try_merge(t, 8, 3, 6).map_err(|_| StmError::Failure));
+    assert_eq!(atomically(|t| storage.read(t, 3)), None);
+    assert_eq!(atomically(|t| storage.read(t, 6)), None);
+    assert_eq!(
+        atomically(|t| storage.read(t, 8)),
+        Some(Temperature::from(0.0))
+    );
     // merge from one undefined value
-    assert_eq!(storage.force_read(4), Some(Temperature::from(281.0)));
-    storage.force_merge(6, 3, 4);
-    assert_eq!(storage.force_read(3), None);
-    assert_eq!(storage.force_read(4), None);
-    assert_eq!(storage.force_read(6), Some(Temperature::from(281.0 / 2.0)));
+    assert_eq!(
+        atomically(|t| storage.read(t, 4)),
+        Some(Temperature::from(281.0))
+    );
+    atomically(|t| storage.try_merge(t, 6, 3, 4).map_err(|_| StmError::Failure));
+    assert_eq!(atomically(|t| storage.read(t, 3)), None);
+    assert_eq!(atomically(|t| storage.read(t, 4)), None);
+    assert_eq!(
+        atomically(|t| storage.read(t, 6)),
+        Some(Temperature::from(281.0 / 2.0))
+    );
 }
 
 #[test]
 fn sparse_vec_split() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
-    assert_eq!(storage.force_remove(6), Some(Temperature::from(285.0)));
-    assert_eq!(storage.force_read(8), Some(Temperature::from(289.0)));
-    storage.force_split(3, 6, 8);
-    assert_eq!(storage.force_read(3), Some(Temperature::from(289.0)));
-    assert_eq!(storage.force_read(6), Some(Temperature::from(289.0)));
-    assert_eq!(storage.force_read(8), None);
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.remove(t, 6)),
+        Some(Temperature::from(285.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.read(t, 8)),
+        Some(Temperature::from(289.0))
+    );
+    atomically(|t| storage.try_split(t, 3, 6, 8).map_err(|_| StmError::Failure));
+    assert_eq!(
+        atomically(|t| storage.read(t, 3)),
+        Some(Temperature::from(289.0))
+    );
+    assert_eq!(
+        atomically(|t| storage.read(t, 6)),
+        Some(Temperature::from(289.0))
+    );
+    assert_eq!(atomically(|t| storage.read(t, 8)), None);
 }
 
 #[test]
 fn sparse_vec_read_set_read() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_read(3), Some(Temperature::from(279.0)));
-    storage.force_write(3, Temperature::from(280.0));
-    assert_eq!(storage.force_read(3), Some(Temperature::from(280.0)));
+    assert_eq!(
+        atomically(|t| storage.read(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    atomically(|t| storage.write(t, 3, Temperature::from(280.0)));
+    assert_eq!(
+        atomically(|t| storage.read(t, 3)),
+        Some(Temperature::from(280.0))
+    );
 }
 
 #[test]
 fn sparse_vec_remove() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
 }
 
 #[test]
 fn sparse_vec_remove_remove() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.force_remove(3).is_none());
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    assert!(atomically(|t| storage.remove(t, 3)).is_none());
 }
 
 #[test]
 fn sparse_vec_remove_read() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
-    assert!(storage.force_read(3).is_none());
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    assert!(atomically(|t| storage.read(t, 3)).is_none());
 }
 
 #[test]
 fn sparse_vec_remove_set() {
     generate_sparse!(storage);
-    assert_eq!(storage.force_remove(3), Some(Temperature::from(279.0)));
-    storage.force_write(3, Temperature::from(280.0));
-    assert!(storage.force_read(3).is_some());
+    assert_eq!(
+        atomically(|t| storage.remove(t, 3)),
+        Some(Temperature::from(279.0))
+    );
+    atomically(|t| storage.write(t, 3, Temperature::from(280.0)));
+    assert!(atomically(|t| storage.read(t, 3)).is_some());
 }
 
 // storage manager
@@ -605,16 +730,19 @@ macro_rules! generate_manager {
     ($name: ident) => {
         let mut $name = AttrStorageManager::default();
         $name.add_storage::<Temperature>(10);
-        $name.force_write_attribute(0, Temperature::from(273.0));
-        $name.force_write_attribute(1, Temperature::from(275.0));
-        $name.force_write_attribute(2, Temperature::from(277.0));
-        $name.force_write_attribute(3, Temperature::from(279.0));
-        $name.force_write_attribute(4, Temperature::from(281.0));
-        $name.force_write_attribute(5, Temperature::from(283.0));
-        $name.force_write_attribute(6, Temperature::from(285.0));
-        $name.force_write_attribute(7, Temperature::from(287.0));
-        $name.force_write_attribute(8, Temperature::from(289.0));
-        $name.force_write_attribute(9, Temperature::from(291.0));
+        atomically(|t| {
+            $name.write_attribute(t, 0, Temperature::from(273.0))?;
+            $name.write_attribute(t, 1, Temperature::from(275.0))?;
+            $name.write_attribute(t, 2, Temperature::from(277.0))?;
+            $name.write_attribute(t, 3, Temperature::from(279.0))?;
+            $name.write_attribute(t, 4, Temperature::from(281.0))?;
+            $name.write_attribute(t, 5, Temperature::from(283.0))?;
+            $name.write_attribute(t, 6, Temperature::from(285.0))?;
+            $name.write_attribute(t, 7, Temperature::from(287.0))?;
+            $name.write_attribute(t, 8, Temperature::from(289.0))?;
+            $name.write_attribute(t, 9, Temperature::from(291.0))?;
+            Ok(())
+        });
     };
 }
 
@@ -631,8 +759,11 @@ fn manager_extend() {
         manager.get_storage::<Temperature>().unwrap().n_attributes(),
         10
     );
-    (10..20).for_each(|id| {
-        manager.force_write_attribute(id, Temperature::from(273.0 + 2.0 * id as f32));
+    atomically(|t| {
+        for id in 10..20 {
+            manager.write_attribute(t, id, Temperature::from(273.0 + 2.0 * id as f32))?;
+        }
+        Ok(())
     });
     assert_eq!(
         manager.get_storage::<Temperature>().unwrap().n_attributes(),
@@ -648,140 +779,166 @@ fn manager_set_oob() {
         manager.get_storage::<Temperature>().unwrap().n_attributes(),
         10
     );
-    manager.force_write_attribute(15, Temperature::from(0.0)); // panic
+    atomically(|t| manager.write_attribute(t, 15, Temperature::from(0.0))); // panic
 }
 
 #[test]
 fn manager_read_set_read() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_read_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    manager.force_write_attribute(3, Temperature::from(280.0));
-    assert_eq!(
-        manager.force_read_attribute(3),
-        Some(Temperature::from(280.0))
-    );
+    atomically(|t| {
+        assert_eq!(
+            manager.read_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        manager.write_attribute(t, 3, Temperature::from(280.0))?;
+        assert_eq!(
+            manager.read_attribute(t, 3)?,
+            Some(Temperature::from(280.0))
+        );
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_vec_remove_remove() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_remove_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    assert!(manager.force_remove_attribute::<Temperature>(3).is_none());
+    atomically(|t| {
+        assert_eq!(
+            manager.remove_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        assert!(manager.remove_attribute::<Temperature>(t, 3)?.is_none());
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_vec_remove_read() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_remove_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    assert!(manager.force_read_attribute::<Temperature>(3).is_none());
+    atomically(|t| {
+        assert_eq!(
+            manager.remove_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        assert!(manager.read_attribute::<Temperature>(t, 3)?.is_none());
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_vec_remove_set() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_remove_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    manager.force_write_attribute(3, Temperature::from(280.0));
-    assert!(manager.force_read_attribute::<Temperature>(3).is_some());
+    atomically(|t| {
+        assert_eq!(
+            manager.remove_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        manager.write_attribute(t, 3, Temperature::from(280.0))?;
+        assert!(manager.read_attribute::<Temperature>(t, 3)?.is_some());
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_merge_attribute() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_read_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    assert_eq!(
-        manager.force_read_attribute(6),
-        Some(Temperature::from(285.0))
-    );
-    assert_eq!(
-        manager.force_read_attribute(8),
-        Some(Temperature::from(289.0))
-    );
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 8, 3, 6));
-    assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
-    assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
-    assert_eq!(
-        manager.force_read_attribute(8),
-        Some(Temperature::from(282.0))
-    );
+    atomically(|t| {
+        assert_eq!(
+            manager.read_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        assert_eq!(
+            manager.read_attribute(t, 6)?,
+            Some(Temperature::from(285.0))
+        );
+        assert_eq!(
+            manager.read_attribute(t, 8)?,
+            Some(Temperature::from(289.0))
+        );
+        manager
+            .try_merge_attribute::<Temperature>(t, 8, 3, 6)
+            .map_err(|_| StmError::Failure)?;
+        assert_eq!(manager.read_attribute::<Temperature>(t, 3)?, None);
+        assert_eq!(manager.read_attribute::<Temperature>(t, 6)?, None);
+        assert_eq!(
+            manager.read_attribute(t, 8)?,
+            Some(Temperature::from(282.0))
+        );
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_merge_undefined_attribute() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_remove_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    assert_eq!(
-        manager.force_remove_attribute(6),
-        Some(Temperature::from(285.0))
-    );
-    assert_eq!(
-        manager.force_remove_attribute(8),
-        Some(Temperature::from(289.0))
-    );
-    // merge from two undefined value
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 8, 3, 6));
-    assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
-    assert_eq!(manager.force_read_attribute::<Temperature>(6), None);
-    assert_eq!(
-        manager.force_read_attribute(8),
-        Some(Temperature::from(0.0))
-    );
-    // merge from one undefined value
-    assert_eq!(
-        manager.force_read_attribute(4),
-        Some(Temperature::from(281.0))
-    );
-    atomically(|trans| manager.merge_attribute::<Temperature>(trans, 6, 3, 4));
-    assert_eq!(manager.force_read_attribute::<Temperature>(3), None);
-    assert_eq!(manager.force_read_attribute::<Temperature>(4), None);
-    assert_eq!(
-        manager.force_read_attribute(6),
-        Some(Temperature::from(281.0 / 2.0))
-    );
+    atomically(|t| {
+        assert_eq!(
+            manager.remove_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        assert_eq!(
+            manager.remove_attribute(t, 6)?,
+            Some(Temperature::from(285.0))
+        );
+        assert_eq!(
+            manager.remove_attribute(t, 8)?,
+            Some(Temperature::from(289.0))
+        );
+        // merge from two undefined value
+        manager
+            .try_merge_attribute::<Temperature>(t, 8, 3, 6)
+            .map_err(|_| StmError::Failure)?;
+        assert_eq!(manager.read_attribute::<Temperature>(t, 3)?, None);
+        assert_eq!(manager.read_attribute::<Temperature>(t, 6)?, None);
+        assert_eq!(manager.read_attribute(t, 8)?, Some(Temperature::from(0.0)));
+        // merge from one undefined value
+        assert_eq!(
+            manager.read_attribute(t, 4)?,
+            Some(Temperature::from(281.0))
+        );
+        manager
+            .try_merge_attribute::<Temperature>(t, 6, 3, 4)
+            .map_err(|_| StmError::Failure)?;
+        assert_eq!(manager.read_attribute::<Temperature>(t, 3)?, None);
+        assert_eq!(manager.read_attribute::<Temperature>(t, 4)?, None);
+        assert_eq!(
+            manager.read_attribute(t, 6)?,
+            Some(Temperature::from(281.0 / 2.0))
+        );
+        Ok(())
+    });
 }
 
 #[test]
 fn manager_split_attribute() {
     generate_manager!(manager);
-    assert_eq!(
-        manager.force_remove_attribute(3),
-        Some(Temperature::from(279.0))
-    );
-    assert_eq!(
-        manager.force_remove_attribute(6),
-        Some(Temperature::from(285.0))
-    );
-    assert_eq!(
-        manager.force_read_attribute(8),
-        Some(Temperature::from(289.0))
-    );
-    atomically(|trans| manager.split_attribute::<Temperature>(trans, 3, 6, 8));
-    assert_eq!(
-        manager.force_read_attribute(3),
-        Some(Temperature::from(289.0))
-    );
-    assert_eq!(
-        manager.force_read_attribute(6),
-        Some(Temperature::from(289.0))
-    );
-    assert_eq!(manager.force_read_attribute::<Temperature>(8), None);
+    atomically(|t| {
+        assert_eq!(
+            manager.remove_attribute(t, 3)?,
+            Some(Temperature::from(279.0))
+        );
+        assert_eq!(
+            manager.remove_attribute(t, 6)?,
+            Some(Temperature::from(285.0))
+        );
+        assert_eq!(
+            manager.read_attribute(t, 8)?,
+            Some(Temperature::from(289.0))
+        );
+        manager
+            .try_split_attribute::<Temperature>(t, 3, 6, 8)
+            .map_err(|_| StmError::Failure)?;
+        assert_eq!(
+            manager.read_attribute(t, 3)?,
+            Some(Temperature::from(289.0))
+        );
+        assert_eq!(
+            manager.read_attribute(t, 6)?,
+            Some(Temperature::from(289.0))
+        );
+        assert_eq!(manager.read_attribute::<Temperature>(t, 8)?, None);
+        Ok(())
+    });
 }
 
 // --- parallel
@@ -797,17 +954,20 @@ fn manager_ordering() {
         manager.add_storage::<Weight>(4);
         manager.add_storage::<Color>(4);
 
-        manager.force_write_attribute(1, Temperature::from(20.0));
-        manager.force_write_attribute(3, Temperature::from(30.0));
+        atomically(|t| {
+            manager.write_attribute(t, 1, Temperature::from(20.0))?;
+            manager.write_attribute(t, 3, Temperature::from(30.0))?;
 
-        manager.force_write_attribute(1, Length(3.0));
-        manager.force_write_attribute(3, Length(2.0));
+            manager.write_attribute(t, 1, Length(3.0))?;
+            manager.write_attribute(t, 3, Length(2.0))?;
 
-        manager.force_write_attribute(1, Weight(10));
-        manager.force_write_attribute(3, Weight(15));
+            manager.write_attribute(t, 1, Weight(10))?;
+            manager.write_attribute(t, 3, Weight(15))?;
 
-        manager.force_write_attribute(1, Color(255, 0, 0));
-        manager.force_write_attribute(3, Color(0, 0, 255));
+            manager.write_attribute(t, 1, Color(255, 0, 0))?;
+            manager.write_attribute(t, 3, Color(0, 0, 255))?;
+            Ok(())
+        });
 
         let arc = Arc::new(manager);
         let c1 = arc.clone();
@@ -847,81 +1007,87 @@ fn manager_ordering() {
         t2.join().unwrap();
 
         // in both cases
-        let slot_1_is_empty = arc.force_read_attribute::<Temperature>(1).is_none()
-            && arc.force_read_attribute::<Weight>(1).is_none()
-            && arc.force_read_attribute::<Length>(1).is_none()
-            && arc.force_read_attribute::<Color>(1).is_none();
+        let slot_1_is_empty = atomically(|t| {
+            Ok(arc.read_attribute::<Temperature>(t, 1)?.is_none()
+                && arc.read_attribute::<Weight>(t, 1)?.is_none()
+                && arc.read_attribute::<Length>(t, 1)?.is_none()
+                && arc.read_attribute::<Color>(t, 1)?.is_none())
+        });
         assert!(slot_1_is_empty);
 
-        // path 1: merge before split
-        let p1_2_temp = arc
-            .force_read_attribute::<Temperature>(2)
-            .is_some_and(|val| val == Temperature::from(25.0));
-        let p1_3_temp = arc
-            .force_read_attribute::<Temperature>(3)
-            .is_some_and(|val| val == Temperature::from(25.0));
+        let p1 = atomically(|t| {
+            // path 1: merge before split
+            let p1_2_temp = arc
+                .read_attribute::<Temperature>(t, 2)?
+                .is_some_and(|val| val == Temperature::from(25.0));
+            let p1_3_temp = arc
+                .read_attribute::<Temperature>(t, 3)?
+                .is_some_and(|val| val == Temperature::from(25.0));
 
-        let p1_2_weight = arc
-            .force_read_attribute::<Weight>(2)
-            .is_some_and(|v| v == Weight(13));
-        let p1_3_weight = arc
-            .force_read_attribute::<Weight>(3)
-            .is_some_and(|v| v == Weight(12));
+            let p1_2_weight = arc
+                .read_attribute::<Weight>(t, 2)?
+                .is_some_and(|v| v == Weight(13));
+            let p1_3_weight = arc
+                .read_attribute::<Weight>(t, 3)?
+                .is_some_and(|v| v == Weight(12));
 
-        let p1_2_len = arc
-            .force_read_attribute::<Length>(2)
-            .is_some_and(|v| v == Length(2.5));
-        let p1_3_len = arc
-            .force_read_attribute::<Length>(3)
-            .is_some_and(|v| v == Length(2.5));
+            let p1_2_len = arc
+                .read_attribute::<Length>(t, 2)?
+                .is_some_and(|v| v == Length(2.5));
+            let p1_3_len = arc
+                .read_attribute::<Length>(t, 3)?
+                .is_some_and(|v| v == Length(2.5));
 
-        let p1_2_col = arc
-            .force_read_attribute::<Color>(2)
-            .is_some_and(|v| v == Color(127, 0, 127));
-        let p1_3_col = arc
-            .force_read_attribute::<Color>(3)
-            .is_some_and(|v| v == Color(127, 0, 127));
+            let p1_2_col = arc
+                .read_attribute::<Color>(t, 2)?
+                .is_some_and(|v| v == Color(127, 0, 127));
+            let p1_3_col = arc
+                .read_attribute::<Color>(t, 3)?
+                .is_some_and(|v| v == Color(127, 0, 127));
 
-        let p1 = slot_1_is_empty
-            && p1_2_temp
-            && p1_3_temp
-            && p1_2_weight
-            && p1_3_weight
-            && p1_2_len
-            && p1_3_len
-            && p1_2_col
-            && p1_3_col;
+            Ok(slot_1_is_empty
+                && p1_2_temp
+                && p1_3_temp
+                && p1_2_weight
+                && p1_3_weight
+                && p1_2_len
+                && p1_3_len
+                && p1_2_col
+                && p1_3_col)
+        });
 
-        // path 2: split before merge
-        let p2_2_temp = arc
-            .force_read_attribute::<Temperature>(2)
-            .is_some_and(|val| val == Temperature::from(5.0));
-        let p2_3_temp = arc.force_read_attribute::<Temperature>(3).is_none();
+        let p2 = atomically(|t| {
+            // path 2: split before merge
+            let p2_2_temp = arc
+                .read_attribute::<Temperature>(t, 2)?
+                .is_some_and(|val| val == Temperature::from(5.0));
+            let p2_3_temp = arc.read_attribute::<Temperature>(t, 3)?.is_none();
 
-        let p2_2_weight = arc
-            .force_read_attribute::<Weight>(2)
-            .is_some_and(|v| v == Weight(10));
-        let p2_3_weight = arc.force_read_attribute::<Weight>(3).is_none();
+            let p2_2_weight = arc
+                .read_attribute::<Weight>(t, 2)?
+                .is_some_and(|v| v == Weight(10));
+            let p2_3_weight = arc.read_attribute::<Weight>(t, 3)?.is_none();
 
-        let p2_2_len = arc
-            .force_read_attribute::<Length>(2)
-            .is_some_and(|v| v == Length(3.0));
-        let p2_3_len = arc.force_read_attribute::<Length>(3).is_none();
+            let p2_2_len = arc
+                .read_attribute::<Length>(t, 2)?
+                .is_some_and(|v| v == Length(3.0));
+            let p2_3_len = arc.read_attribute::<Length>(t, 3)?.is_none();
 
-        let p2_2_col = arc
-            .force_read_attribute::<Color>(2)
-            .is_some_and(|v| v == Color(255, 0, 0));
-        let p2_3_col = arc.force_read_attribute::<Color>(3).is_none();
+            let p2_2_col = arc
+                .read_attribute::<Color>(t, 2)?
+                .is_some_and(|v| v == Color(255, 0, 0));
+            let p2_3_col = arc.read_attribute::<Color>(t, 3)?.is_none();
 
-        let p2 = slot_1_is_empty
-            && p2_2_temp
-            && p2_3_temp
-            && p2_2_weight
-            && p2_3_weight
-            && p2_2_len
-            && p2_3_len
-            && p2_2_col
-            && p2_3_col;
+            Ok(slot_1_is_empty
+                && p2_2_temp
+                && p2_3_temp
+                && p2_2_weight
+                && p2_3_weight
+                && p2_2_len
+                && p2_3_len
+                && p2_2_col
+                && p2_3_col)
+        });
 
         assert!(p1 || p2);
     });

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -228,6 +228,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to `read_attribute`, but internally uses a transaction that will be
     /// retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_read_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,
@@ -239,6 +240,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to `write_attribute`, but internally uses a transaction that will be
     /// retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_write_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,
@@ -251,6 +253,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to `remove_attribute`, but internally uses a transaction that
     /// will be retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_remove_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,

--- a/honeycomb-core/src/cmap/dim3/embed.rs
+++ b/honeycomb-core/src/cmap/dim3/embed.rs
@@ -229,6 +229,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to `read_attribute`, but internally uses a transaction that will be
     /// retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_read_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,
@@ -240,6 +241,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to `write_attribute`, but internally uses a transaction that will be
     /// retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_write_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,
@@ -252,6 +254,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to `remove_attribute`, but internally uses a transaction that
     /// will be retried until validated.
+    #[allow(clippy::needless_pass_by_value)]
     pub fn force_remove_attribute<A: AttributeBind + AttributeUpdate>(
         &self,
         id: A::IdentifierType,


### PR DESCRIPTION
### Description


**Scope**:  core

**Type of change**: refactor

**Content description**: follow up of #277 

Now that the API has converged, the only methods variants we need are transactional. we can wrap them at the highest level since the user is not supposed to directly interact with attribute containers anyway. 

I will do yet another PR to rename the remaining methods from the various attribute traits since code fro the `sew` impls will be affected