### PR TITLE
refactor(grisubal): add anchor insertion after geometry capture

### DIFF
--- a/honeycomb-core/src/attributes/manager.rs
+++ b/honeycomb-core/src/attributes/manager.rs
@@ -816,4 +816,10 @@ impl AttrStorageManager {
             Ok(None)
         }
     }
+
+    /// Returns a boolean indicating whether an attribute is stored by the manager or not.
+    pub(crate) fn contains_attribute<A: AttributeBind + AttributeUpdate>(&self) -> bool {
+        get_storage!(self, storage);
+        storage.is_some()
+    }
 }

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -272,6 +272,7 @@ impl<T: CoordsFloat> CMap2<T> {
     }
 
     /// Return a boolean indicating if the map contains the specified attribute.
+    #[must_use = "unused return value"]
     pub fn contains_attribute<A: AttributeBind + AttributeUpdate>(&self) -> bool {
         self.attributes.contains_attribute::<A>()
     }

--- a/honeycomb-core/src/cmap/dim2/embed.rs
+++ b/honeycomb-core/src/cmap/dim2/embed.rs
@@ -270,4 +270,9 @@ impl<T: CoordsFloat> CMap2<T> {
     pub fn remove_attribute_storage<A: AttributeBind + AttributeUpdate>(&mut self) {
         self.attributes.remove_storage::<A>();
     }
+
+    /// Return a boolean indicating if the map contains the specified attribute.
+    pub fn contains_attribute<A: AttributeBind + AttributeUpdate>(&self) -> bool {
+        self.attributes.contains_attribute::<A>()
+    }
 }

--- a/honeycomb-core/src/cmap/dim3/embed.rs
+++ b/honeycomb-core/src/cmap/dim3/embed.rs
@@ -272,6 +272,7 @@ impl<T: CoordsFloat> CMap3<T> {
     }
 
     /// Return a boolean indicating if the map contains the specified attribute.
+    #[must_use = "unused return value"]
     pub fn contains_attribute<A: AttributeBind + AttributeUpdate>(&self) -> bool {
         self.attributes.contains_attribute::<A>()
     }

--- a/honeycomb-core/src/cmap/dim3/embed.rs
+++ b/honeycomb-core/src/cmap/dim3/embed.rs
@@ -270,4 +270,9 @@ impl<T: CoordsFloat> CMap3<T> {
     pub fn remove_attribute_storage<A: AttributeBind + AttributeUpdate>(&mut self) {
         self.attributes.remove_storage::<A>();
     }
+
+    /// Return a boolean indicating if the map contains the specified attribute.
+    pub fn contains_attribute<A: AttributeBind + AttributeUpdate>(&self) -> bool {
+        self.attributes.contains_attribute::<A>()
+    }
 }

