### PR TITLE
implement thread binding features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get update
             sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
@@ -47,7 +46,6 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get update
             sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
@@ -69,7 +67,6 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get update
             sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Status
+name: Build Status (\*nix)
 
 on:
   push:
@@ -14,12 +14,20 @@ jobs:
     name: Build crates for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get update
+            sudo apt-get libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
@@ -28,12 +36,20 @@ jobs:
     name: Build examples for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get update
+            sudo apt-get libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
@@ -42,12 +58,20 @@ jobs:
     name: Build benchmarks for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get update
+            sudo apt-get libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             brew install hwloc
           else
             sudo apt-get update
-            sudo apt-get libhwloc-dev
+            sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -48,7 +48,7 @@ jobs:
             brew install hwloc
           else
             sudo apt-get update
-            sudo apt-get libhwloc-dev
+            sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -70,7 +70,7 @@ jobs:
             brew install hwloc
           else
             sudo apt-get update
-            sudo apt-get libhwloc-dev
+            sudo apt-get -y libhwloc-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,45 @@
+name: Build Status (Windows)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_crates:
+    name: Build crates
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build crates
+        run: cargo build --all --disable-default-features --features=kernel,render
+  build_examples:
+    name: Build examples
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build examples
+        run: cargo build --examples --disable-default-features --features=kernel,render
+  build_benchmarks:
+    name: Build benchmarks
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build benchmarks
+        run: cargo build --benches --disable-default-features --features=kernel,render

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
-        run: cargo build --all --disable-default-features --features=kernel,render
+        run: cargo build --all --no-default-features --features=kernel,render
   build_examples:
     name: Build examples
     runs-on: windows-latest
@@ -31,7 +31,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
-        run: cargo build --examples --disable-default-features --features=kernel,render
+        run: cargo build --examples --no-default-features --features=kernel,render
   build_benchmarks:
     name: Build benchmarks
     runs-on: windows-latest
@@ -42,4 +42,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks
-        run: cargo build --benches --disable-default-features --features=kernel,render
+        run: cargo build --benches --no-default-features --features=kernel,render

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
-        run: cargo build --all --no-default-features --features=kernel,render
+        run: cargo build --all --no-default-features --features=kernels,render
   build_examples:
     name: Build examples
     runs-on: windows-latest
@@ -31,7 +31,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
-        run: cargo build --examples --no-default-features --features=kernel,render
+        run: cargo build --examples --no-default-features --features=kernels,render
   build_benchmarks:
     name: Build benchmarks
     runs-on: windows-latest
@@ -42,4 +42,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks
-        run: cargo build --benches --no-default-features --features=kernel,render
+        run: cargo build --benches --no-default-features --features=kernels,render

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ smallvec = "2.0.0-alpha.10"
 
 # benchmarks
 criterion = "0.5.1"
+hwlocality = "1.0.0-alpha.7"
 iai-callgrind = "0.14.0"
 rand = "0.9.0-alpha.2"
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,13 +11,15 @@ publish = false
 
 [features]
 _single_precision = []
+thread-binding = ["dep:hwlocality"]
 
 # deps
 
 [dependencies]
