### PR TITLE
add remeshing module w/ cut-edges routines

### DIFF
--- a/benches/src/cut_edges.rs
+++ b/benches/src/cut_edges.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 
 use honeycomb::{
     core::{
-        cmap::LinkError,
+        cmap::SewError,
         stm::{Transaction, TransactionControl, TransactionResult},
     },
     kernels::remeshing::{cut_inner_edge, cut_outer_edge},
@@ -227,7 +227,7 @@ fn process_outer_edge<T: CoordsFloat>(
     n_retry: &mut u8,
     e: EdgeIdType,
     [nd1, nd2, nd3, _, _, _]: [DartIdType; 6],
-) -> TransactionResult<(), LinkError> {
+) -> TransactionResult<(), SewError> {
     Transaction::with_control_and_err(
         |_| {
             *n_retry += 1;
@@ -243,7 +243,7 @@ fn process_inner_edge<T: CoordsFloat>(
     n_retry: &mut u8,
     e: EdgeIdType,
     nds: [DartIdType; 6],
-) -> TransactionResult<(), LinkError> {
+) -> TransactionResult<(), SewError> {
     Transaction::with_control_and_err(
         |_| {
             *n_retry += 1;

--- a/benches/src/cut_edges.rs
+++ b/benches/src/cut_edges.rs
@@ -3,9 +3,12 @@ use std::time::Instant;
 use rayon::prelude::*;
 
 use honeycomb::{
-    core::cmap::LinkError,
-    core::stm::{StmError, Transaction, TransactionControl, TransactionResult, retry},
-    prelude::{CMap2, CMapBuilder, CoordsFloat, DartIdType, EdgeIdType, Vertex2},
+    core::{
+        cmap::LinkError,
+        stm::{Transaction, TransactionControl, TransactionResult},
+    },
+    kernels::remeshing::{cut_inner_edge, cut_outer_edge},
+    prelude::{CMap2, CMapBuilder, CoordsFloat, DartIdType, EdgeIdType},
 };
 
 use crate::{cli::CutEdgesArgs, utils::hash_file};
@@ -230,41 +233,7 @@ fn process_outer_edge<T: CoordsFloat>(
             *n_retry += 1;
             TransactionControl::Retry
         },
-        |trans| {
-            // unfallible
-            map.link::<2>(trans, nd1, nd2)?;
-            map.link::<1>(trans, nd2, nd3)?;
-
-            let ld = e as DartIdType;
-            let (b0ld, b1ld) = (
-                map.beta_transac::<0>(trans, ld)?,
-                map.beta_transac::<1>(trans, ld)?,
-            );
-
-            let (vid1, vid2) = (
-                map.vertex_id_transac(trans, ld)?,
-                map.vertex_id_transac(trans, b1ld)?,
-            );
-            let new_v = match (map.read_vertex(trans, vid1)?, map.read_vertex(trans, vid2)?) {
-                (Some(v1), Some(v2)) => Vertex2::average(&v1, &v2),
-                _ => retry()?,
-            };
-            map.write_vertex(trans, nd1, new_v)?;
-
-            map.unsew::<1>(trans, ld).map_err(|_| StmError::Failure)?;
-            map.unsew::<1>(trans, b1ld).map_err(|_| StmError::Failure)?;
-
-            map.sew::<1>(trans, ld, nd1)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd1, b0ld)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd3, b1ld)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, b1ld, nd2)
-                .map_err(|_| StmError::Failure)?;
-
-            Ok(())
-        },
+        |trans| cut_outer_edge(trans, map, e, [nd1, nd2, nd3]),
     ) // Transaction::with_control
 }
 
@@ -273,73 +242,13 @@ fn process_inner_edge<T: CoordsFloat>(
     map: &CMap2<T>,
     n_retry: &mut u8,
     e: EdgeIdType,
-    [nd1, nd2, nd3, nd4, nd5, nd6]: [DartIdType; 6],
+    nds: [DartIdType; 6],
 ) -> TransactionResult<(), LinkError> {
     Transaction::with_control_and_err(
         |_| {
             *n_retry += 1;
             TransactionControl::Retry
         },
-        |trans| {
-            // unfallible
-            map.link::<2>(trans, nd1, nd2)?;
-            map.link::<1>(trans, nd2, nd3)?;
-            map.link::<2>(trans, nd4, nd5)?;
-            map.link::<1>(trans, nd5, nd6)?;
-
-            let (ld, rd) = (
-                e as DartIdType,
-                map.beta_transac::<2>(trans, e as DartIdType)?,
-            );
-            let (b0ld, b1ld) = (
-                map.beta_transac::<0>(trans, ld)?,
-                map.beta_transac::<1>(trans, ld)?,
-            );
-            let (b0rd, b1rd) = (
-                map.beta_transac::<0>(trans, rd)?,
-                map.beta_transac::<1>(trans, rd)?,
-            );
-
-            let (vid1, vid2) = (
-                map.vertex_id_transac(trans, ld)?,
-                map.vertex_id_transac(trans, b1ld)?,
-            );
-            let new_v = match (map.read_vertex(trans, vid1)?, map.read_vertex(trans, vid2)?) {
-                (Some(v1), Some(v2)) => Vertex2::average(&v1, &v2),
-                _ => retry()?,
-            };
-            map.write_vertex(trans, nd1, new_v)?;
-
-            map.unsew::<2>(trans, ld).map_err(|_| StmError::Failure)?;
-            map.unsew::<1>(trans, ld).map_err(|_| StmError::Failure)?;
-            map.unsew::<1>(trans, b1ld).map_err(|_| StmError::Failure)?;
-            map.unsew::<1>(trans, rd).map_err(|_| StmError::Failure)?;
-            map.unsew::<1>(trans, b1rd).map_err(|_| StmError::Failure)?;
-
-            map.sew::<2>(trans, ld, nd6)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<2>(trans, rd, nd3)
-                .map_err(|_| StmError::Failure)?;
-
-            map.sew::<1>(trans, ld, nd1)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd1, b0ld)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd3, b1ld)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, b1ld, nd2)
-                .map_err(|_| StmError::Failure)?;
-
-            map.sew::<1>(trans, rd, nd4)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd4, b0rd)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, nd6, b1rd)
-                .map_err(|_| StmError::Failure)?;
-            map.sew::<1>(trans, b1rd, nd5)
-                .map_err(|_| StmError::Failure)?;
-
-            Ok(())
-        },
+        |trans| cut_inner_edge(trans, map, e, nds),
     ) // Transaction::with_control
 }