--- a/honeycomb-kernels/src/grisubal/mod.rs
+++ b/honeycomb-kernels/src/grisubal/mod.rs
@@ -177,7 +177,7 @@ pub fn grisubal<T: CoordsFloat>(
     //----/
 
     // --- FIND AN OVERLAPPING GRID
-    let ([nx, ny], origin) = compute_overlapping_grid(&geometry, grid_cell_sizes)?;
+    let ([nx, ny], origin) = compute_overlapping_grid(&geometry, grid_cell_sizes, false)?;
     let [cx, cy] = grid_cell_sizes;
     let ogrid = GridDescriptor::default()
         .n_cells([nx, ny])

--- a/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
+++ b/honeycomb-kernels/src/grisubal/routines/insert_new_edges.rs
@@ -10,6 +10,7 @@ use crate::cell_insertion::insert_vertices_on_edge;
 use crate::grisubal::model::{Boundary, MapEdge};
 use crate::remeshing::VertexAnchor;
 
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn insert_edges_in_map<T: CoordsFloat>(cmap: &mut CMap2<T>, edges: &[MapEdge<T>]) {
     let dart_slices = build_workload(cmap, edges);
 

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -5,8 +5,14 @@ use honeycomb_core::{
     cmap::{EdgeIdType, FaceIdType, OrbitPolicy, VertexIdType},
 };
 
-/// Geometrical cell identifier type.
-pub type GCellIdType = u32;
+/// Geometrical 0-cell identifier type.
+pub type NodeIdType = u32;
+/// Geometrical 1-cell identifier type.
+pub type CurveIdType = u32;
+/// Geometrical 2-cell identifier type.
+pub type SurfaceIdType = u32;
+/// Geometrical 3-cell identifier type.
+pub type BodyIdType = u32;
 
 // --- Vertex anchors
 
@@ -21,13 +27,13 @@ pub type GCellIdType = u32;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VertexAnchor {
     /// Vertex is linked to a node.
-    Node(GCellIdType),
+    Node(NodeIdType),
     /// Vertex is linked to a curve.
-    Curve(GCellIdType),
+    Curve(CurveIdType),
     /// Vertex is linked to a surface.
-    Surface(GCellIdType),
+    Surface(SurfaceIdType),
     /// Vertex is linked to a 3D body.
-    Body(GCellIdType),
+    Body(BodyIdType),
 }
 
 impl AttributeBind for VertexAnchor {
@@ -103,11 +109,11 @@ impl AttributeUpdate for VertexAnchor {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EdgeAnchor {
     /// Vertex is linked to a curve.
-    Curve(GCellIdType),
+    Curve(NodeIdType),
     /// Vertex is linked to a surface.
-    Surface(GCellIdType),
+    Surface(CurveIdType),
     /// Vertex is linked to a 3D body.
-    Body(GCellIdType),
+    Body(SurfaceIdType),
 }
 
 impl AttributeBind for EdgeAnchor {
@@ -172,9 +178,9 @@ impl AttributeUpdate for EdgeAnchor {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FaceAnchor {
     /// Vertex is linked to a surface.
-    Surface(GCellIdType),
+    Surface(SurfaceIdType),
     /// Vertex is linked to a 3D body.
-    Body(GCellIdType),
+    Body(BodyIdType),
 }
 
 impl AttributeBind for FaceAnchor {

--- a/honeycomb-kernels/src/remeshing/anchoring.rs
+++ b/honeycomb-kernels/src/remeshing/anchoring.rs
@@ -24,7 +24,7 @@ pub type BodyIdType = u32;
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum VertexAnchor {
     /// Vertex is linked to a node.
     Node(NodeIdType),
@@ -106,7 +106,7 @@ impl AttributeUpdate for VertexAnchor {
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EdgeAnchor {
     /// Vertex is linked to a curve.
     Curve(NodeIdType),
@@ -175,7 +175,7 @@ impl AttributeUpdate for EdgeAnchor {
 /// merge two anchors. The merge-ability of two anchors also depends on their intersection; we
 /// expect this to be handled outside of the merge functor, as doing it inside would require leaking
 /// map data into the trait's methods.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum FaceAnchor {
     /// Vertex is linked to a surface.
     Surface(SurfaceIdType),

--- a/honeycomb-kernels/src/remeshing/capture.rs
+++ b/honeycomb-kernels/src/remeshing/capture.rs
@@ -1,0 +1,297 @@
+use std::collections::{HashSet, VecDeque};
+
+use honeycomb_core::{
+    cmap::{CMap2, CMapBuilder, DartIdType, GridDescriptor, NULL_DART_ID, OrbitPolicy},
+    geometry::CoordsFloat,
+};
+use vtkio::Vtk;
+
+use crate::grisubal::{
+    Clip, GrisubalError,
+    model::{Boundary, Geometry2},
+    routines::{
+        clip_left, clip_right, compute_intersection_ids, compute_overlapping_grid,
+        detect_orientation_issue, generate_edge_data, generate_intersection_data,
+        group_intersections_per_edge, insert_edges_in_map, insert_intersections,
+    },
+};
+
+use super::{CurveIdType, EdgeAnchor, FaceAnchor, VertexAnchor};
+
+#[allow(clippy::missing_errors_doc)]
+/// Capture the geometry specified as input using the `grisubal` algorithm.
+///
+/// This function follows roughly the same step as the `grisubal` algorithm, but differs in two
+/// instances:
+/// - The overlapping grid avoids landing Points of Interest on all edges of the grid (instead of
+///   only corners), meaning we do not remove any from the original geometry.
+/// - Points of Interest are used to associate `VertexAnchor::Node` values to some vertices of the mesh.
+///
+/// A complete classification of the resulting mesh can be obtained using the [`classify_capture`] function.
+///
+/// # Return / Errors
+///
+/// This function returns a `Result` taking the following values:
+/// - `Ok(CMap2)` -- Algorithm ran successfully.
+/// - `Err(GrisubalError)` -- Algorithm encountered an issue. See [`GrisubalError`] for all
+///   possible errors.
+///
+/// # Panics
+///
+/// This function may panic if the specified VTK file cannot be opened.
+#[allow(clippy::needless_pass_by_value)]
+pub fn capture_geometry<T: CoordsFloat>(
+    file_path: impl AsRef<std::path::Path>,
+    grid_cell_sizes: [T; 2],
+    clip: Clip,
+) -> Result<CMap2<T>, GrisubalError> {
+    // --- IMPORT VTK INPUT
+    let geometry_vtk = match Vtk::import(file_path) {
+        Ok(vtk) => vtk,
+        Err(e) => panic!("E: could not open specified vtk file - {e}"),
+    };
+
+    // --- BUILD OUR MODEL FROM THE VTK IMPORT
+    let geometry = Geometry2::try_from(geometry_vtk)?;
+
+    // --- FIRST DETECTION OF ORIENTATION ISSUES
+    detect_orientation_issue(&geometry)?;
+
+    // --- FIND AN OVERLAPPING GRID
+    let ([nx, ny], origin) = compute_overlapping_grid(&geometry, grid_cell_sizes, true)?;
+    let [cx, cy] = grid_cell_sizes;
+    let ogrid = GridDescriptor::default()
+        .n_cells([nx, ny])
+        .len_per_cell([cx, cy])
+        .origin([origin.0, origin.1]);
+
+    // --- BUILD THE GRID
+    let mut cmap = CMapBuilder::from_grid_descriptor(ogrid)
+        .add_attribute::<Boundary>() // will be used for clipping
+        .add_attribute::<VertexAnchor>()
+        .add_attribute::<EdgeAnchor>()
+        .add_attribute::<FaceAnchor>()
+        .build()
+        .expect("E: unreachable"); // unreachable because grid dims are valid
+
+    // process the geometry
+
+    // --- STEP 1 & 2
+    // (1)
+    let (new_segments, intersection_metadata) =
+        generate_intersection_data(&cmap, &geometry, [nx, ny], [cx, cy], origin);
+    // (2)
+    let n_intersec = intersection_metadata.len();
+    let (edge_intersec, dart_slices) =
+        group_intersections_per_edge(&mut cmap, intersection_metadata);
+    let intersection_darts = compute_intersection_ids(n_intersec, &edge_intersec, &dart_slices);
+
+    // --- STEP 3
+    insert_intersections(&cmap, &edge_intersec, &dart_slices);
+
+    // --- STEP 4
+    let edges = generate_edge_data(&cmap, &geometry, &new_segments, &intersection_darts);
+
+    // --- STEP 5
+    insert_edges_in_map(&mut cmap, &edges);
+
+    // --- CLIP
+    match clip {
+        Clip::Left => clip_left(&mut cmap)?,
+        Clip::Right => clip_right(&mut cmap)?,
+        Clip::None => {}
+    }
+
+    // CLEANUP
+    cmap.remove_attribute_storage::<Boundary>();
+
+    Ok(cmap)
+}
+
+/// Error-modeling enum for classification issues.
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum ClassificationError {
+    /// One of the attribute used to classify mesh entities isn't included in the map.
+    #[error("missing attribute for classification: {0}")]
+    MissingAttribute(&'static str),
+    /// There is an unsupported configuration in the geometry.
+    #[error("geometry contains an ambiguous or unsupported configuration: {0}")]
+    UnsupportedGeometry(&'static str),
+}
+
+/// Classify all entities of a mesh on a default geometry.
+///
+/// This function classifies all i-cells of a mesh using a basic traversal algorithm. It expects
+/// the map passed as argument to already have a set of vertices linked to nodes.
+///
+/// The algorithm uses a first oriented traversal starting from anchored vertices to classifies
+/// boundaries as curves. It also checks for curves that are not linked to anchored vertices (e.g.
+/// a hole inside of the geometry).
+///
+/// Once curves are classified, the remaining unclassified cells are associated to surfaces, which
+/// are identified using a BFS-like algorithm stopping on already marked edges, to correctly
+/// discriminate surfaces.
+///
+/// # Errors
+///
+/// This function may fail and return an error if:
+/// - one of the attribute used to classify entities is missing (e.g. `VertexAnchor`),
+/// - The structure of the mesh is incorrect / unsupported (e.g. an open geometry).
+///
+/// # Panics
+///
+/// In `debug` mode, we use assertions to check every single i-cell of the mesh has been
+/// classified. If that is not the case, the function fill panic.
+#[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
+pub fn classify_capture<T: CoordsFloat>(cmap: &CMap2<T>) -> Result<(), ClassificationError> {
+    if !cmap.contains_attribute::<VertexAnchor>() {
+        Err(ClassificationError::MissingAttribute(
+            std::any::type_name::<VertexAnchor>(),
+        ))?;
+    }
+    if !cmap.contains_attribute::<EdgeAnchor>() {
+        Err(ClassificationError::MissingAttribute(
+            std::any::type_name::<EdgeAnchor>(),
+        ))?;
+    }
+    if !cmap.contains_attribute::<FaceAnchor>() {
+        Err(ClassificationError::MissingAttribute(
+            std::any::type_name::<FaceAnchor>(),
+        ))?;
+    }
+
+    let mut curve_id = 0;
+
+    // classify boundaries
+    for (i, dart) in cmap
+        .iter_vertices()
+        .filter_map(|v| {
+            cmap.force_read_attribute::<VertexAnchor>(v).and_then(|_| {
+                cmap.orbit(OrbitPolicy::Vertex, v)
+                    .find(|d| cmap.beta::<2>(*d) == NULL_DART_ID)
+            })
+        })
+        .enumerate()
+    {
+        mark_curve(cmap, dart, i as CurveIdType)?;
+        curve_id = curve_id.max(i);
+    }
+    // check for boundaries that are not reachable from anchored vertices (e.g. a hole with no PoI)
+    while let Some(dart) = (1..cmap.n_darts() as DartIdType).find(|d| {
+        // surely this is inlined, and we benefit from left-to-right lazy evaluation? right?
+        let used = !cmap.is_unused(*d);
+        let on_boundary = cmap
+            .orbit(OrbitPolicy::Vertex, *d)
+            .any(|dd| cmap.beta::<2>(dd) == NULL_DART_ID);
+        let unclassifed = cmap
+            .force_read_attribute::<EdgeAnchor>(cmap.edge_id(*d))
+            .is_none();
+        used && on_boundary && unclassifed
+    }) {
+        curve_id += 1; // use a new curve id
+        cmap.force_write_attribute(
+            cmap.vertex_id(dart),
+            VertexAnchor::Curve(curve_id as CurveIdType),
+        );
+        mark_curve(cmap, dart, curve_id as CurveIdType)?;
+    }
+
+    // classify inner entities using a coloring-like algorithm
+    let mut surface_id = 0;
+    let mut queue = VecDeque::new();
+    let mut marked = HashSet::new();
+    cmap.iter_faces()
+        // does this filter item updated in the for_each block?
+        // .filter(|f| cmap.force_read_attribute::<FaceAnchor>(*f).is_some())
+        .for_each(|f| {
+            queue.clear();
+            queue.push_front(f);
+            marked.clear();
+            marked.insert(0);
+            while let Some(crt) = queue.pop_front() {
+                // if the filter works correctly, this if isn't useful
+                if cmap.force_read_attribute::<FaceAnchor>(f).is_none() {
+                    cmap.force_write_attribute(crt, FaceAnchor::Surface(surface_id));
+                    cmap.orbit(OrbitPolicy::Face, crt as DartIdType)
+                        .filter(|d| {
+                            cmap.force_read_attribute::<FaceAnchor>(cmap.edge_id(*d))
+                                .is_none()
+                        })
+                        .for_each(|d| {
+                            cmap.force_write_attribute(
+                                cmap.edge_id(d),
+                                EdgeAnchor::Surface(surface_id),
+                            );
+                            if cmap
+                                .force_read_attribute::<VertexAnchor>(cmap.vertex_id(d))
+                                .is_none()
+                            {
+                                cmap.force_write_attribute(
+                                    cmap.vertex_id(d),
+                                    VertexAnchor::Surface(surface_id),
+                                );
+                                let neighbor_face = cmap.face_id(cmap.beta::<2>(d));
+                                if marked.insert(neighbor_face) {
+                                    queue.push_back(neighbor_face);
+                                }
+                            }
+                        });
+                }
+            }
+            surface_id += 1;
+        });
+
+    // in debug mode, ensure all entities are classified
+    debug_assert!(
+        cmap.iter_vertices()
+            .all(|v| cmap.force_read_attribute::<VertexAnchor>(v).is_some()),
+        "E: Not all vertices are classified",
+    );
+    debug_assert!(
+        cmap.iter_edges()
+            .all(|e| cmap.force_read_attribute::<EdgeAnchor>(e).is_some()),
+        "E: Not all edges are classified",
+    );
+    debug_assert!(
+        cmap.iter_faces()
+            .all(|f| cmap.force_read_attribute::<FaceAnchor>(f).is_some()),
+        "E: Not all faces are classified",
+    );
+
+    Ok(())
+}
+
+/// Traverse and anchor a boundary starting from the specified dart.
+///
+/// All entities making up the boundary (vertices, edges) are anchored to the `curve_id` curve.
+/// The only exception is the vertex associated to the starting dart.
+#[allow(clippy::cast_possible_truncation)]
+fn mark_curve<T: CoordsFloat>(
+    cmap: &CMap2<T>,
+    start: DartIdType,
+    curve_id: CurveIdType,
+) -> Result<(), ClassificationError> {
+    // only write attribute on the edge for the first one
+    // since we start from an anchored vertex
+    cmap.force_write_attribute::<EdgeAnchor>(cmap.edge_id(start), EdgeAnchor::Curve(curve_id));
+    let mut next = cmap.beta::<1>(start);
+    while cmap
+        .force_read_attribute::<VertexAnchor>(cmap.vertex_id(next))
+        .is_none()
+    {
+        if let Some(crt) = cmap
+            .orbit(OrbitPolicy::Vertex, next)
+            .find(|d| cmap.beta::<2>(*d) == NULL_DART_ID)
+        {
+            cmap.force_write_attribute(cmap.vertex_id(crt), VertexAnchor::Curve(curve_id));
+            cmap.force_write_attribute(cmap.edge_id(crt), EdgeAnchor::Curve(curve_id));
+            next = cmap.beta::<1>(crt);
+        } else {
+            // this should be unreachable as long as the geometry is closed and the node is on the boundary
+            Err(ClassificationError::UnsupportedGeometry(
+                "open geometry or node outside of boundary",
+            ))?;
+        }
+    }
+    Ok(())
+}

--- a/honeycomb-kernels/src/remeshing/mod.rs
+++ b/honeycomb-kernels/src/remeshing/mod.rs
@@ -8,6 +8,7 @@
 //! - swap-based cell edition routines
 
 mod anchoring;
+mod capture;
 mod cut;
 mod relaxation;
 mod swap;
@@ -15,6 +16,7 @@ mod swap;
 pub use anchoring::{
     BodyIdType, CurveIdType, EdgeAnchor, FaceAnchor, NodeIdType, SurfaceIdType, VertexAnchor,
 };
+pub use capture::{ClassificationError, capture_geometry, classify_capture};
 pub use cut::{cut_inner_edge, cut_outer_edge};
 pub use relaxation::move_vertex_to_average;
 pub use swap::{EdgeSwapError, swap_edge};

--- a/honeycomb-kernels/src/remeshing/mod.rs
+++ b/honeycomb-kernels/src/remeshing/mod.rs
@@ -12,7 +12,9 @@ mod cut;
 mod relaxation;
 mod swap;
 
-pub use anchoring::{EdgeAnchor, FaceAnchor, VertexAnchor};
+pub use anchoring::{
+    BodyIdType, CurveIdType, EdgeAnchor, FaceAnchor, NodeIdType, SurfaceIdType, VertexAnchor,
+};
 pub use cut::{cut_inner_edge, cut_outer_edge};
 pub use relaxation::move_vertex_to_average;
 pub use swap::{EdgeSwapError, swap_edge};


### PR DESCRIPTION
### Description

**Scope**: kernels and core

**Type of change**: refactor

**Content description**:
- [x] Add `contains_attribute` methods to `CMap2` and `CMap3`, checking if an attribute is present in the attribute manager of the map.
- [x] Split the edge insertion step of grisubal into subroutines; remove redundant allocs.
- [x] Conditionally add `VertexAnchor::Node` values to vertices coming from the geometry's PoI. The insertion occurs only if the attribute is present in the map.
- [x] write the capture function for the remeshing pipeline, based on grisubal components.
- [x] associate anchors to all i-cells of the captured geometry
- [x] add tests