-clap = { workspace =true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 cfg-if.workspace = true
 honeycomb.workspace = true
+hwlocality = { workspace = true, optional = true }
 rayon.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 publish = false
 
 [features]
+default = ["thread-binding"]
 _single_precision = []
 thread-binding = ["dep:hwlocality"]
 

--- a/benches/src/cli.rs
+++ b/benches/src/cli.rs
@@ -11,6 +11,14 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 pub struct Cli {
     #[command(subcommand)]
     pub benches: Benches,
+    #[cfg(feature = "thread-binding")]
+    /// Bind threads to physical core if enabled (requires hwloc dev library and hardware support)
+    #[arg(short('b'), long("bind-threads"))]
+    pub bind_threads: bool,
+    /// Number of threads used for parallel workloads;
+    /// default to the number of physical cores or `std::thread::available_parallelism`
+    #[arg(short('t'), long("n-threads"))]
+    pub n_threads: Option<NonZero<usize>>,
     /// Serialize the map returned by the benchmark, if applicable
     #[arg(short, long("save-as"), value_enum, value_name("FORMAT"))]
     pub save_as: Option<Format>,

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,7 +1,16 @@
-use std::io::Write;
+use std::{collections::VecDeque, io::Write, sync::Arc};
 
 use clap::Parser;
 use honeycomb::prelude::{CMap2, CoordsFloat};
+#[cfg(feature = "thread-binding")]
+use hwlocality::{
+    Topology,
+    cpu::binding::CpuBindingFlags,
+    object::types::ObjectType,
+    topology::support::{DiscoverySupport, FeatureSupport},
+};
+#[cfg(feature = "thread-binding")]
+use rayon::ThreadPoolBuilder;
 
 use honeycomb_benches::{
     cli::{Benches, Cli, Format},
@@ -14,6 +23,79 @@ use honeycomb_benches::{
 
 fn main() {
     let cli = Cli::parse();
+
+    let n_t = if let Some(val) = cli.n_threads {
+        val.get()
+    } else {
+        std::thread::available_parallelism().unwrap().get()
+    };
+    let builder = ThreadPoolBuilder::new().num_threads(n_t);
+
+    #[cfg(feature = "thread-binding")]
+    {
+        if cli.bind_threads {
+            // build the topology & check that all necessary features are available on the machine
+            let topology = Topology::new().unwrap();
+            let topology = Arc::new(topology);
+            if topology.supports(FeatureSupport::discovery, DiscoverySupport::pu_count) {
+                let cpu_bind_feats = topology
+                    .feature_support()
+                    .cpu_binding()
+                    .is_some_and(|s| s.get_thread() && s.set_thread());
+                if cpu_bind_feats {
+                    // configure the global thread pool
+                    let core_depth = topology.depth_or_below_for_type(ObjectType::Core).unwrap();
+                    let mut cores = topology
+                        .objects_at_depth(core_depth)
+                        .collect::<VecDeque<_>>();
+                    let n_t = if cores.len() < n_t {
+                        // don't allow more than one thread per physical core
+                        // this is sane since this branch executes only if we explicitly enable binding
+                        eprintln!(
+                            "W: Less physical cores than logical threads; proceeding with one thread per core ({})",
+                            cores.len()
+                        );
+                        cores.len()
+                    } else {
+                        n_t
+                    };
+                    builder
+                        .num_threads(n_t)
+                        .spawn_handler(|t_builder| {
+                            // master thread
+                            let topology = topology.clone();
+                            // safe to unwrap due to n_t value adjustment
+                            let core = cores.pop_front().expect("E: unreachable");
+                            let mut bind_to = core.cpuset().unwrap().clone_target();
+                            bind_to.singlify();
+                            std::thread::spawn(move || {
+                                // worker thread
+                                let tid = hwlocality::current_thread_id();
+                                topology
+                                    .bind_thread_cpu(tid, &bind_to, CpuBindingFlags::empty())
+                                    .unwrap();
+
+                                // do the work
+                                t_builder.run()
+                            });
+                            Ok(())
+                        })
+                        .build_global()
+                        .unwrap();
+                } else {
+                    eprintln!(
+                        "W: Missing CPU binding support; proceeding with the default rayon threadpool"
+                    );
+                    builder.build_global().unwrap();
+                }
+            } else {
+                eprintln!(
+                    "W: Missing PU reporting support; proceeding with the default rayon threadpool"
+                );
+                builder.build_global().unwrap();
+            }
+        }
+    }
 
     if cli.simple_precision {
         run_benchmarks::<f32>(cli);

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, io::Write, sync::Arc};
+use std::io::Write;
+#[cfg(feature = "thread-binding")]
+use std::{collections::VecDeque, sync::Arc};
 
 use clap::Parser;
 use honeycomb::prelude::{CMap2, CoordsFloat};
@@ -9,7 +11,6 @@ use hwlocality::{
     object::types::ObjectType,
     topology::support::{DiscoverySupport, FeatureSupport},
 };
-#[cfg(feature = "thread-binding")]
 use rayon::ThreadPoolBuilder;
 
 use honeycomb_benches::{
@@ -95,6 +96,10 @@ fn main() {
                 builder.build_global().unwrap();
             }
         }
+    }
+    #[cfg(not(feature = "thread-binding"))]
+    {
+        builder.build_global().unwrap();
     }
 
     if cli.simple_precision {


### PR DESCRIPTION
### Description

**Scope**: benches (`hc-bench` bin)

**Type of change**: feat

**Content description**:
- add `thread-binding` feature to the `benches` crate
- update the CLI (mistake in commit msg) to add 2 new options:
  - `-b/--bind-threads`
  - `-t/--n-threads VAL`
- use `hwlocality` to bind threads of the rayon threadpool to physical core

Note that if binding is enabled via the CLI, and the number of thread is superior to the number of core (whether due to the CLI or `std::thread::available_parallelism`), the pool will be configured to spawn one thread per physical core.

### Additional information

- [x] New dependency: `hwlocality`, gated behind the feature to still allow compilation on systems lacking the dependency. The feature is **enabled** by default with consideration to our HPC context.

### Necessary follow-up

...