--- a/benches/src/shift.rs
+++ b/benches/src/shift.rs
@@ -15,6 +15,7 @@
 //! `taskset`. By controlling this, and the grid size, we can evaluate both strong and weak
 //! scaling characteristics.
 
+use honeycomb::kernels::remeshing::move_vertex_to_average;
 use rayon::prelude::*;
 
 use honeycomb::core::stm::{Transaction, TransactionControl};
@@ -84,18 +85,8 @@ pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
                             n += 1;
                             TransactionControl::Retry
                         },
-                        |trans| {
-                            let mut new_val = Vertex2::default();
-                            for v in neigh {
-                                let vertex = map.read_vertex(trans, *v)?.unwrap();
-                                new_val.0 += vertex.0;
-                                new_val.1 += vertex.1;
-                            }
-                            new_val.0 /= T::from(neigh.len()).unwrap();
-                            new_val.1 /= T::from(neigh.len()).unwrap();
-                            map.write_vertex(trans, *vid, new_val)
-                        },
-                    ); // Transaction::with_control
+                        |trans| move_vertex_to_average(trans, &map, *vid, &neigh),
+                    );
                     n
                 })
                 .sum();

--- a/benches/src/shift.rs
+++ b/benches/src/shift.rs
@@ -20,8 +20,7 @@ use rayon::prelude::*;
 
 use honeycomb::core::stm::{Transaction, TransactionControl};
 use honeycomb::prelude::{
-    CMap2, CMapBuilder, CoordsFloat, DartIdType, NULL_DART_ID, Orbit2, OrbitPolicy, Vertex2,
-    VertexIdType,
+    CMap2, CMapBuilder, CoordsFloat, DartIdType, NULL_DART_ID, Orbit2, OrbitPolicy, VertexIdType,
 };
 
 use crate::cli::ShiftArgs;
@@ -85,7 +84,7 @@ pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
                             n += 1;
                             TransactionControl::Retry
                         },
-                        |trans| move_vertex_to_average(trans, &map, *vid, &neigh),
+                        |trans| move_vertex_to_average(trans, &map, *vid, neigh),
                     );
                     n
                 })

--- a/honeycomb-kernels/src/lib.rs
+++ b/honeycomb-kernels/src/lib.rs
@@ -12,5 +12,6 @@
 #![allow(clippy::module_name_repetitions)]
 
 pub mod grisubal;
+pub mod remeshing;
 pub mod splits;
 pub mod triangulation;

