### PR TITLE
feat(kernels): implement geometrical anchoring attributes

### DIFF
--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -118,24 +118,26 @@ impl<T: CoordsFloat> CMap2<T> {
                 let rhs_vid_old = self.vertex_id_transac(trans, rhs_dart_id)?;
 
                 // check orientation
-                #[rustfmt::skip]
-                    if let (
-                        Ok(Some(l_vertex)), Ok(Some(b1r_vertex)), // (lhs/b1rhs) vertices
-                        Ok(Some(b1l_vertex)), Ok(Some(r_vertex)), // (b1lhs/rhs) vertices
-                    ) = (
-                        self.vertices.read(trans, lhs_vid_old), self.vertices.read(trans, b1rhs_vid_old),// (lhs/b1rhs)
-                        self.vertices.read(trans, b1lhs_vid_old), self.vertices.read(trans, rhs_vid_old) // (b1lhs/rhs)
-                    )
-                    {
-                        let lhs_vector = b1l_vertex - l_vertex;
-                        let rhs_vector = b1r_vertex - r_vertex;
-                        // dot product should be negative if the two darts have opposite direction
-                        // we could also put restriction on the angle made by the two darts to prevent
-                        // drastic deformation
-                        if lhs_vector.dot(&rhs_vector) >= T::zero() {
-                            abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?;
-                        }
-                    };
+                if let (
+                    Ok(Some(l_vertex)),   // lhs
+                    Ok(Some(b1r_vertex)), // b1rhs
+                    Ok(Some(b1l_vertex)), // b1lhs
+                    Ok(Some(r_vertex)),   // rhs
+                ) = (
+                    self.vertices.read(trans, lhs_vid_old),   // lhs
+                    self.vertices.read(trans, b1rhs_vid_old), // b1rhs
+                    self.vertices.read(trans, b1lhs_vid_old), // b1lhs
+                    self.vertices.read(trans, rhs_vid_old),   // rhs
+                ) {
+                    let lhs_vector = b1l_vertex - l_vertex;
+                    let rhs_vector = b1r_vertex - r_vertex;
+                    // dot product should be negative if the two darts have opposite direction
+                    // we could also put restriction on the angle made by the two darts to prevent
+                    // drastic deformation
+                    if lhs_vector.dot(&rhs_vector) >= T::zero() {
+                        abort(SewError::BadGeometry(2, lhs_dart_id, rhs_dart_id))?;
+                    }
+                }
 
                 // update the topology
                 try_or_coerce!(

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -96,7 +96,7 @@ impl<T: CoordsFloat> CMap3<T> {
                 if lhs_vector.dot(&rhs_vector) >= T::zero() {
                     abort(SewError::BadGeometry(3, ld, rd))?;
                 }
-            };
+            }
         }
 
         // (*): these branch corresponds to incomplete merges (at best),

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -123,7 +123,7 @@ impl<T: CoordsFloat> CMap3<T> {
                     if lhs_vector.dot(&rhs_vector) >= T::zero() {
                         abort(SewError::BadGeometry(2, ld, rd))?;
                     }
-                };
+                }
 
                 // update the topology
                 try_or_coerce!(self.betas.two_link_core(trans, ld, rd), SewError);

