### PR TITLE
feat(render): add support for `CMap3` rendering

### DIFF
--- a/honeycomb-render/Cargo.toml
+++ b/honeycomb-render/Cargo.toml
@@ -19,3 +19,4 @@ bevy_egui.workspace = true
 bevy_mod_picking.workspace = true
 bevy_mod_outline.workspace = true
 egui_dock.workspace = true
+itertools.workspace = true

--- a/honeycomb-render/src/import_map.rs
+++ b/honeycomb-render/src/import_map.rs
@@ -278,7 +278,6 @@ pub fn extract_data_from_map<T: CoordsFloat>(mut commands: Commands, cmap: Res<M
 pub fn extract_data_from_3d_map<T: CoordsFloat>(mut commands: Commands, cmap: Res<Map3<T>>) {
     let cmap = &cmap.0;
     let map_vertices: Vec<_> = cmap.iter_vertices().collect();
-    println!("nv: {}", map_vertices.len());
     let map_edges: Vec<_> = cmap.iter_edges().collect();
     let map_faces: Vec<_> = cmap.iter_faces().collect();
     let map_volumes: Vec<_> = cmap.iter_volumes().collect();
@@ -347,10 +346,10 @@ pub fn extract_data_from_3d_map<T: CoordsFloat>(mut commands: Commands, cmap: Re
                     vertex_vals[*ver] - vertex_vals[*ver_in],
                     vertex_vals[*ver_out] - vertex_vals[*ver],
                 );
-                // vec_in/out belong to X/Y plane => .cross(Z) == normal in the plane
-                // a first normalization is required because both edges should weight equally
-                let normal = (vec_in.cross(Vec3::Z).normalize()
-                    + vec_out.cross(Vec3::Z).normalize())
+                // we need to compute the normql formed by the two vectors in 3D
+                let plane_normal = vec_in.cross(vec_out).normalize();
+                let normal = (vec_in.cross(plane_normal).normalize()
+                    + vec_out.cross(plane_normal).normalize())
                 .normalize();
                 face_normals.insert((*id, *ver), normal);
             }
@@ -362,8 +361,10 @@ pub fn extract_data_from_3d_map<T: CoordsFloat>(mut commands: Commands, cmap: Re
                     vertex_vals[*ver] - vertex_vals[*ver_in],
                     vertex_vals[*ver_out] - vertex_vals[*ver],
                 );
-                let normal = (vec_in.cross(Vec3::Z).normalize()
-                    + vec_out.cross(Vec3::Z).normalize())
+                // we need to compute the normql formed by the two vectors in 3D
+                let plane_normal = vec_in.cross(vec_out).normalize();
+                let normal = (vec_in.cross(plane_normal).normalize()
+                    + vec_out.cross(plane_normal).normalize())
                 .normalize();
                 face_normals.insert((*id, *ver), normal);
             });
@@ -374,8 +375,10 @@ pub fn extract_data_from_3d_map<T: CoordsFloat>(mut commands: Commands, cmap: Re
                     vertex_vals[*ver] - vertex_vals[*ver_in],
                     vertex_vals[*ver_out] - vertex_vals[*ver],
                 );
-                let normal = (vec_in.cross(Vec3::Z).normalize()
-                    + vec_out.cross(Vec3::Z).normalize())
+                // we need to compute the normql formed by the two vectors in 3D
+                let plane_normal = vec_in.cross(vec_out).normalize();
+                let normal = (vec_in.cross(plane_normal).normalize()
+                    + vec_out.cross(plane_normal).normalize())
                 .normalize();
                 face_normals.insert((*id, *ver), normal);
             }

--- a/honeycomb-render/src/import_map.rs
+++ b/honeycomb-render/src/import_map.rs
@@ -1,15 +1,23 @@
-use bevy::prelude::*;
+use bevy::prelude::{Bundle, Commands, Component, Res, Resource, Vec3};
 use bevy::utils::HashMap;
+use honeycomb_core::cmap::NULL_DART_ID;
 use honeycomb_core::{
-    cmap::{CMap2, DartIdType, EdgeIdType, FaceIdType, OrbitPolicy, VertexIdType, VolumeIdType},
+    cmap::{
+        CMap2, CMap3, DartIdType, EdgeIdType, FaceIdType, OrbitPolicy, VertexIdType, VolumeIdType,
+    },
     geometry::CoordsFloat,
 };