--- a/honeycomb-kernels/src/remeshing/mod.rs
+++ b/honeycomb-kernels/src/remeshing/mod.rs
@@ -1,0 +1,97 @@
+//!
+
+use honeycomb_core::{
+    cmap::{CMap2, DartIdType, EdgeIdType, LinkError},
+    geometry::{CoordsFloat, Vertex2},
+    stm::{StmError, Transaction, TransactionClosureResult, retry},
+};
+
+/// Cut an edge in half and build triangles from the new vertex.
+///
+///
+#[inline]
+pub fn cut_outer_edge<T: CoordsFloat>(
+    t: &mut Transaction,
+    map: &CMap2<T>,
+    e: EdgeIdType,
+    [nd1, nd2, nd3]: [DartIdType; 3],
+) -> TransactionClosureResult<(), LinkError> {
+    // unfallible
+    map.link::<2>(t, nd1, nd2)?;
+    map.link::<1>(t, nd2, nd3)?;
+
+    let ld = e as DartIdType;
+    let (b0ld, b1ld) = (map.beta_transac::<0>(t, ld)?, map.beta_transac::<1>(t, ld)?);
+
+    let (vid1, vid2) = (
+        map.vertex_id_transac(t, ld)?,
+        map.vertex_id_transac(t, b1ld)?,
+    );
+    let new_v = match (map.read_vertex(t, vid1)?, map.read_vertex(t, vid2)?) {
+        (Some(v1), Some(v2)) => Vertex2::average(&v1, &v2),
+        _ => retry()?,
+    };
+    map.write_vertex(t, nd1, new_v)?;
+
+    map.unsew::<1>(t, ld).map_err(|_| StmError::Retry)?;
+    map.unsew::<1>(t, b1ld).map_err(|_| StmError::Retry)?;
+
+    map.sew::<1>(t, ld, nd1).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd1, b0ld).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd3, b1ld).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, b1ld, nd2).map_err(|_| StmError::Retry)?;
+
+    Ok(())
+}
+
+/// Cut an edge in half and build triangles from the new vertex.
+///
+///
+#[inline]
+pub fn cut_inner_edge<T: CoordsFloat>(
+    t: &mut Transaction,
+    map: &CMap2<T>,
+    e: EdgeIdType,
+    [nd1, nd2, nd3, nd4, nd5, nd6]: [DartIdType; 6],
+) -> TransactionClosureResult<(), LinkError> {
+    // unfallible
+    map.link::<2>(t, nd1, nd2)?;
+    map.link::<1>(t, nd2, nd3)?;
+    map.link::<2>(t, nd4, nd5)?;
+    map.link::<1>(t, nd5, nd6)?;
+
+    let (ld, rd) = (e as DartIdType, map.beta_transac::<2>(t, e as DartIdType)?);
+    let (b0ld, b1ld) = (map.beta_transac::<0>(t, ld)?, map.beta_transac::<1>(t, ld)?);
+    let (b0rd, b1rd) = (map.beta_transac::<0>(t, rd)?, map.beta_transac::<1>(t, rd)?);
+
+    let (vid1, vid2) = (
+        map.vertex_id_transac(t, ld)?,
+        map.vertex_id_transac(t, b1ld)?,
+    );
+    let new_v = match (map.read_vertex(t, vid1)?, map.read_vertex(t, vid2)?) {
+        (Some(v1), Some(v2)) => Vertex2::average(&v1, &v2),
+        _ => retry()?,
+    };
+    map.write_vertex(t, nd1, new_v)?;
+
+    map.unsew::<2>(t, ld).map_err(|_| StmError::Retry)?;
+    map.unsew::<1>(t, ld).map_err(|_| StmError::Retry)?;
+    map.unsew::<1>(t, b1ld).map_err(|_| StmError::Retry)?;
+    map.unsew::<1>(t, rd).map_err(|_| StmError::Retry)?;
+    map.unsew::<1>(t, b1rd).map_err(|_| StmError::Retry)?;
+
+    map.sew::<2>(t, ld, nd6).map_err(|_| StmError::Retry)?;
+    map.sew::<2>(t, rd, nd3).map_err(|_| StmError::Retry)?;
+
+    map.sew::<1>(t, ld, nd1).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd1, b0ld).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd3, b1ld).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, b1ld, nd2).map_err(|_| StmError::Retry)?;
+
+    map.sew::<1>(t, rd, nd4).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd4, b0rd).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, nd6, b1rd).map_err(|_| StmError::Retry)?;
+    map.sew::<1>(t, b1rd, nd5).map_err(|_| StmError::Retry)?;
+
+    Ok(())
+}

--- a/honeycomb-kernels/src/remeshing/mod.rs
+++ b/honeycomb-kernels/src/remeshing/mod.rs
@@ -68,7 +68,7 @@ pub fn move_vertex_to_average<T: CoordsFloat>(
 /// This function takes an edge of the map's boundary as argument, cut it in half, and build two
 /// triangles from the new vertex.
 ///
-/// ```
+/// ```text
 ///
 ///       +                   +
 ///      / \                 /|\
@@ -142,7 +142,7 @@ pub fn cut_outer_edge<T: CoordsFloat>(
 /// This function takes an edge of the map's as argument, cut it in half, and build four triangles
 /// from the new vertex.
 ///
-/// ```
+/// ```text
 ///
 ///       +                   +
 ///      / \                 /|\


### PR DESCRIPTION
### Description

**Scope**: kernels

**Type of change**: feat

**Content description**:

- add a new `remeshing` module to the kernel crate
- move core operations of the `shift` and `cut-edges` benchmarks there
