### PR TITLE
feat(core): implement transactional orbits

### DIFF
--- a/honeycomb-core/src/cmap/components/orbits.rs
+++ b/honeycomb-core/src/cmap/components/orbits.rs
@@ -21,3 +21,34 @@ pub enum OrbitPolicy {
     /// Ordered array of beta functions defining the orbit.
     Custom(&'static [u8]),
 }
+
+/// Custom fallible `unfold` iterator.
+///
+/// This doesn't solve usability issues, but it reduces internal boilerplate by
+/// allowing the usage of `?` inside the closure.
+///
+/// Modelled after [`std::iter::FromFn`].
+#[derive(Clone)]
+pub(crate) struct TryFromFn<F>(F);
+
+impl<T, E, F> Iterator for TryFromFn<F>
+where
+    F: FnMut() -> Result<Option<T>, E>,
+{
+    type Item = Result<T, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.0)() {
+            Ok(Some(value)) => Some(Ok(value)), // Yield a successful item
+            Ok(None) => None,                   // End iteration
+            Err(e) => Some(Err(e)),             // Yield an error
+        }
+    }
+}
+
+pub(crate) fn try_from_fn<T, E, F>(f: F) -> TryFromFn<F>
+where
+    F: FnMut() -> Result<Option<T>, E>,
+{
+    TryFromFn(f)
+}

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -33,6 +33,7 @@ impl<T: CoordsFloat> CMap2<T> {
     /// and a `HashSet`. There is a possibility to use static thread-local instances to avoid
     /// ephemeral allocations, but [it would require a guard mechanism][PR].
     ///
+    /// [WIKIBFS]: https://en.wikipedia.org/wiki/Breadth-first_search
     /// [PR]: https://github.com/LIHPC-Computational-Geometry/honeycomb/pull/293
     #[allow(clippy::needless_for_each)]
     #[rustfmt::skip]
@@ -118,6 +119,7 @@ impl<T: CoordsFloat> CMap2<T> {
     }
 
     /// Generic orbit transactional implementation.
+    #[allow(clippy::needless_for_each)]
     pub fn orbit_transac(
         &self,
         t: &mut Transaction,

--- a/honeycomb-core/src/cmap/dim2/orbits.rs
+++ b/honeycomb-core/src/cmap/dim2/orbits.rs
@@ -82,7 +82,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     }
                     OrbitPolicy::FaceLinear => {
                         let im = self.beta::<1>(d);
-                        check(im)
+                        check(im);
                     }
                     OrbitPolicy::Custom(beta_slice) => {
                         for beta_id in beta_slice {
@@ -151,7 +151,7 @@ impl<T: CoordsFloat> CMap2<T> {
                     }
                     OrbitPolicy::FaceLinear => {
                         let im = self.beta_transac::<1>(t, d)?;
-                        check(im)
+                        check(im);
                     }
                     OrbitPolicy::Custom(beta_slice) => {
                         for beta_id in beta_slice {

--- a/honeycomb-core/src/cmap/dim2/tests.rs
+++ b/honeycomb-core/src/cmap/dim2/tests.rs
@@ -127,13 +127,14 @@ fn example_test_transactional() {
     let faces: Vec<_> = map.iter_faces().collect();
     assert_eq!(faces.len(), 1);
     assert_eq!(faces[0], 1);
-    {
-        let mut face = map.orbit(OrbitPolicy::Face, 1);
-        assert_eq!(face.next(), Some(1));
-        assert_eq!(face.next(), Some(2));
-        assert_eq!(face.next(), Some(3));
+    atomically(|t| {
+        let mut face = map.orbit_transac(t, OrbitPolicy::Face, 1);
+        assert_eq!(face.next(), Some(Ok(1)));
+        assert_eq!(face.next(), Some(Ok(2)));
+        assert_eq!(face.next(), Some(Ok(3)));
         assert_eq!(face.next(), None);
-    }
+        Ok(())
+    });
 
     // build a second triangle
     map.add_free_darts(3);
@@ -151,13 +152,14 @@ fn example_test_transactional() {
     // checks
     let faces: Vec<_> = map.iter_faces().collect();
     assert_eq!(&faces, &[1, 4]);
-    {
-        let mut face = map.orbit(OrbitPolicy::Face, 4);
-        assert_eq!(face.next(), Some(4));
-        assert_eq!(face.next(), Some(5));
-        assert_eq!(face.next(), Some(6));
+    atomically(|t| {
+        let mut face = map.orbit_transac(t, OrbitPolicy::Face, 4);
+        assert_eq!(face.next(), Some(Ok(4)));
+        assert_eq!(face.next(), Some(Ok(5)));
+        assert_eq!(face.next(), Some(Ok(6)));
         assert_eq!(face.next(), None);
-    }
+        Ok(())
+    });
 
     // sew both triangles
     atomically(|trans| {
@@ -471,6 +473,14 @@ fn full_map_from_orbit() {
     assert_eq!(darts.len(), 11);
     // because the algorithm is consistent, we can predict the exact layout
     assert_eq!(&darts, &[3, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+    let darts_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Custom(&[1, 2]), 3)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(darts, darts_t);
 }
 
 #[test]
@@ -485,11 +495,48 @@ fn orbit_variants() {
     assert_eq!(&face_linear, &[7, 8, 9, 10, 11]);
     assert_eq!(&face_custom, &[7, 11, 8, 10, 9]);
 
+    let face_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Face, 7)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(face, face_t);
+    let face_linear_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::FaceLinear, 7)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(face_linear, face_linear_t);
+    let face_custom_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Custom(&[0, 1]), 7)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(face_custom, face_custom_t);
+
     // vertex is incomplete, so using the linear variant will yield an incomplete orbit
     let vertex: Vec<DartIdType> = map.orbit(OrbitPolicy::Vertex, 4).collect();
     let vertex_linear: Vec<DartIdType> = map.orbit(OrbitPolicy::VertexLinear, 4).collect();
     assert_eq!(&vertex, &[4, 3, 7]);
     assert_eq!(&vertex_linear, &[4, 3]);
+
+    let vertex_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Vertex, 4)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(vertex, vertex_t);
+    let vertex_linear_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::VertexLinear, 4)
+            .map(Result::unwrap)
+            .collect())
+    });
+    assert_eq!(vertex_linear, vertex_linear_t);
 }
 
 #[test]
@@ -510,12 +557,26 @@ fn edge_from_orbit() {
     let map = simple_map();
     let face_orbit = map.orbit(OrbitPolicy::Edge, 1);
     let darts: Vec<DartIdType> = face_orbit.collect();
+    let darts_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Edge, 1)
+            .map(Result::unwrap)
+            .collect())
+    });
     assert_eq!(darts.len(), 1);
     assert_eq!(&darts, &[1]); // dart 1 is on the boundary