+use itertools::Itertools;
 
 // --- shared data
 
 /// Combinatorial map to render.
 #[derive(Resource)]
 pub struct Map<T: CoordsFloat>(pub CMap2<T>);
+
+/// Combinatorial map to render.
+#[derive(Resource)]
+pub struct Map3<T: CoordsFloat>(pub CMap3<T>);
 
 /// Collection of a map's vertices.
 #[derive(Resource)]
@@ -32,6 +40,7 @@ pub struct DartBundle {
     pub(crate) vertex_id: VertexId,
     pub(crate) edge_id: EdgeId,
     pub(crate) face_id: FaceId,
+    pub(crate) volume_id: VolumeId,
     pub(crate) dart: Dart,
 }
 
@@ -226,6 +235,7 @@ pub fn extract_data_from_map<T: CoordsFloat>(mut commands: Commands, cmap: Res<M
                     vertex_id: VertexId(cmap.vertex_id(*dart_id)),
                     edge_id: EdgeId(cmap.edge_id(*dart_id)),
                     face_id: FaceId(*id),
+                    volume_id: VolumeId(1),
                     dart: Dart {
                         start: *v1_id,
                         end: *v2_id,
@@ -244,6 +254,251 @@ pub fn extract_data_from_map<T: CoordsFloat>(mut commands: Commands, cmap: Res<M
 
     commands.insert_resource(MapVertices(vertex_vals));
     commands.insert_resource(FaceNormals(face_normals));
+
+    for bundle in darts {
+        commands.spawn(bundle);
+    }
+    for bundle in vertices {
+        commands.spawn(bundle);
+    }
+    for bundle in edges {
+        commands.spawn(bundle);
+    }
+    for bundle in faces {
+        commands.spawn(bundle);
+    }
+}
+
+/// Build ECS data from a combinatorial map object.
+///
+/// # Panics
+///
+/// This function will panic if there is a topological vertex with no associated coordinates.
+#[allow(clippy::too_many_lines)]
+pub fn extract_data_from_3d_map<T: CoordsFloat>(mut commands: Commands, cmap: Res<Map3<T>>) {
+    let cmap = &cmap.0;
+    let map_vertices: Vec<_> = cmap.iter_vertices().collect();
+    println!("nv: {}", map_vertices.len());
+    let map_edges: Vec<_> = cmap.iter_edges().collect();
+    let map_faces: Vec<_> = cmap.iter_faces().collect();
+    let map_volumes: Vec<_> = cmap.iter_volumes().collect();
+
+    let mut index_map: HashMap<VertexIdType, usize> = HashMap::with_capacity(cmap.n_vertices());
+
+    let vertex_vals: Vec<Vec3> = map_vertices
+        .iter()
+        .enumerate()
+        .map(|(idx, vid)| {
+            index_map.insert(*vid, idx);
+            let v = cmap
+                .force_read_vertex(*vid)
+                .expect("E: found a topological vertex with no associated coordinates");
+            // sane unwraps; will crash if the coordinates cannot be converted to f32
+            Vec3::from((
+                v.0.to_f32().unwrap(),
+                v.1.to_f32().unwrap(),
+                v.2.to_f32().unwrap(),
+            ))
+        })
+        .collect();
+
+    let vertices: Vec<VertexBundle> = map_vertices
+        .iter()
+        .map(|id| VertexBundle {
+            id: VertexId(*id),
+            vertex: Vertex(index_map[id]),
+        })
+        .collect();
+
+    let edges: Vec<EdgeBundle> = map_edges
+        .iter()
+        .map(|id| {
+            let v1id = cmap.vertex_id(*id as DartIdType);
+            let v2id = if cmap.is_i_free::<3>(*id as DartIdType) {
+                if cmap.is_i_free::<2>(*id as DartIdType) {
+                    cmap.vertex_id(cmap.beta::<1>(*id as DartIdType))
+                } else {
+                    cmap.vertex_id(cmap.beta::<2>(*id as DartIdType))
+                }
+            } else {
+                cmap.vertex_id(cmap.beta::<3>(*id as DartIdType))
+            };
+            EdgeBundle {
+                id: EdgeId(*id),
+                edge: Edge(index_map[&v1id], index_map[&v2id]),
+            }
+        })
+        .collect();
+
+    let mut face_normals = HashMap::new();
+    let mut darts: Vec<DartBundle> = Vec::new();
+
+    let faces: Vec<FaceBundle> = map_faces
+        .iter()
+        .map(|id| {
+            let vertex_ids: Vec<usize> = cmap
+                .orbit(OrbitPolicy::Custom(&[1]), *id as DartIdType) // cannot use FaceLinear here due to doubled darts in 3D
+                .map(|dart_id| index_map[&cmap.vertex_id(dart_id)])
+                .collect();
+            let n_v = vertex_ids.len();
+            {
+                let (ver_in, ver, ver_out) = (&vertex_ids[n_v - 1], &vertex_ids[0], &vertex_ids[1]);
+                let (vec_in, vec_out) = (
+                    vertex_vals[*ver] - vertex_vals[*ver_in],
+                    vertex_vals[*ver_out] - vertex_vals[*ver],
+                );
+                // vec_in/out belong to X/Y plane => .cross(Z) == normal in the plane
+                // a first normalization is required because both edges should weight equally
+                let normal = (vec_in.cross(Vec3::Z).normalize()
+                    + vec_out.cross(Vec3::Z).normalize())
+                .normalize();
+                face_normals.insert((*id, *ver), normal);
+            }
+            vertex_ids.windows(3).for_each(|wdw| {
+                let [ver_in, ver, ver_out] = wdw else {
+                    unreachable!("i kneel");
+                };
+                let (vec_in, vec_out) = (
+                    vertex_vals[*ver] - vertex_vals[*ver_in],
+                    vertex_vals[*ver_out] - vertex_vals[*ver],
+                );
+                let normal = (vec_in.cross(Vec3::Z).normalize()
+                    + vec_out.cross(Vec3::Z).normalize())
+                .normalize();
+                face_normals.insert((*id, *ver), normal);
+            });
+            {
+                let (ver_in, ver, ver_out) =
+                    (&vertex_ids[n_v - 2], &vertex_ids[n_v - 1], &vertex_ids[0]);
+                let (vec_in, vec_out) = (
+                    vertex_vals[*ver] - vertex_vals[*ver_in],
+                    vertex_vals[*ver_out] - vertex_vals[*ver],
+                );
+                let normal = (vec_in.cross(Vec3::Z).normalize()
+                    + vec_out.cross(Vec3::Z).normalize())
+                .normalize();
+                face_normals.insert((*id, *ver), normal);
+            }
+
+            // common dart iterator
+            let mut tmp = cmap
+                .orbit(OrbitPolicy::Custom(&[1]), *id as DartIdType)
+                .map(|dart_id| (dart_id, index_map[&cmap.vertex_id(dart_id)]))
+                .collect::<Vec<_>>();
+            tmp.push(tmp[0]); // trick for the `.windows` call
+
+            // dart bodies
+            let bodies = tmp.windows(2).map(|wd| {
+                let [(dart_id, v1_id), (_, v2_id)] = wd else {
+                    unreachable!("i kneel");
+                };
+
+                DartBundle {
+                    id: DartId(*dart_id),
+                    vertex_id: VertexId(cmap.vertex_id(*dart_id)),
+                    edge_id: EdgeId(cmap.edge_id(*dart_id)),
+                    face_id: FaceId(*id),
+                    volume_id: VolumeId(cmap.volume_id(*dart_id)),
+                    dart: Dart {
+                        start: *v1_id,
+                        end: *v2_id,
+                    },
+                }
+            });
+
+            darts.extend(bodies);
+
+            // common dart iterator
+            let mut tmp2 = cmap
+                .orbit(OrbitPolicy::Custom(&[1]), cmap.beta::<3>(*id as DartIdType))
+                .filter_map(|dart_id| {
+                    if dart_id != NULL_DART_ID {
+                        Some((dart_id, index_map[&cmap.vertex_id(dart_id)]))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            if !tmp2.is_empty() {
+                tmp2.push(tmp2[0]); // trick for the `.windows` call
+            }
+            // dart bodies
+            let bodies2 = tmp2.windows(2).map(|wd| {
+                let [(dart_id, v1_id), (_, v2_id)] = wd else {
+                    unreachable!("i kneel");
+                };
+
+                DartBundle {
+                    id: DartId(*dart_id),
+                    vertex_id: VertexId(cmap.vertex_id(*dart_id)),
+                    edge_id: EdgeId(cmap.edge_id(*dart_id)),
+                    face_id: FaceId(*id),
+                    volume_id: VolumeId(cmap.volume_id(*dart_id)),
+                    dart: Dart {
+                        start: *v1_id,
+                        end: *v2_id,
+                    },
+                }
+            });
+
+            darts.extend(bodies2);
+
+            FaceBundle {
+                id: FaceId(*id),
+                face: Face(vertex_ids),
+            }
+        })
+        .collect();
+
+    let mut volume_normals = HashMap::new();
+
+    map_volumes.iter().for_each(|vol| {
+        let darts: Vec<_> = cmap
+            .orbit(OrbitPolicy::Volume, *vol as DartIdType)
+            .collect();
+        let norms: HashMap<_, _> = darts
+            .iter()
+            .unique_by(|&d| cmap.face_id(*d))
+            .map(|d| {
+                let mut base = Vec3::default();
+                let tmp: Vec<_> = cmap
+                    .orbit(OrbitPolicy::Custom(&[1]), *d as DartIdType)
+                    .chain([*d].into_iter())
+                    .collect();
+                tmp.windows(2).for_each(|sl| {
+                    let [d1, d2] = sl else { unreachable!() };
+                    let (vid1, vid2) = (
+                        index_map[&cmap.vertex_id(*d1)],
+                        index_map[&cmap.vertex_id(*d2)],
+                    );
+                    let (v1, v2) = (vertex_vals[vid1], vertex_vals[vid2]);
+                    base.x += (v1.y - v2.y) * (v1.z + v2.z);
+                    base.y += (v1.z - v2.z) * (v1.x + v2.x);
+                    base.z += (v1.x - v2.x) * (v1.y + v2.y);
+                });
+                (cmap.face_id(*d), base.normalize())
+            })
+            .collect();
+
+        // maps are cool => in the vertex/volume suborbit, there is exactly a single dart belonging
+        // to each intersecting faces.
+        darts.iter().for_each(|d| {
+            let fid = cmap.face_id(*d);
+            let vid = index_map[&cmap.vertex_id(*d)];
+            if let Some(val) = volume_normals.get_mut(&(*vol, vid)) {
+                *val += norms[&fid];
+            } else {
+                volume_normals.insert((*vol, vid), norms[&fid]);
+            }
+        });
+    });
+    for val in volume_normals.values_mut() {
+        *val = val.normalize();
+    }
+
+    commands.insert_resource(MapVertices(vertex_vals));
+    commands.insert_resource(FaceNormals(face_normals));
+    commands.insert_resource(VolumeNormals(volume_normals));
 
     for bundle in darts {
         commands.spawn(bundle);

--- a/honeycomb-render/src/lib.rs
+++ b/honeycomb-render/src/lib.rs
@@ -37,7 +37,7 @@ mod scene;
 // out of the box render tool
 
 use bevy::prelude::*;
-use honeycomb_core::cmap::CMap2;
+use honeycomb_core::cmap::{CMap2, CMap3};
 use honeycomb_core::geometry::CoordsFloat;
 
 /// Main rendering function.
@@ -60,6 +60,25 @@ pub fn render_2d_map<T: CoordsFloat>(cmap: CMap2<T>) {
     app.run();
 }
 
+/// Main rendering function.
+pub fn render_3d_map<T: CoordsFloat>(cmap: CMap3<T>) {
+    let mut app = App::new();
+    app.insert_resource(resources::Map3(cmap));
+    app.init_gizmo_group::<resources::DartGizmos>()
+        .init_gizmo_group::<resources::VertexGizmos>()
+        .init_gizmo_group::<resources::EdgeGizmos>();
+    app.add_systems(Startup, import_map::extract_data_from_3d_map::<T>);
+    // resource
+    app.insert_resource(Msaa::Sample4)
+        .insert_resource(ClearColor(Color::srgb(0.9, 0.9, 0.9)));
+    // plugins
+    app.add_plugins(DefaultPlugins)
+        .add_plugins(plugins::OptionsPlugin)
+        .add_plugins(plugins::GuiPlugin)
+        .add_plugins(plugins::ScenePlugin);
+
+    app.run();
+}
 // item for custom composition
 
 /// plugins used to build the default [`App`]
@@ -84,7 +103,7 @@ pub mod components {
 /// resources used to build the default [`App`]
 pub mod resources {
     pub use crate::gui::WindowVisible;
-    pub use crate::import_map::{FaceNormals, Map, MapVertices, VolumeNormals};
+    pub use crate::import_map::{FaceNormals, Map, Map3, MapVertices, VolumeNormals};
     pub use crate::options::{
         DartHeadMul, DartRenderColor, DartShrink, DartWidth, EdgeRenderColor, EdgeWidth,
         FaceRenderColor, FaceShrink, VertexRenderColor, VertexWidth, VolumeRenderColor,
@@ -96,9 +115,9 @@ pub mod resources {
 /// systems used to build the default [`App`]
 pub mod systems {
     pub use crate::gui::{draw_inspected_data, draw_options};
-    pub use crate::import_map::extract_data_from_map;
+    pub use crate::import_map::{extract_data_from_3d_map, extract_data_from_map};
     pub use crate::render_map::{
-        render_dart_enabled, render_darts, render_edge_enabled, render_edges, render_face_enabled,
-        render_faces, render_vertex_enabled, render_vertices,
+        render_dart_enabled, render_darts, render_darts_3d, render_edge_enabled, render_edges,
+        render_face_enabled, render_faces, render_vertex_enabled, render_vertices,
     };
 }

--- a/honeycomb-render/src/render_map.rs
+++ b/honeycomb-render/src/render_map.rs
@@ -2,10 +2,10 @@ use bevy::prelude::*;
 
 use crate::{
     components::{Dart, Edge, FaceId, Vertex},
-    import_map::Face,
+    import_map::{Face, VolumeId},
     resources::{
         DartHeadMul, DartRenderColor, DartShrink, EdgeRenderColor, FaceNormals, FaceRenderColor,
-        FaceShrink, MapVertices, VertexRenderColor, VertexWidth,
+        FaceShrink, MapVertices, VertexRenderColor, VertexWidth, VolumeNormals,
     },
 };
 
@@ -46,6 +46,53 @@ pub fn render_darts(
         let (ov1, ov2) = (&vertices[d.start], &vertices[d.end]);
 
         let (mut v1, mut v2) = (*ov1 + (*n1 * dart_shrink.0), *ov2 + (*n2 * dart_shrink.0));
+        let (dir, len) = ((v2 - v1).normalize(), (v2 - v1).length());
+        v1 += dir * (len * dart_shrink.0.abs() / 2.0);
+        v2 -= dir * (len * dart_shrink.0.abs() / 2.0);
+
+        gizmos
+            .arrow(v1, v2, Color::srgba_u8(red, green, blue, alpha))
+            .with_tip_length(dart_head_mul.0);
+    }
+}
+
+/// Dart rendering system.
+pub fn render_darts_3d(
+    mut gizmos: Gizmos<DartGizmos>,
+    // common data
+    vertices: Res<MapVertices>,
+    face_normals: Res<FaceNormals>,
+    volume_normals: Res<VolumeNormals>,
+    // dart render params
+    dart_render_color: Res<DartRenderColor>,
+    dart_head_mul: Res<DartHeadMul>,
+    // dart_width: Res<DartWidth>, // config is edited directly in the option functions
+    dart_shrink: Res<DartShrink>,
+    // dart to render
+    q: Query<(&Dart, &FaceId, &VolumeId)>,
+) {
+    // let dart_mat = materials.add(Color::Srgba(Srgba::from_u8_array(
+    //     dart_render_color.1.to_array(),
+    // )));
+    let vertices = &vertices.0;
+    let face_normals = &face_normals.0;
+    let volume_normals = &volume_normals.0;
+    let [red, green, blue, alpha] = dart_render_color.1.to_srgba_unmultiplied();
+    for (d, face_id, volume_id) in &q {
+        let (vn1, vn2) = (
+            &volume_normals[&(volume_id.0, d.start)],
+            &volume_normals[&(volume_id.0, d.end)],
+        );
+        let (fn1, fn2) = (
+            &face_normals[&(face_id.0, d.start)],
+            &face_normals[&(face_id.0, d.end)],
+        );
+        let (ov1, ov2) = (&vertices[d.start], &vertices[d.end]);
+
+        let (mut v1, mut v2) = (
+            *ov1 + (*vn1 * dart_shrink.0) + (*fn1 * dart_shrink.0),
+            *ov2 + (*vn2 * dart_shrink.0) + (*fn2 * dart_shrink.0),
+        );
         let (dir, len) = ((v2 - v1).normalize(), (v2 - v1).length());
         v1 += dir * (len * dart_shrink.0.abs() / 2.0);
         v2 -= dir * (len * dart_shrink.0.abs() / 2.0);

--- a/honeycomb-render/src/render_map.rs
+++ b/honeycomb-render/src/render_map.rs
@@ -57,6 +57,7 @@ pub fn render_darts(
 }
 
 /// Dart rendering system.
+#[allow(clippy::too_many_arguments)]
 pub fn render_darts_3d(
     mut gizmos: Gizmos<DartGizmos>,
     // common data

--- a/honeycomb-render/src/scene/mod.rs
+++ b/honeycomb-render/src/scene/mod.rs
@@ -8,7 +8,7 @@ use bevy_mod_picking::selection::SelectionPluginSettings;
 
 use crate::gui::WindowVisible;
 use crate::systems::{
-    render_dart_enabled, render_darts, render_edge_enabled, render_edges, render_face_enabled,
+    render_dart_enabled, render_darts_3d, render_edge_enabled, render_edges, render_face_enabled,
     render_faces, render_vertex_enabled, render_vertices,
 };
 
@@ -35,12 +35,13 @@ impl Plugin for ScenePlugin {
             .add_systems(Update, picking::update_picking);
 
         // content rendering
-        app.add_systems(Update, render_darts.run_if(render_dart_enabled))
+        app.add_systems(Update, render_darts_3d.run_if(render_dart_enabled))
             .add_systems(Update, render_vertices.run_if(render_vertex_enabled))
             .add_systems(Update, render_edges.run_if(render_edge_enabled))
             .add_systems(Update, render_faces.run_if(render_face_enabled));
     }
 }
+
 /// Scene setup routine.
 pub fn setup_scene(mut commands: Commands) {
     let camera_transform = Transform::from_xyz(0.0, 0.0, 5.0);

--- a/honeycomb-render/src/scene/mod.rs
+++ b/honeycomb-render/src/scene/mod.rs
@@ -7,9 +7,10 @@ use bevy_mod_picking::DefaultPickingPlugins;
 use bevy_mod_picking::selection::SelectionPluginSettings;
 
 use crate::gui::WindowVisible;
+use crate::resources::{Map, Map3};
 use crate::systems::{
-    render_dart_enabled, render_darts_3d, render_edge_enabled, render_edges, render_face_enabled,
-    render_faces, render_vertex_enabled, render_vertices,
+    render_dart_enabled, render_darts, render_darts_3d, render_edge_enabled, render_edges,
+    render_face_enabled, render_faces, render_vertex_enabled, render_vertices,
 };
 
 /// Plugin handling scene setup and updates.
@@ -34,11 +35,17 @@ impl Plugin for ScenePlugin {
             .insert_resource(SelectionPluginSettings::default())
             .add_systems(Update, picking::update_picking);
 
-        // content rendering
-        app.add_systems(Update, render_darts_3d.run_if(render_dart_enabled))
-            .add_systems(Update, render_vertices.run_if(render_vertex_enabled))
+        // common content rendering
+        app.add_systems(Update, render_vertices.run_if(render_vertex_enabled))
             .add_systems(Update, render_edges.run_if(render_edge_enabled))
             .add_systems(Update, render_faces.run_if(render_face_enabled));
+        // dim. specific rendering
+        let world = app.world();
+        if world.contains_resource::<Map3<f32>>() || world.contains_resource::<Map3<f64>>() {
+            app.add_systems(Update, render_darts_3d.run_if(render_dart_enabled));
+        } else if world.contains_resource::<Map<f32>>() || world.contains_resource::<Map<f64>>() {
+            app.add_systems(Update, render_darts.run_if(render_dart_enabled));
+        }
     }
 }
 


### PR DESCRIPTION
### Description

**Scope**: render

**Type of change**: feat

**Content description**:
- add bevy items to import and render `CMap3` items
- add a main rendering function

I haven't renamed 2D items to not break things uselessly

### Additional information

- [x] New dependency: use itertools (already in the workspace) in the render crate

<img width="1392" alt="Capture d’écran 2025-04-10 à 17 29 06" src="https://github.com/user-attachments/assets/c0e551c3-5865-4c83-ad68-222ef9008ebf" />


### Necessary follow-up

render and grid generation both fixed; next step is fixing the shrinking logic to avoid uneven shrinks. 
