### PR TITLE
fix(bench): adjust last printed line of `cut-edges` output

### DIFF
--- a/benches/src/cut_edges.rs
+++ b/benches/src/cut_edges.rs
@@ -116,7 +116,8 @@ pub fn bench_cut_edges<T: CoordsFloat>(args: CutEdgesArgs) -> CMap2<T> {
             print!("| {:>18.6e} ", instant.elapsed().as_secs_f64()); // t_compute_batch
         } else {
             print!("| {:>18.6e} ", instant.elapsed().as_secs_f64()); // t_compute_batch
-            println!("| {:>18.6e} ", 0.0); // t_process_batch
+            print!("| {:>18.6e} ", 0.0); // t_process_batch
+            println!("| {:>15}", 0); // n_transac_retry
         }
     }
 


### PR DESCRIPTION
add the missing last column print on last step