--- a/honeycomb-kernels/src/grisubal/model.rs
+++ b/honeycomb-kernels/src/grisubal/model.rs
@@ -171,7 +171,7 @@ impl<T: CoordsFloat> TryFrom<Vtk> for Geometry2<T> {
                                 },
                             ) {
                                 return Err(err);
-                            };
+                            }
                         }
                         VertexNumbers::XML { .. } => {
                             return Err(GrisubalError::UnsupportedVtkData("XML format"));

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -15,7 +15,7 @@ use honeycomb_core::{
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VertexAnchor {
     /// Vertex is linked to a node.
     Node(usize),
@@ -108,7 +108,7 @@ impl AttributeUpdate for VertexAnchor {
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EdgeAnchor {
     /// Vertex is linked to a curve.
     Curve(usize),
@@ -185,7 +185,7 @@ impl AttributeUpdate for EdgeAnchor {
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FaceAnchor {
     /// Vertex is linked to a surface.
     Surface(usize),

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -1,0 +1,237 @@
+//! geometrical anchoring code
+
+use honeycomb_core::{
+    attributes::{AttrSparseVec, AttributeBind, AttributeError, AttributeUpdate},
+    cmap::{EdgeIdType, FaceIdType, OrbitPolicy, VertexIdType},
+};
+
+// --- Vertex anchors
+
+/// Geometrical mesh anchor.
+///
+/// This enum is used as an attribute to link mesh vertices to entities of the represented geometry.
+///
+/// The `AttributeUpdate` implementation is used to enforce the dimensional conditions required to
+/// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
+/// expect this to be handled outside of the merge functor, as doing it inside would require leaking
+/// map data into the trait's methods.
+#[derive(Debug, Copy, Clone)]
+pub enum VertexAnchor {
+    /// Vertex is linked to a node.
+    Node(usize),
+    /// Vertex is linked to a curve.
+    Curve(usize),
+    /// Vertex is linked to a surface.
+    Surface(usize),
+    /// Vertex is linked to a 3D body.
+    Body(usize),
+}
+
+impl AttributeBind for VertexAnchor {
+    type StorageType = AttrSparseVec<Self>;
+    type IdentifierType = VertexIdType;
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Vertex;
+}
+
+impl AttributeUpdate for VertexAnchor {
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        match attr1 {
+            Self::Node(id1) => match attr2 {
+                Self::Node(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Node(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Curve(_) | Self::Surface(_) | Self::Body(_) => Ok(attr1),
+            },
+            Self::Curve(id1) => match attr2 {
+                Self::Node(_) => Ok(attr2),
+                Self::Curve(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Curve(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Surface(_) | Self::Body(_) => Ok(attr1),
+            },
+            Self::Surface(id1) => match attr2 {
+                Self::Node(_) | Self::Curve(_) => Ok(attr2),
+                Self::Surface(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Surface(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Body(_) => Ok(attr1),
+            },
+            Self::Body(id1) => match attr2 {
+                Self::Node(_) | Self::Curve(_) | Self::Surface(_) => Ok(attr2),
+                Self::Body(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Body(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+            },
+        }
+    }
+
+    fn split(attr: Self) -> Result<(Self, Self), AttributeError> {
+        Ok((attr, attr))
+    }
+}
+
+// --- Edge anchors
+
+/// Geometrical mesh anchor.
+///
+/// This enum is used as an attribute to link mesh edges to entities of the represented geometry..
+///
+/// The `AttributeUpdate` implementation is used to enforce the dimensional conditions required to
+/// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
+/// expect this to be handled outside of the merge functor, as doing it inside would require leaking
+/// map data into the trait's methods.
+#[derive(Debug, Copy, Clone)]
+pub enum EdgeAnchor {
+    /// Vertex is linked to a curve.
+    Curve(usize),
+    /// Vertex is linked to a surface.
+    Surface(usize),
+    /// Vertex is linked to a 3D body.
+    Body(usize),
+}
+
+impl AttributeBind for EdgeAnchor {
+    type StorageType = AttrSparseVec<Self>;
+    type IdentifierType = EdgeIdType;
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Edge;
+}
+
+impl AttributeUpdate for EdgeAnchor {
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        match attr1 {
+            Self::Curve(id1) => match attr2 {
+                Self::Curve(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Curve(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Surface(_) | Self::Body(_) => Ok(attr1),
+            },
+            Self::Surface(id1) => match attr2 {
+                Self::Curve(_) => Ok(attr2),
+                Self::Surface(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Surface(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Body(_) => Ok(attr1),
+            },
+            Self::Body(id1) => match attr2 {
+                Self::Curve(_) | Self::Surface(_) => Ok(attr2),
+                Self::Body(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Body(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+            },
+        }
+    }
+
+    fn split(attr: Self) -> Result<(Self, Self), AttributeError> {
+        Ok((attr, attr))
+    }
+}
+
+// --- Face anchors
+
+/// Geometrical mesh anchor.
+///
+/// This enum is used as an attribute to link mesh faces to entities of the represented geometry..
+///
+/// The `AttributeUpdate` implementation is used to enforce the dimensional conditions required to
+/// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
+/// expect this to be handled outside of the merge functor, as doing it inside would require leaking
+/// map data into the trait's methods.
+#[derive(Debug, Copy, Clone)]
+pub enum FaceAnchor {
+    /// Vertex is linked to a surface.
+    Surface(usize),
+    /// Vertex is linked to a 3D body.
+    Body(usize),
+}
+
+impl AttributeBind for FaceAnchor {
+    type StorageType = AttrSparseVec<Self>;
+    type IdentifierType = FaceIdType;
+    const BIND_POLICY: OrbitPolicy = OrbitPolicy::Face;
+}
+
+impl AttributeUpdate for FaceAnchor {
+    fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
+        match attr1 {
+            Self::Surface(id1) => match attr2 {
+                Self::Surface(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Surface(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+                Self::Body(_) => Ok(attr1),
+            },
+            Self::Body(id1) => match attr2 {
+                Self::Surface(_) => Ok(attr2),
+                Self::Body(id2) => {
+                    if id1 == id2 {
+                        Ok(Self::Body(id1))
+                    } else {
+                        Err(AttributeError::FailedMerge(
+                            std::any::type_name::<Self>(),
+                            "anchors have the same dimension but different IDs",
+                        ))
+                    }
+                }
+            },
+        }
+    }
+
+    fn split(attr: Self) -> Result<(Self, Self), AttributeError> {
+        Ok((attr, attr))
+    }
+}

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -5,6 +5,9 @@ use honeycomb_core::{
     cmap::{EdgeIdType, FaceIdType, OrbitPolicy, VertexIdType},
 };
 
+/// Geometrical cell identifier type.
+pub type GCellIdType = u32;
+
 // --- Vertex anchors
 
 /// Geometrical mesh anchor.
@@ -18,13 +21,13 @@ use honeycomb_core::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VertexAnchor {
     /// Vertex is linked to a node.
-    Node(usize),
+    Node(GCellIdType),
     /// Vertex is linked to a curve.
-    Curve(usize),
+    Curve(GCellIdType),
     /// Vertex is linked to a surface.
-    Surface(usize),
+    Surface(GCellIdType),
     /// Vertex is linked to a 3D body.
-    Body(usize),
+    Body(GCellIdType),
 }
 
 impl AttributeBind for VertexAnchor {
@@ -100,11 +103,11 @@ impl AttributeUpdate for VertexAnchor {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EdgeAnchor {
     /// Vertex is linked to a curve.
-    Curve(usize),
+    Curve(GCellIdType),
     /// Vertex is linked to a surface.
-    Surface(usize),
+    Surface(GCellIdType),
     /// Vertex is linked to a 3D body.
-    Body(usize),
+    Body(GCellIdType),
 }
 
 impl AttributeBind for EdgeAnchor {
@@ -169,9 +172,9 @@ impl AttributeUpdate for EdgeAnchor {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FaceAnchor {
     /// Vertex is linked to a surface.
-    Surface(usize),
+    Surface(GCellIdType),
     /// Vertex is linked to a 3D body.
-    Body(usize),
+    Body(GCellIdType),
 }
 
 impl AttributeBind for FaceAnchor {

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -35,61 +35,50 @@ impl AttributeBind for VertexAnchor {
 
 impl AttributeUpdate for VertexAnchor {
     fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
-        match attr1 {
-            Self::Node(id1) => match attr2 {
-                Self::Node(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Node(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+        match (attr1, attr2) {
+            (Self::Node(id1), Self::Node(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Node(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Curve(_) | Self::Surface(_) | Self::Body(_) => Ok(attr1),
-            },
-            Self::Curve(id1) => match attr2 {
-                Self::Node(_) => Ok(attr2),
-                Self::Curve(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Curve(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Node(id), _) | (_, Self::Node(id)) => Ok(Self::Node(id)),
+            (Self::Curve(id1), Self::Curve(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Curve(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Surface(_) | Self::Body(_) => Ok(attr1),
-            },
-            Self::Surface(id1) => match attr2 {
-                Self::Node(_) | Self::Curve(_) => Ok(attr2),
-                Self::Surface(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Surface(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Curve(id), _) | (_, Self::Curve(id)) => Ok(Self::Curve(id)),
+            (Self::Surface(id1), Self::Surface(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Surface(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Body(_) => Ok(attr1),
-            },
-            Self::Body(id1) => match attr2 {
-                Self::Node(_) | Self::Curve(_) | Self::Surface(_) => Ok(attr2),
-                Self::Body(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Body(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Surface(id), _) | (_, Self::Surface(id)) => Ok(Self::Surface(id)),
+            (Self::Body(id1), Self::Body(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Body(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-            },
+            }
         }
     }
 
@@ -126,47 +115,39 @@ impl AttributeBind for EdgeAnchor {
 
 impl AttributeUpdate for EdgeAnchor {
     fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
-        match attr1 {
-            Self::Curve(id1) => match attr2 {
-                Self::Curve(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Curve(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+        match (attr1, attr2) {
+            (Self::Curve(id1), Self::Curve(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Curve(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Surface(_) | Self::Body(_) => Ok(attr1),
-            },
-            Self::Surface(id1) => match attr2 {
-                Self::Curve(_) => Ok(attr2),
-                Self::Surface(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Surface(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Curve(id), _) | (_, Self::Curve(id)) => Ok(Self::Curve(id)),
+            (Self::Surface(id1), Self::Surface(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Surface(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Body(_) => Ok(attr1),
-            },
-            Self::Body(id1) => match attr2 {
-                Self::Curve(_) | Self::Surface(_) => Ok(attr2),
-                Self::Body(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Body(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Surface(id), _) | (_, Self::Surface(id)) => Ok(Self::Surface(id)),
+            (Self::Body(id1), Self::Body(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Body(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-            },
+            }
         }
     }
 
@@ -201,33 +182,28 @@ impl AttributeBind for FaceAnchor {
 
 impl AttributeUpdate for FaceAnchor {
     fn merge(attr1: Self, attr2: Self) -> Result<Self, AttributeError> {
-        match attr1 {
-            Self::Surface(id1) => match attr2 {
-                Self::Surface(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Surface(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+        match (attr1, attr2) {
+            (Self::Surface(id1), Self::Surface(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Surface(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-                Self::Body(_) => Ok(attr1),
-            },
-            Self::Body(id1) => match attr2 {
-                Self::Surface(_) => Ok(attr2),
-                Self::Body(id2) => {
-                    if id1 == id2 {
-                        Ok(Self::Body(id1))
-                    } else {
-                        Err(AttributeError::FailedMerge(
-                            std::any::type_name::<Self>(),
-                            "anchors have the same dimension but different IDs",
-                        ))
-                    }
+            }
+            (Self::Surface(id), _) | (_, Self::Surface(id)) => Ok(Self::Surface(id)),
+            (Self::Body(id1), Self::Body(id2)) => {
+                if id1 == id2 {
+                    Ok(Self::Body(id1))
+                } else {
+                    Err(AttributeError::FailedMerge(
+                        std::any::type_name::<Self>(),
+                        "anchors have the same dimension but different IDs",
+                    ))
                 }
-            },
+            }
         }
     }
 

--- a/honeycomb-kernels/src/remeshing/mod.rs
+++ b/honeycomb-kernels/src/remeshing/mod.rs
@@ -7,10 +7,12 @@
 //! - cell fusion routines
 //! - swap-based cell edition routines
 
+mod anchoring;
 mod cut;
 mod relaxation;
 mod swap;
 
+pub use anchoring::{EdgeAnchor, FaceAnchor, VertexAnchor};
 pub use cut::{cut_inner_edge, cut_outer_edge};
 pub use relaxation::move_vertex_to_average;
 pub use swap::{EdgeSwapError, swap_edge};

--- a/honeycomb-kernels/src/remeshing/tests.rs
+++ b/honeycomb-kernels/src/remeshing/tests.rs
@@ -1,9 +1,347 @@
 use honeycomb_core::{
+    attributes::{AttrSparseVec, AttributeStorage, UnknownAttributeStorage},
     cmap::{CMapBuilder, OrbitPolicy},
-    stm::atomically_with_err,
+    stm::{atomically, atomically_with_err},
 };
 
-use crate::remeshing::{EdgeSwapError, swap_edge};
+use crate::remeshing::{EdgeSwapError, VertexAnchor, swap_edge};
+
+use super::{EdgeAnchor, FaceAnchor};
+
+// --- anchors
+
+#[test]
+fn merge_vertex_eq_dim() {
+    let storage: AttrSparseVec<VertexAnchor> = AttrSparseVec::new(13);
+    atomically(|t| {
+        storage.write(t, 1, VertexAnchor::Node(1))?;
+        storage.write(t, 2, VertexAnchor::Node(1))?;
+        storage.write(t, 3, VertexAnchor::Node(2))?;
+        storage.write(t, 4, VertexAnchor::Curve(1))?;
+        storage.write(t, 5, VertexAnchor::Curve(1))?;
+        storage.write(t, 6, VertexAnchor::Curve(2))?;
+        storage.write(t, 7, VertexAnchor::Surface(3))?;
+        storage.write(t, 8, VertexAnchor::Surface(3))?;
+        storage.write(t, 9, VertexAnchor::Surface(4))?;
+        storage.write(t, 10, VertexAnchor::Body(5))?;
+        storage.write(t, 11, VertexAnchor::Body(6))?;
+        storage.write(t, 12, VertexAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        // Node merges
+        assert!(storage.merge(t, 1, 1, 2).is_ok());
+        assert!(storage.read(t, 1)?.is_some());
+        assert!(storage.read(t, 2)?.is_none());
+        assert!(storage.merge(t, 1, 1, 3).is_err());
+        assert!(storage.read(t, 3)?.is_some());
+        // Curve merges
+        assert!(storage.merge(t, 4, 4, 5).is_ok());
+        assert!(storage.read(t, 4)?.is_some());
+        assert!(storage.read(t, 5)?.is_none());
+        assert!(storage.merge(t, 6, 4, 6).is_err());
+        assert!(storage.read(t, 6)?.is_some());
+        // Surface merges
+        assert!(storage.merge(t, 7, 7, 8).is_ok());
+        assert!(storage.read(t, 7)?.is_some());
+        assert!(storage.read(t, 8)?.is_none());
+        assert!(storage.merge(t, 7, 7, 9).is_err());
+        assert!(storage.read(t, 9)?.is_some());
+        // Body merges
+        assert!(storage.merge(t, 11, 12, 11).is_ok());
+        assert!(storage.read(t, 11)?.is_some());
+        assert!(storage.read(t, 12)?.is_none());
+        assert!(storage.merge(t, 10, 10, 11).is_err());
+        assert!(storage.read(t, 11)?.is_some());
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_vertex_diff_dim() {
+    let storage: AttrSparseVec<VertexAnchor> = AttrSparseVec::new(11);
+    atomically(|t| {
+        storage.write(t, 1, VertexAnchor::Node(1))?;
+        storage.write(t, 2, VertexAnchor::Curve(2))?;
+        storage.write(t, 3, VertexAnchor::Surface(3))?;
+        storage.write(t, 4, VertexAnchor::Body(4))?;
+        storage.write(t, 5, VertexAnchor::Body(5))?;
+        storage.write(t, 6, VertexAnchor::Node(10))?;
+        storage.write(t, 7, VertexAnchor::Curve(9))?;
+        storage.write(t, 8, VertexAnchor::Surface(8))?;
+        storage.write(t, 9, VertexAnchor::Body(7))?;
+        storage.write(t, 10, VertexAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 3, 4, 3).is_ok());
+        assert!(
+            storage
+                .read(t, 3)?
+                .is_some_and(|v| v == VertexAnchor::Surface(3))
+        );
+        assert!(storage.merge(t, 2, 3, 2).is_ok());
+        assert!(
+            storage
+                .read(t, 2)?
+                .is_some_and(|v| v == VertexAnchor::Curve(2))
+        );
+        assert!(storage.merge(t, 1, 2, 1).is_ok());
+        assert!(
+            storage
+                .read(t, 1)?
+                .is_some_and(|v| v == VertexAnchor::Node(1))
+        );
+        assert!(storage.merge(t, 5, 1, 5).is_ok());
+        assert!(
+            storage
+                .read(t, 5)?
+                .is_some_and(|v| v == VertexAnchor::Node(1))
+        );
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 6, 10, 6).is_ok());
+        assert!(
+            storage
+                .read(t, 6)?
+                .is_some_and(|v| v == VertexAnchor::Node(10))
+        );
+        assert!(storage.merge(t, 8, 8, 9).is_ok());
+        assert!(
+            storage
+                .read(t, 8)?
+                .is_some_and(|v| v == VertexAnchor::Surface(8))
+        );
+        assert!(storage.merge(t, 7, 7, 8).is_ok());
+        assert!(
+            storage
+                .read(t, 7)?
+                .is_some_and(|v| v == VertexAnchor::Curve(9))
+        );
+        assert!(storage.merge(t, 6, 6, 7).is_ok());
+        assert!(
+            storage
+                .read(t, 6)?
+                .is_some_and(|v| v == VertexAnchor::Node(10))
+        );
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_edge_eq_dim() {
+    let storage: AttrSparseVec<EdgeAnchor> = AttrSparseVec::new(13);
+    atomically(|t| {
+        storage.write(t, 4, EdgeAnchor::Curve(1))?;
+        storage.write(t, 5, EdgeAnchor::Curve(1))?;
+        storage.write(t, 6, EdgeAnchor::Curve(2))?;
+        storage.write(t, 7, EdgeAnchor::Surface(3))?;
+        storage.write(t, 8, EdgeAnchor::Surface(3))?;
+        storage.write(t, 9, EdgeAnchor::Surface(4))?;
+        storage.write(t, 10, EdgeAnchor::Body(5))?;
+        storage.write(t, 11, EdgeAnchor::Body(6))?;
+        storage.write(t, 12, EdgeAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        // Curve merges
+        assert!(storage.merge(t, 4, 4, 5).is_ok());
+        assert!(storage.read(t, 4)?.is_some());
+        assert!(storage.read(t, 5)?.is_none());
+        assert!(storage.merge(t, 6, 4, 6).is_err());
+        assert!(storage.read(t, 6)?.is_some());
+        // Surface merges
+        assert!(storage.merge(t, 7, 7, 8).is_ok());
+        assert!(storage.read(t, 7)?.is_some());
+        assert!(storage.read(t, 8)?.is_none());
+        assert!(storage.merge(t, 7, 7, 9).is_err());
+        assert!(storage.read(t, 9)?.is_some());
+        // Body merges
+        assert!(storage.merge(t, 11, 12, 11).is_ok());
+        assert!(storage.read(t, 11)?.is_some());
+        assert!(storage.read(t, 12)?.is_none());
+        assert!(storage.merge(t, 10, 10, 11).is_err());
+        assert!(storage.read(t, 11)?.is_some());
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_edge_diff_dim() {
+    let storage: AttrSparseVec<EdgeAnchor> = AttrSparseVec::new(11);
+    atomically(|t| {
+        storage.write(t, 2, EdgeAnchor::Curve(2))?;
+        storage.write(t, 3, EdgeAnchor::Surface(3))?;
+        storage.write(t, 4, EdgeAnchor::Body(4))?;
+        storage.write(t, 5, EdgeAnchor::Body(5))?;
+        storage.write(t, 7, EdgeAnchor::Curve(9))?;
+        storage.write(t, 8, EdgeAnchor::Surface(8))?;
+        storage.write(t, 9, EdgeAnchor::Body(7))?;
+        storage.write(t, 10, EdgeAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 3, 4, 3).is_ok());
+        assert!(
+            storage
+                .read(t, 3)?
+                .is_some_and(|v| v == EdgeAnchor::Surface(3))
+        );
+        assert!(storage.merge(t, 2, 3, 2).is_ok());
+        assert!(
+            storage
+                .read(t, 2)?
+                .is_some_and(|v| v == EdgeAnchor::Curve(2))
+        );
+        assert!(storage.merge(t, 5, 2, 5).is_ok());
+        assert!(
+            storage
+                .read(t, 5)?
+                .is_some_and(|v| v == EdgeAnchor::Curve(2))
+        );
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 8, 8, 9).is_ok());
+        assert!(
+            storage
+                .read(t, 8)?
+                .is_some_and(|v| v == EdgeAnchor::Surface(8))
+        );
+        assert!(storage.merge(t, 7, 7, 8).is_ok());
+        assert!(
+            storage
+                .read(t, 7)?
+                .is_some_and(|v| v == EdgeAnchor::Curve(9))
+        );
+        assert!(storage.merge(t, 10, 10, 7).is_ok());
+        assert!(
+            storage
+                .read(t, 10)?
+                .is_some_and(|v| v == EdgeAnchor::Curve(9))
+        );
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_face_eq_dim() {
+    let storage: AttrSparseVec<FaceAnchor> = AttrSparseVec::new(13);
+    atomically(|t| {
+        storage.write(t, 7, FaceAnchor::Surface(3))?;
+        storage.write(t, 8, FaceAnchor::Surface(3))?;
+        storage.write(t, 9, FaceAnchor::Surface(4))?;
+        storage.write(t, 10, FaceAnchor::Body(5))?;
+        storage.write(t, 11, FaceAnchor::Body(6))?;
+        storage.write(t, 12, FaceAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        // Surface merges
+        assert!(storage.merge(t, 7, 7, 8).is_ok());
+        assert!(storage.read(t, 7)?.is_some());
+        assert!(storage.read(t, 8)?.is_none());
+        assert!(storage.merge(t, 7, 7, 9).is_err());
+        assert!(storage.read(t, 9)?.is_some());
+        // Body merges
+        assert!(storage.merge(t, 11, 12, 11).is_ok());
+        assert!(storage.read(t, 11)?.is_some());
+        assert!(storage.read(t, 12)?.is_none());
+        assert!(storage.merge(t, 10, 10, 11).is_err());
+        assert!(storage.read(t, 11)?.is_some());
+        Ok(())
+    });
+}
+
+#[test]
+fn merge_face_diff_dim() {
+    let storage: AttrSparseVec<FaceAnchor> = AttrSparseVec::new(11);
+    atomically(|t| {
+        storage.write(t, 3, FaceAnchor::Surface(3))?;
+        storage.write(t, 4, FaceAnchor::Body(4))?;
+        storage.write(t, 5, FaceAnchor::Body(5))?;
+        storage.write(t, 8, FaceAnchor::Surface(8))?;
+        storage.write(t, 9, FaceAnchor::Body(7))?;
+        storage.write(t, 10, FaceAnchor::Body(6))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 3, 4, 3).is_ok());
+        assert!(
+            storage
+                .read(t, 3)?
+                .is_some_and(|v| v == FaceAnchor::Surface(3))
+        );
+        assert!(storage.merge(t, 5, 3, 5).is_ok());
+        assert!(
+            storage
+                .read(t, 5)?
+                .is_some_and(|v| v == FaceAnchor::Surface(3))
+        );
+        Ok(())
+    });
+
+    atomically(|t| {
+        assert!(storage.merge(t, 8, 8, 9).is_ok());
+        assert!(
+            storage
+                .read(t, 8)?
+                .is_some_and(|v| v == FaceAnchor::Surface(8))
+        );
+        assert!(storage.merge(t, 10, 10, 8).is_ok());
+        assert!(
+            storage
+                .read(t, 10)?
+                .is_some_and(|v| v == FaceAnchor::Surface(8))
+        );
+        Ok(())
+    });
+}
+
+#[test]
+fn split_anchors() {
+    let storage: AttrSparseVec<VertexAnchor> = AttrSparseVec::new(13);
+    atomically(|t| {
+        storage.write(t, 1, VertexAnchor::Node(1))?;
+        storage.write(t, 4, VertexAnchor::Curve(1))?;
+        storage.write(t, 7, VertexAnchor::Surface(3))?;
+        storage.write(t, 10, VertexAnchor::Body(5))?;
+        Ok(())
+    });
+
+    atomically(|t| {
+        // Node split
+        assert!(storage.split(t, 2, 3, 1).is_ok());
+        assert!(storage.read(t, 1)?.is_none());
+        assert!(storage.read(t, 2)?.is_some());
+        assert!(storage.read(t, 3)?.is_some());
+        // Curve split
+        assert!(storage.split(t, 5, 6, 4).is_ok());
+        assert!(storage.read(t, 4)?.is_none());
+        assert!(storage.read(t, 5)?.is_some());
+        assert!(storage.read(t, 6)?.is_some());
+        // Surface split
+        assert!(storage.split(t, 9, 8, 7).is_ok());
+        assert!(storage.read(t, 7)?.is_none());
+        assert!(storage.read(t, 8)?.is_some());
+        assert!(storage.read(t, 9)?.is_some());
+        // Body split
+        assert!(storage.split(t, 11, 12, 10).is_ok());
+        assert!(storage.read(t, 10)?.is_none());
+        assert!(storage.read(t, 11)?.is_some());
+        assert!(storage.read(t, 12)?.is_some());
+        Ok(())
+    });
+}
 
 #[test]
 fn swap_edge_errs() {


### PR DESCRIPTION
### Description

**Scope**: kernels

**Type of change**: feat

**Content description**:
- add three new enums: `VertexAnchor`, `EdgeAnchor`, and `FaceAnchor`
- implement attribute traits for these

### Necessary follow-up

- ~~add tests~~ done
- set these at the end of the `grisubal` kernel
- use these to implement predicates controlling the `collapse_edge` routine