### PR TITLE
refactor!(core): update the builder structure API

### DIFF
--- a/benches/benches/core/cmap2/basic_ops.rs
+++ b/benches/benches/core/cmap2/basic_ops.rs
@@ -39,7 +39,7 @@ fn get_sparse_map(n_square: usize) -> CMap2<FloatType> {
 
 fn get_empty_map(n_squares: usize) -> (CMap2<FloatType>, usize) {
     (
-        CMapBuilder::default().build().unwrap(),
+        CMapBuilder::from_n_darts(0).build().unwrap(),
         n_squares.pow(2) * 4,
     )
 }
@@ -85,9 +85,9 @@ fn insert_dart_full(map: &mut CMap2<FloatType>) -> DartIdType {
 }
 
 #[library_benchmark]
-#[bench::small(&mut CMapBuilder::default().n_darts(16_usize.pow(2) * 4).build().unwrap())]
-#[bench::medium(&mut CMapBuilder::default().n_darts(64_usize.pow(2) * 4).build().unwrap())]
-#[bench::large(&mut CMapBuilder::default().n_darts(256_usize.pow(2) * 4).build().unwrap())]
+#[bench::small(&mut CMapBuilder::from_n_darts(16_usize.pow(2) * 4).build().unwrap())]
+#[bench::medium(&mut CMapBuilder::from_n_darts(64_usize.pow(2) * 4).build().unwrap())]
+#[bench::large(&mut CMapBuilder::from_n_darts(256_usize.pow(2) * 4).build().unwrap())]
 fn remove_dart(map: &mut CMap2<FloatType>) {
     map.remove_free_dart(5);
     black_box(map);

--- a/benches/benches/core/cmap2/constructors.rs
+++ b/benches/benches/core/cmap2/constructors.rs
@@ -32,8 +32,7 @@ fn get_map(n_square: usize) -> CMap2<FloatType> {
 #[benches::with_setup(args = [16, 32, 64, 128, 256, 512])]
 fn new(n_squares: usize) -> CMap2<FloatType> {
     black_box(
-        CMapBuilder::default()
-            .n_darts(n_squares.pow(2) * 4)
+        CMapBuilder::from_n_darts(n_squares.pow(2) * 4)
             .build()
             .unwrap(),
     )

--- a/benches/benches/core/cmap2/link_and_sew.rs
+++ b/benches/benches/core/cmap2/link_and_sew.rs
@@ -26,15 +26,13 @@ fn get_map(n_square: usize) -> CMap2<FloatType> {
 }
 
 fn get_link_map(n_square: usize) -> CMap2<FloatType> {
-    CMapBuilder::default()
-        .n_darts(n_square.pow(2) * 4)
+    CMapBuilder::from_n_darts(n_square.pow(2) * 4)
         .build()
         .unwrap()
 }
 
 fn get_sew_map(n_square: usize) -> CMap2<FloatType> {
-    let map = CMapBuilder::default()
-        .n_darts(n_square.pow(2) * 4)
+    let map = CMapBuilder::from_n_darts(n_square.pow(2) * 4)
         .build()
         .unwrap();
     map.force_write_vertex(4, (0.0, 0.0));

--- a/benches/benches/triangulate/quads.rs
+++ b/benches/benches/triangulate/quads.rs
@@ -9,7 +9,7 @@ use honeycomb_benches::utils::FloatType;
 const PATH: &str = "../examples/quads.vtk";
 
 fn fan_bench() -> Result<(), TriangulateError> {
-    let mut map: CMap2<FloatType> = CMapBuilder::default().vtk_file(PATH).build().unwrap();
+    let mut map: CMap2<FloatType> = CMapBuilder::from_vtk_file(PATH).build().unwrap();
 
     // prealloc darts
     let faces: Vec<_> = map.iter_faces().collect();
@@ -43,7 +43,7 @@ fn fan_bench() -> Result<(), TriangulateError> {
 }
 
 fn earclip_bench() -> Result<(), TriangulateError> {
-    let mut map: CMap2<FloatType> = CMapBuilder::default().vtk_file(PATH).build().unwrap();
+    let mut map: CMap2<FloatType> = CMapBuilder::from_vtk_file(PATH).build().unwrap();
 
     // prealloc darts
     let faces: Vec<_> = map.iter_faces().collect();

--- a/benches/src/cut_edges.rs
+++ b/benches/src/cut_edges.rs
@@ -28,9 +28,9 @@ pub fn bench_cut_edges<T: CoordsFloat>(args: CutEdgesArgs) -> CMap2<T> {
     let input_hash = hash_file(input_map).expect("E: could not compute input hash"); // file id for posterity
 
     let mut map: CMap2<T> = if input_map.ends_with(".cmap") {
-        CMapBuilder::default().cmap_file(input_map).build().unwrap()
+        CMapBuilder::from_cmap_file(input_map).build().unwrap()
     } else if input_map.ends_with(".vtk") {
-        CMapBuilder::default().vtk_file(input_map).build().unwrap()
+        CMapBuilder::from_vtk_file(input_map).build().unwrap()
     } else {
         panic!(
             "E: Unknown file format; only .cmap or .vtk files are supported for map initialization"

--- a/benches/src/grid_gen.rs
+++ b/benches/src/grid_gen.rs
@@ -21,7 +21,9 @@ pub fn bench_generate_2d_grid<T: CoordsFloat>(args: Generate2dGridArgs) -> CMap2
         .len_per_cell_y(T::from(args.ly).unwrap())
         .split_quads(args.split.is_some_and(|s| s == Split::Uniform));
 
-    let mut map = CMapBuilder::from(descriptor).build().unwrap();
+    let mut map = CMapBuilder::from_grid_descriptor(descriptor)
+        .build()
+        .unwrap();
 
     if args.split.is_some_and(|s| s == Split::Random) {
         // fixed probability and seed value from  the original binary

--- a/benches/src/shift.rs
+++ b/benches/src/shift.rs
@@ -31,9 +31,9 @@ pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
     let input_map = args.input.to_str().unwrap();
     let input_hash = hash_file(input_map).unwrap();
     let map: CMap2<T> = if input_map.ends_with(".cmap") {
-        CMapBuilder::default().cmap_file(input_map).build().unwrap()
+        CMapBuilder::from_cmap_file(input_map).build().unwrap()
     } else if input_map.ends_with(".vtk") {
-        CMapBuilder::default().vtk_file(input_map).build().unwrap()
+        CMapBuilder::from_vtk_file(input_map).build().unwrap()
     } else {
         panic!(
             "E: Unknown file format; only .cmap or .vtk files are supported for map initialization"

--- a/examples/examples/io/read.rs
+++ b/examples/examples/io/read.rs
@@ -7,7 +7,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if let Some(path) = args.get(1) {
-        let map: CMap2<f32> = match CMapBuilder::default().vtk_file(path).build() {
+        let map: CMap2<f32> = match CMapBuilder::from_vtk_file(path).build() {
             Ok(cmap) => cmap,
             Err(e) => panic!("Error while building map: {e:?}"),
         };

--- a/examples/examples/render.rs
+++ b/examples/examples/render.rs
@@ -5,17 +5,16 @@ use honeycomb_render::App;
 fn main() {
     // build a simple 4 by 4 grid at origin (1.5, 1.5)
 
-    let map = CMapBuilder::default()
-        .grid_descriptor(
-            GridDescriptor::default()
-                .origin(Vertex2(1.5, 1.5))
-                .n_cells_x(4)
-                .n_cells_y(4)
-                .len_per_cell_x(1.)
-                .len_per_cell_y(1.),
-        )
-        .build()
-        .unwrap();
+    let map = CMapBuilder::from_grid_descriptor(
+        GridDescriptor::default()
+            .origin(Vertex2(1.5, 1.5))
+            .n_cells_x(4)
+            .n_cells_y(4)
+            .len_per_cell_x(1.)
+            .len_per_cell_y(1.),
+    )
+    .build()
+    .unwrap();
 
     // create the render app, add the map to it, and run the app
 

--- a/honeycomb-core/src/attributes/tests.rs
+++ b/honeycomb-core/src/attributes/tests.rs
@@ -140,9 +140,7 @@ impl AttributeBind for Color {
 #[test]
 fn temperature_map() {
     // build the map
-    let builder = CMapBuilder::default()
-        .n_darts(6)
-        .add_attribute::<Temperature>();
+    let builder = CMapBuilder::from_n_darts(6).add_attribute::<Temperature>();
     let map: CMap2<f64> = builder.build().unwrap();
 
     map.force_link::<2>(1, 2).unwrap();

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -62,7 +62,7 @@ pub enum BuilderError {
 /// # fn main() -> Result<(), BuilderError> {
 /// use honeycomb_core::cmap::{CMap2, CMapBuilder};
 ///
-/// let builder = CMapBuilder::default().n_darts(10);
+/// let builder = CMapBuilder::from_n_darts(10);
 /// let map: CMap2<f64> = builder.build()?;
 ///
 /// assert_eq!(map.n_darts(), 11); // 10 + null dart = 11

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -179,13 +179,13 @@ impl<T: CoordsFloat> CMapBuilder<T> {
             )),
             BuilderType::Grid(gridb) => {
                 let split = gridb.split_quads;
-                return gridb.parse_2d().map(|(origin, ns, lens)| {
+                gridb.parse_2d().map(|(origin, ns, lens)| {
                     if split {
                         super::grid::build_2d_splitgrid(origin, ns, lens, self.attributes)
                     } else {
                         super::grid::build_2d_grid(origin, ns, lens, self.attributes)
                     }
-                });
+                })
             }
             BuilderType::Vtk(vfile) => super::io::build_2d_from_vtk(vfile, self.attributes),
         }

--- a/honeycomb-core/src/cmap/builder/structure.rs
+++ b/honeycomb-core/src/cmap/builder/structure.rs
@@ -70,44 +70,39 @@ pub enum BuilderError {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Default)]
 pub struct CMapBuilder<T>
 where
     T: CoordsFloat,
 {
-    pub(super) cmap_file: Option<CMapFile>,
-    pub(super) vtk_file: Option<Vtk>,
-    pub(super) grid_descriptor: Option<GridDescriptor<T>>,
-    pub(super) attributes: AttrStorageManager,
-    pub(super) n_darts: usize,
-    pub(super) coordstype: std::marker::PhantomData<T>,
+    builder_kind: BuilderType<T>,
+    attributes: AttrStorageManager,
 }
 
-// --- `From` impls & predefinite values
-
-impl<T: CoordsFloat> From<GridDescriptor<T>> for CMapBuilder<T> {
-    fn from(value: GridDescriptor<T>) -> Self {
-        CMapBuilder {
-            grid_descriptor: Some(value),
-            ..Default::default()
-        }
-    }
+enum BuilderType<T: CoordsFloat> {
+    CMap(CMapFile),
+    FreeDarts(usize),
+    Grid(GridDescriptor<T>),
+    Vtk(Vtk),
 }
 
 /// # Regular methods
 impl<T: CoordsFloat> CMapBuilder<T> {
     /// Set the number of dart that the created map will contain.
     #[must_use = "unused builder object"]
-    pub fn n_darts(mut self, n_darts: usize) -> Self {
-        self.n_darts = n_darts;
-        self
+    pub fn from_n_darts(n_darts: usize) -> Self {
+        Self {
+            builder_kind: BuilderType::FreeDarts(n_darts),
+            attributes: AttrStorageManager::default(),
+        }
     }
 
     /// Set the [`GridDescriptor`] that will be used when building the map.
     #[must_use = "unused builder object"]
-    pub fn grid_descriptor(mut self, grid_descriptor: GridDescriptor<T>) -> Self {
-        self.grid_descriptor = Some(grid_descriptor);
-        self
+    pub fn from_grid_descriptor(grid_descriptor: GridDescriptor<T>) -> Self {
+        Self {
+            builder_kind: BuilderType::Grid(grid_descriptor),
+            attributes: AttrStorageManager::default(),
+        }
     }
 
     /// Set the `cmap` file that will be used when building the map.
@@ -116,14 +111,17 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     ///
     /// This function may panic if the file cannot be loaded, or basic section parsing fails.
     #[must_use = "unused builder object"]
-    pub fn cmap_file(mut self, file_path: impl AsRef<std::path::Path> + std::fmt::Debug) -> Self {
+    pub fn from_cmap_file(file_path: impl AsRef<std::path::Path> + std::fmt::Debug) -> Self {
         let mut f = File::open(file_path).expect("E: could not open specified file");
         let mut buf = String::new();
         f.read_to_string(&mut buf)
             .expect("E: could not read content from file");
         let cmap_file = CMapFile::try_from(buf).unwrap();
-        self.cmap_file = Some(cmap_file);
-        self
+
+        Self {
+            builder_kind: BuilderType::CMap(cmap_file),
+            attributes: AttrStorageManager::default(),
+        }
     }
 
     /// Set the VTK file that will be used when building the map.
@@ -132,11 +130,14 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     ///
     /// This function may panic if the file cannot be loaded.
     #[must_use = "unused builder object"]
-    pub fn vtk_file(mut self, file_path: impl AsRef<std::path::Path> + std::fmt::Debug) -> Self {
+    pub fn from_vtk_file(file_path: impl AsRef<std::path::Path> + std::fmt::Debug) -> Self {
         let vtk_file =
             Vtk::import(file_path).unwrap_or_else(|e| panic!("E: failed to load file: {e:?}"));
-        self.vtk_file = Some(vtk_file);
-        self
+
+        Self {
+            builder_kind: BuilderType::Vtk(vtk_file),
+            attributes: AttrStorageManager::default(),
+        }
     }
 
     /// Add the attribute `A` to the attributes the created map will contain.
@@ -153,7 +154,7 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     /// and [here](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)
     #[must_use = "unused builder object"]
     pub fn add_attribute<A: AttributeBind + 'static>(mut self) -> Self {
-        self.attributes.add_storage::<A>(self.n_darts);
+        self.attributes.add_storage::<A>(1);
         self
     }
 
@@ -170,29 +171,24 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     ///
     /// This method may panic if type casting goes wrong during parameters parsing.
     pub fn build(self) -> Result<CMap2<T>, BuilderError> {
-        if let Some(cfile) = self.cmap_file {
-            // build from our custom format
-            return super::io::build_2d_from_cmap_file(cfile, self.attributes);
+        match self.builder_kind {
+            BuilderType::CMap(cfile) => super::io::build_2d_from_cmap_file(cfile, self.attributes),
+            BuilderType::FreeDarts(n_darts) => Ok(CMap2::new_with_undefined_attributes(
+                n_darts,
+                self.attributes,
+            )),
+            BuilderType::Grid(gridb) => {
+                let split = gridb.split_quads;
+                return gridb.parse_2d().map(|(origin, ns, lens)| {
+                    if split {
+                        super::grid::build_2d_splitgrid(origin, ns, lens, self.attributes)
+                    } else {
+                        super::grid::build_2d_grid(origin, ns, lens, self.attributes)
+                    }
+                });
+            }
+            BuilderType::Vtk(vfile) => super::io::build_2d_from_vtk(vfile, self.attributes),
         }
-        if let Some(vfile) = self.vtk_file {
-            // build from vtk
-            return super::io::build_2d_from_vtk(vfile, self.attributes);
-        }
-        if let Some(gridb) = self.grid_descriptor {
-            // build from grid descriptor
-            let split = gridb.split_quads;
-            return gridb.parse_2d().map(|(origin, ns, lens)| {
-                if split {
-                    super::grid::build_2d_splitgrid(origin, ns, lens, self.attributes)
-                } else {
-                    super::grid::build_2d_grid(origin, ns, lens, self.attributes)
-                }
-            });
-        }
-        Ok(CMap2::new_with_undefined_attributes(
-            self.n_darts,
-            self.attributes,
-        ))
     }
 }
 
@@ -215,10 +211,14 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     /// ![`CMAP2_GRID`](https://lihpc-computational-geometry.github.io/honeycomb/user-guide/images/bg_grid.svg)
     #[must_use = "unused builder object"]
     pub fn unit_grid(n_square: usize) -> Self {
-        GridDescriptor::default()
-            .n_cells([n_square; 3])
-            .len_per_cell([T::one(); 3])
-            .into()
+        Self {
+            builder_kind: BuilderType::Grid(
+                GridDescriptor::default()
+                    .n_cells([n_square; 3])
+                    .len_per_cell([T::one(); 3]),
+            ),
+            attributes: AttrStorageManager::default(),
+        }
     }
 
     /// Create a [`CMapBuilder`] with a predefinite [`GridDescriptor`] value.
@@ -239,10 +239,14 @@ impl<T: CoordsFloat> CMapBuilder<T> {
     /// ![`CMAP2_GRID`](https://lihpc-computational-geometry.github.io/honeycomb/user-guide/images/bg_grid_tri.svg)
     #[must_use = "unused builder object"]
     pub fn unit_triangles(n_square: usize) -> Self {
-        GridDescriptor::default()
-            .n_cells([n_square; 3])
-            .len_per_cell([T::one(); 3])
-            .split_quads(true)
-            .into()
+        Self {
+            builder_kind: BuilderType::Grid(
+                GridDescriptor::default()
+                    .n_cells([n_square; 3])
+                    .len_per_cell([T::one(); 3])
+                    .split_quads(true),
+            ),
+            attributes: AttrStorageManager::default(),
+        }
     }
 }

--- a/honeycomb-core/src/cmap/builder/tests.rs
+++ b/honeycomb-core/src/cmap/builder/tests.rs
@@ -7,7 +7,7 @@ use crate::cmap::{CMap2, CMapBuilder, DartIdType, GridDescriptor, OrbitPolicy};
 
 #[test]
 fn example_test() {
-    let builder = CMapBuilder::default().n_darts(10);
+    let builder = CMapBuilder::from_n_darts(10);
     let cmap: CMap2<f64> = builder.build().unwrap();
     assert_eq!(cmap.n_darts(), 11);
 }
@@ -115,7 +115,9 @@ fn square_cmap2_correctness() {
     let descriptor = GridDescriptor::default()
         .n_cells([2, 2, 2])
         .len_per_cell([1., 1., 1.]);
-    let cmap: CMap2<f64> = CMapBuilder::from(descriptor).build().unwrap();
+    let cmap: CMap2<f64> = CMapBuilder::from_grid_descriptor(descriptor)
+        .build()
+        .unwrap();
 
     // hardcoded because using a generic loop & dim would just mean
     // reusing the same pattern as the one used during construction

--- a/honeycomb-core/src/cmap/dim2/structure.rs
+++ b/honeycomb-core/src/cmap/dim2/structure.rs
@@ -49,7 +49,7 @@ use super::CMAP2_BETA;
 /// };
 ///
 /// // build a triangle (A)
-/// let mut map: CMap2<f64> = CMapBuilder::default().n_darts(3).build().unwrap(); // three darts
+/// let mut map: CMap2<f64> = CMapBuilder::from_n_darts(3).build().unwrap(); // three darts
 /// map.force_link::<1>(1, 2); // beta1(1) = 2 & beta0(2) = 1
 /// map.force_link::<1>(2, 3); // beta1(2) = 3 & beta0(3) = 2
 /// map.force_link::<1>(3, 1); // beta1(3) = 1 & beta0(1) = 3

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 #[test]
 fn example_test() {
     // build a triangle
-    let mut map: CMap2<f64> = CMapBuilder::default().n_darts(3).build().unwrap();
+    let mut map: CMap2<f64> = CMapBuilder::from_n_darts(3).build().unwrap();
     map.force_link::<1>(1, 2).unwrap();
     map.force_link::<1>(2, 3).unwrap();
     map.force_link::<1>(3, 1).unwrap();
@@ -111,7 +111,7 @@ fn example_test() {
 #[test]
 fn example_test_transactional() {
     // build a triangle
-    let mut map: CMap2<f64> = CMapBuilder::default().n_darts(3).build().unwrap();
+    let mut map: CMap2<f64> = CMapBuilder::from_n_darts(3).build().unwrap();
     let res = atomically_with_err(|trans| {
         map.link::<1>(trans, 1, 2)?;
         map.link::<1>(trans, 2, 3)?;
@@ -650,7 +650,7 @@ impl AttributeBind for Weight {
 fn sew_ordering() {
     loom::model(|| {
         // setup the map
-        let map: CMap2<f64> = CMapBuilder::default().n_darts(5).build().unwrap();
+        let map: CMap2<f64> = CMapBuilder::from_n_darts(5).build().unwrap();
         map.force_link::<2>(1, 2).unwrap();
         map.force_link::<1>(4, 5).unwrap();
         map.force_write_vertex(2, Vertex2(1.0, 1.0));
@@ -697,7 +697,7 @@ fn sew_ordering() {
 fn sew_ordering_with_transactions() {
     loom::model(|| {
         // setup the map
-        let map: CMap2<f64> = CMapBuilder::default().n_darts(5).build().unwrap();
+        let map: CMap2<f64> = CMapBuilder::from_n_darts(5).build().unwrap();
         let res = atomically_with_err(|trans| {
             map.link::<2>(trans, 1, 2)?;
             map.link::<1>(trans, 4, 5)?;
@@ -778,8 +778,7 @@ fn sew_ordering_with_transactions() {
 fn unsew_ordering() {
     loom::model(|| {
         // setup the map
-        let map: CMap2<f64> = CMapBuilder::default()
-            .n_darts(5)
+        let map: CMap2<f64> = CMapBuilder::from_n_darts(5)
             .add_attribute::<Weight>()
             .build()
             .unwrap();
@@ -832,8 +831,7 @@ fn unsew_ordering() {
 fn unsew_ordering_with_transactions() {
     loom::model(|| {
         // setup the map
-        let map: CMap2<f64> = CMapBuilder::default()
-            .n_darts(5)
+        let map: CMap2<f64> = CMapBuilder::from_n_darts(5)
             .add_attribute::<Weight>()
             .build()
             .unwrap();

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -197,8 +197,7 @@ pub fn grisubal<T: CoordsFloat>(
     start_timer!(kernel);
 
     // --- BUILD THE GRID
-    let mut cmap = CMapBuilder::default()
-        .grid_descriptor(ogrid)
+    let mut cmap = CMapBuilder::from_grid_descriptor(ogrid)
         .add_attribute::<Boundary>() // will be used for clipping
         .build()
         .expect("E: unreachable"); // unreachable because grid dims are valid

--- a/honeycomb-kernels/src/grisubal/tests.rs
+++ b/honeycomb-kernels/src/grisubal/tests.rs
@@ -114,7 +114,7 @@ fn build_valid_geometry() {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn regular_intersections() {
-    let mut cmap = CMapBuilder::from(
+    let mut cmap = CMapBuilder::from_grid_descriptor(
         GridDescriptor::default()
             .len_per_cell([1.0; 3])
             .n_cells([2; 3]),
@@ -262,7 +262,7 @@ fn regular_intersections() {
 fn corner_intersection() {
     use num_traits::Float;
 
-    let mut cmap = CMapBuilder::from(
+    let mut cmap = CMapBuilder::from_grid_descriptor(
         GridDescriptor::default()
             .len_per_cell([1.0; 3])
             .n_cells([2; 3]),
@@ -406,7 +406,7 @@ fn corner_intersection() {
 #[allow(clippy::too_many_lines)]
 #[test]
 pub fn successive_straight_intersections() {
-    let mut cmap = CMapBuilder::from(
+    let mut cmap = CMapBuilder::from_grid_descriptor(
         GridDescriptor::default()
             .len_per_cell([1.0; 3])
             .n_cells([3; 3]),
@@ -688,7 +688,7 @@ pub fn successive_straight_intersections() {
 #[allow(clippy::too_many_lines)]
 #[test]
 pub fn successive_diag_intersections() {
-    let mut cmap = CMapBuilder::from(
+    let mut cmap = CMapBuilder::from_grid_descriptor(
         GridDescriptor::default()
             .len_per_cell([1.0; 3])
             .n_cells([3; 3]),

--- a/honeycomb-kernels/src/splits/edge_multiple.rs
+++ b/honeycomb-kernels/src/splits/edge_multiple.rs
@@ -43,8 +43,7 @@ use crate::splits::SplitEdgeError;
 /// //    <--2---
 /// //  1         2
 /// //    ---1-->
-/// let mut map: CMap2<f64> = CMapBuilder::default()
-///                             .n_darts(2)
+/// let mut map: CMap2<f64> = CMapBuilder::from_n_darts(2)
 ///                             .build()
 ///                             .unwrap();
 /// map.force_link::<2>(1, 2);

--- a/honeycomb-kernels/src/splits/tests.rs
+++ b/honeycomb-kernels/src/splits/tests.rs
@@ -6,7 +6,7 @@ use honeycomb_core::geometry::{CoordsFloat, Vertex2};
 use super::*;
 
 fn newmap<T: CoordsFloat>(n: usize) -> CMap2<T> {
-    CMapBuilder::default().n_darts(n).build().unwrap()
+    CMapBuilder::from_n_darts(n).build().unwrap()
 }
 
 mod standard {

--- a/honeycomb-kernels/src/triangulation/tests.rs
+++ b/honeycomb-kernels/src/triangulation/tests.rs
@@ -10,7 +10,7 @@ use crate::triangulation::{TriangulateError, earclip_cell, fan_cell};
 // - one triangle
 // - one non-fannable n-gon
 fn generate_map() -> CMap2<f64> {
-    let cmap: CMap2<f64> = CMapBuilder::default().n_darts(28).build().unwrap();
+    let cmap: CMap2<f64> = CMapBuilder::from_n_darts(28).build().unwrap();
 
     // topology
     cmap.force_link::<1>(1, 2).unwrap();


### PR DESCRIPTION
### Description

**Scope**: core with fixes in other crates

**Type of change**: refactor

**Content description**:

- update `CMapBuilder` internal to use a private enum that distinguishes between init methods
- remove field setters as a consequence; this also removes the "priority" requirements for the case where conflicting fields were set (e.g. a grid descriptor and a file)
- remove the `Default` and `From<GridDescriptor>` impls for `CMapBuilder`. The item is now exclusively built using non-ambiguous functions (e.g. `from_grid_descriptor`)

### Additional information

- [x] Breaking change