+    assert_eq!(darts, darts_t);
     let other_face_orbit = map.orbit(OrbitPolicy::Custom(&[2]), 4);
     let other_darts: Vec<DartIdType> = other_face_orbit.collect();
+    let other_darts_t: Vec<_> = atomically(|t| {
+        Ok(map
+            .orbit_transac(t, OrbitPolicy::Custom(&[2]), 4)
+            .map(Result::unwrap)
+            .collect())
+    });
     assert_eq!(other_darts.len(), 2);
     assert_eq!(&other_darts, &[4, 2]);
+    assert_eq!(other_darts, other_darts_t);
 }
 
 #[test]

--- a/honeycomb-core/src/cmap/dim3/tests.rs
+++ b/honeycomb-core/src/cmap/dim3/tests.rs
@@ -42,6 +42,9 @@ fn example_test() {
         assert_eq!(vertices.next(), Some(3));
         assert_eq!(vertices.next(), Some(6));
         assert_eq!(vertices.next(), None);
+
+        let darts: Vec<_> = map.orbit(OrbitPolicy::FaceLinear, 2).collect();
+        assert_eq!(&darts, &[2, 3, 1]);
     }
 
     map.force_write_vertex(1, (1.0, 0.0, 0.0));
@@ -100,17 +103,6 @@ fn example_test() {
 
     // Sew both tetrahedrons along a face (C)
 
-    println!("v d10: {:?}", map.force_read_vertex(map.vertex_id(10)));
-    println!(
-        "v b1d10: {:?}",
-        map.force_read_vertex(map.vertex_id(map.beta::<1>(10)))
-    );
-    println!("v d16: {:?}", map.force_read_vertex(map.vertex_id(16)));
-    println!(
-        "v b1d16: {:?}",
-        map.force_read_vertex(map.vertex_id(map.beta::<1>(16)))
-    );
-
     assert_eq!(map.n_vertices(), 8);
     map.force_sew::<3>(10, 16).unwrap();
     assert_eq!(map.n_vertices(), 5);
@@ -130,6 +122,14 @@ fn example_test() {
         assert_eq!(faces.next(), None);
         // there should be 9 edges total; quad base pyramid (8) + the base split diagonal (1)
         assert_eq!(map.iter_edges().count(), 9);
+
+        let darts: Vec<_> = map.orbit(OrbitPolicy::Face, 10).collect();
+        assert!(darts.contains(&10));
+        assert!(darts.contains(&11));
+        assert!(darts.contains(&12));
+        assert!(darts.contains(&16));
+        assert!(darts.contains(&17));
+        assert!(darts.contains(&18));
     }
 
     // Adjust shared vertices (D)
@@ -237,6 +237,14 @@ fn example_test_transactional() {
         assert_eq!(vertices.next(), Some(3));
         assert_eq!(vertices.next(), Some(6));
         assert_eq!(vertices.next(), None);
+
+        let darts: Vec<_> = atomically(|t| {
+            Ok(map
+                .orbit_transac(t, OrbitPolicy::FaceLinear, 2)
+                .map(Result::unwrap)
+                .collect())
+        });
+        assert_eq!(&darts, &[2, 3, 1]);
     }
 
     atomically(|trans| {
@@ -322,6 +330,19 @@ fn example_test_transactional() {
         assert_eq!(faces.next(), None);
         // there should be 9 edges total; quad base pyramid (8) + the base split diagonal (1)
         assert_eq!(map.iter_edges().count(), 9);
+
+        let darts: Vec<_> = atomically(|t| {
+            Ok(map
+                .orbit_transac(t, OrbitPolicy::Face, 10)
+                .map(Result::unwrap)
+                .collect())
+        });
+        assert!(darts.contains(&10));
+        assert!(darts.contains(&11));
+        assert!(darts.contains(&12));
+        assert!(darts.contains(&16));
+        assert!(darts.contains(&17));
+        assert!(darts.contains(&18));
     }
 
     // Adjust shared vertices (D)

--- a/honeycomb-core/src/cmap/mod.rs
+++ b/honeycomb-core/src/cmap/mod.rs
@@ -18,3 +18,5 @@ pub use components::{
 pub use dim2::structure::CMap2;
 pub use dim3::structure::CMap3;
 pub use error::{LinkError, SewError};
+
+pub(crate) use components::orbits::{TryFromFn, try_from_fn};

--- a/honeycomb-core/src/cmap/mod.rs
+++ b/honeycomb-core/src/cmap/mod.rs
@@ -19,4 +19,4 @@ pub use dim2::structure::CMap2;
 pub use dim3::structure::CMap3;
 pub use error::{LinkError, SewError};
 
-pub(crate) use components::orbits::{TryFromFn, try_from_fn};
+pub(crate) use components::orbits::try_from_fn;


### PR DESCRIPTION
### Description

**Scope**: core

**Type of change**: feat

**Content description**:
- add a custom unfold iterator `TryFromFn` to use `?` inside the definition closure
- implement transactional orbit computations. 


Usage is slightly weird since chaining operators isn't be possible due to the closure system. The only two solutions I see for this are:
- remove lazy computations, and check whether anything is invalid before returning an iterator over values (effectively moving the `Result` out of the iterator)
- provide a functions that does what's described above, to still allow using the lazily evaluated iterator (in a for loop for example, where results can be `?`)


### Necessary follow-up

use this content in #298 to expose transactions in the API
