### PR TITLE
add thread-binding features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get install -y libhwloc-dev
+            sudo apt-get install -y libhwloc-dev libudev-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -46,7 +46,7 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get install -y libhwloc-dev
+            sudo apt-get install -y libhwloc-dev libudev-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -67,7 +67,7 @@ jobs:
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
             brew install hwloc
           else
-            sudo apt-get install -y libhwloc-dev
+            sudo apt-get install -y libhwloc-dev libudev-dev
           fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Status
+name: Build Status (*nix)
 
 on:
   push:
@@ -14,12 +14,19 @@ jobs:
     name: Build crates for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
@@ -28,12 +35,19 @@ jobs:
     name: Build examples for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
@@ -42,12 +56,19 @@ jobs:
     name: Build benchmarks for ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev
+          fi
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,0 +1,45 @@
+name: Build Status (Windows)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_crates:
+    name: Build crates
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build crates
+        run: cargo build --all --no-default-features --features=kernels,render
+  build_examples:
+    name: Build examples
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build examples
+        run: cargo build --examples --no-default-features --features=kernels,render
+  build_benchmarks:
+    name: Build benchmarks
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build benchmarks
+        run: cargo build --benches --no-default-features --features=kernels,render

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -38,5 +38,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install hwloc
+        run: sudo apt-get install -y libhwloc-dev libudev-dev
       - name: Run Tests
         run: cargo test --all --all-features

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -28,6 +28,8 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install hwloc
+        run: sudo apt-get install -y libhwloc-dev libudev-dev
       - name: Run Clippy
         run: cargo clippy --all-features -- -D warnings
   tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ smallvec = "2.0.0-alpha.10"
 
 # benchmarks
 criterion = "0.5.1"
+hwlocality = "1.0.0-alpha.7"
 iai-callgrind = "0.14.0"
 rand = "0.9.0-alpha.2"
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,13 +11,15 @@ publish = false
 
 [features]
 _single_precision = []
+thread-binding = ["dep:hwlocality"]
 
 # deps
 
 [dependencies]
-clap = { workspace =true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 cfg-if.workspace = true
 honeycomb.workspace = true
+hwlocality = { workspace = true, optional = true }
 rayon.workspace = true
 rand = { workspace = true, features = ["small_rng"] }
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 publish = false
 
 [features]
+default = ["thread-binding"]
 _single_precision = []
 thread-binding = ["dep:hwlocality"]
 

--- a/benches/src/cli.rs
+++ b/benches/src/cli.rs
@@ -11,6 +11,14 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 pub struct Cli {
     #[command(subcommand)]
     pub benches: Benches,
+    #[cfg(feature = "thread-binding")]
+    /// Bind threads to physical core if enabled (requires hwloc dev library and hardware support)
+    #[arg(short('b'), long("bind-threads"))]
+    pub bind_threads: bool,
+    /// Number of threads used for parallel workloads;
+    /// default to the number of physical cores or `std::thread::available_parallelism`
+    #[arg(short('t'), long("n-threads"))]
+    pub n_threads: Option<NonZero<usize>>,
     /// Serialize the map returned by the benchmark, if applicable
     #[arg(short, long("save-as"), value_enum, value_name("FORMAT"))]
     pub save_as: Option<Format>,

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,18 +1,15 @@
 use std::io::Write;
 #[cfg(feature = "thread-binding")]
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 
 use clap::Parser;
 use honeycomb::prelude::{CMap2, CoordsFloat};
 #[cfg(feature = "thread-binding")]
-use hwlocality::{
-    Topology,
-    cpu::binding::CpuBindingFlags,
-    object::types::ObjectType,
-    topology::support::{DiscoverySupport, FeatureSupport},
-};
+use hwlocality::{Topology, cpu::binding::CpuBindingFlags};
 use rayon::ThreadPoolBuilder;
 
+#[cfg(feature = "thread-binding")]
+use honeycomb_benches::utils::get_physical_cores;
 use honeycomb_benches::{
     cli::{Benches, Cli, Format},
     cut_edges::bench_cut_edges,
@@ -28,7 +25,9 @@ fn main() {
     let n_t = if let Some(val) = cli.n_threads {
         val.get()
     } else {
-        std::thread::available_parallelism().unwrap().get()
+        std::thread::available_parallelism()
+            .map(|v| v.get())
+            .unwrap_or(1)
     };
     let builder = ThreadPoolBuilder::new().num_threads(n_t);
 
@@ -38,17 +37,8 @@ fn main() {
             // build the topology & check that all necessary features are available on the machine
             let topology = Topology::new().unwrap();
             let topology = Arc::new(topology);
-            if topology.supports(FeatureSupport::discovery, DiscoverySupport::pu_count) {
-                let cpu_bind_feats = topology
-                    .feature_support()
-                    .cpu_binding()
-                    .is_some_and(|s| s.get_thread() && s.set_thread());
-                if cpu_bind_feats {
-                    // configure the global thread pool
-                    let core_depth = topology.depth_or_below_for_type(ObjectType::Core).unwrap();
-                    let mut cores = topology
-                        .objects_at_depth(core_depth)
-                        .collect::<VecDeque<_>>();
+            match get_physical_cores(&topology) {
+                Ok(mut cores) => {
                     let n_t = if cores.len() < n_t {
                         // don't allow more than one thread per physical core
                         // this is sane since this branch executes only if we explicitly enable binding
@@ -83,18 +73,14 @@ fn main() {
                         })
                         .build_global()
                         .unwrap();
-                } else {
-                    eprintln!(
-                        "W: Missing CPU binding support; proceeding with the default rayon threadpool"
-                    );
+                }
+                Err(e) => {
+                    eprintln!("W: {e}");
                     builder.build_global().unwrap();
                 }
-            } else {
-                eprintln!(
-                    "W: Missing PU reporting support; proceeding with the default rayon threadpool"
-                );
-                builder.build_global().unwrap();
             }
+        } else {
+            builder.build_global().unwrap();
         }
     }
     #[cfg(not(feature = "thread-binding"))]
@@ -103,16 +89,24 @@ fn main() {
     }
 
     if cli.simple_precision {
-        run_benchmarks::<f32>(cli);
+        run_benchmarks::<f32>(cli, n_t);
     } else {
-        run_benchmarks::<f64>(cli);
+        run_benchmarks::<f64>(cli, n_t);
     }
 }
 
-fn run_benchmarks<T: CoordsFloat>(cli: Cli) {
+fn run_benchmarks<T: CoordsFloat>(cli: Cli, n_threads: usize) {
+    #[allow(unused_mut, unused_assignments)]
+    let mut bind_threads = false;
+
+    #[cfg(feature = "thread-binding")]
+    {
+        bind_threads = cli.bind_threads;
+    }
+
     let map: CMap2<T> = match cli.benches {
         Benches::Generate2dGrid(args) => bench_generate_2d_grid(args),
-        Benches::CutEdges(args) => bench_cut_edges(args),
+        Benches::CutEdges(args) => bench_cut_edges(args, n_threads, bind_threads),
         Benches::Grisubal(args) => bench_grisubal(args),
         Benches::Remesh(args) => bench_remesh(args),
         Benches::Shift(args) => bench_shift(args),

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,7 +1,16 @@
-use std::io::Write;
+use std::{collections::VecDeque, io::Write, sync::Arc};
 
 use clap::Parser;
 use honeycomb::prelude::{CMap2, CoordsFloat};
+#[cfg(feature = "thread-binding")]
+use hwlocality::{
+    Topology,
+    cpu::binding::CpuBindingFlags,
+    object::types::ObjectType,
+    topology::support::{DiscoverySupport, FeatureSupport},
+};
+#[cfg(feature = "thread-binding")]
+use rayon::ThreadPoolBuilder;
 
 use honeycomb_benches::{
     cli::{Benches, Cli, Format},
@@ -14,6 +23,79 @@ use honeycomb_benches::{
 
 fn main() {
     let cli = Cli::parse();
+
+    let n_t = if let Some(val) = cli.n_threads {
+        val.get()
+    } else {
+        std::thread::available_parallelism().unwrap().get()
+    };
+    let builder = ThreadPoolBuilder::new().num_threads(n_t);
+
+    #[cfg(feature = "thread-binding")]
+    {
+        if cli.bind_threads {
+            // build the topology & check that all necessary features are available on the machine
+            let topology = Topology::new().unwrap();
+            let topology = Arc::new(topology);
+            if topology.supports(FeatureSupport::discovery, DiscoverySupport::pu_count) {
+                let cpu_bind_feats = topology
+                    .feature_support()
+                    .cpu_binding()
+                    .is_some_and(|s| s.get_thread() && s.set_thread());
+                if cpu_bind_feats {
+                    // configure the global thread pool
+                    let core_depth = topology.depth_or_below_for_type(ObjectType::Core).unwrap();
+                    let mut cores = topology
+                        .objects_at_depth(core_depth)
+                        .collect::<VecDeque<_>>();
+                    let n_t = if cores.len() < n_t {
+                        // don't allow more than one thread per physical core
+                        // this is sane since this branch executes only if we explicitly enable binding
+                        eprintln!(
+                            "W: Less physical cores than logical threads; proceeding with one thread per core ({})",
+                            cores.len()
+                        );
+                        cores.len()
+                    } else {
+                        n_t
+                    };
+                    builder
+                        .num_threads(n_t)
+                        .spawn_handler(|t_builder| {
+                            // master thread
+                            let topology = topology.clone();
+                            // safe to unwrap due to n_t value adjustment
+                            let core = cores.pop_front().expect("E: unreachable");
+                            let mut bind_to = core.cpuset().unwrap().clone_target();
+                            bind_to.singlify();
+                            std::thread::spawn(move || {
+                                // worker thread
+                                let tid = hwlocality::current_thread_id();
+                                topology
+                                    .bind_thread_cpu(tid, &bind_to, CpuBindingFlags::empty())
+                                    .unwrap();
+
+                                // do the work
+                                t_builder.run()
+                            });
+                            Ok(())
+                        })
+                        .build_global()
+                        .unwrap();
+                } else {
+                    eprintln!(
+                        "W: Missing CPU binding support; proceeding with the default rayon threadpool"
+                    );
+                    builder.build_global().unwrap();
+                }
+            } else {
+                eprintln!(
+                    "W: Missing PU reporting support; proceeding with the default rayon threadpool"
+                );
+                builder.build_global().unwrap();
+            }
+        }
+    }
 
     if cli.simple_precision {
         run_benchmarks::<f32>(cli);

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, io::Write, sync::Arc};
+use std::io::Write;
+#[cfg(feature = "thread-binding")]
+use std::{collections::VecDeque, sync::Arc};
 
 use clap::Parser;
 use honeycomb::prelude::{CMap2, CoordsFloat};
@@ -9,7 +11,6 @@ use hwlocality::{
     object::types::ObjectType,
     topology::support::{DiscoverySupport, FeatureSupport},
 };
-#[cfg(feature = "thread-binding")]
 use rayon::ThreadPoolBuilder;
 
 use honeycomb_benches::{
@@ -95,6 +96,10 @@ fn main() {
                 builder.build_global().unwrap();
             }
         }
+    }
+    #[cfg(not(feature = "thread-binding"))]
+    {
+        builder.build_global().unwrap();
     }
 
     if cli.simple_precision {

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -1,7 +1,16 @@
+#[cfg(feature = "thread-binding")]
+use std::collections::VecDeque;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::Hasher;
 use std::io::Read;
+
+#[cfg(feature = "thread-binding")]
+use hwlocality::{
+    Topology,
+    object::{TopologyObject, types::ObjectType},
+    topology::support::{DiscoverySupport, FeatureSupport},
+};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "_single_precision")] {
@@ -31,4 +40,39 @@ pub fn hash_file(path: &str) -> Result<u64, std::io::Error> {
     }
 
     Ok(hasher.finish())
+}
+
+#[cfg(feature = "thread-binding")]
+pub fn get_physical_cores<'a, 'b>(
+    topology: &'a Topology,
+) -> Result<VecDeque<&'b TopologyObject>, String>
+where
+    'a: 'b,
+{
+    if topology.supports(FeatureSupport::discovery, DiscoverySupport::pu_count) {
+        let cpu_bind_feats = topology
+            .feature_support()
+            .cpu_binding()
+            .is_some_and(|s| s.get_thread() && s.set_thread());
+        if cpu_bind_feats {
+            // configure the global thread pool
+            let core_depth = topology
+                .depth_or_below_for_type(ObjectType::Core)
+                .map_err(|e| e.to_string())?;
+            let cores = topology
+                .objects_at_depth(core_depth)
+                .collect::<VecDeque<_>>();
+            Ok(cores)
+        } else {
+            Err(
+                "Missing CPU binding support; proceeding with the default rayon threadpool"
+                    .to_string(),
+            )
+        }
+    } else {
+        Err(
+            "Missing PU reporting support; proceeding with the default rayon threadpool"
+                .to_string(),
+        )
+    }
 }

--- a/honeycomb-kernels/src/cell_insertion/vertices.rs
+++ b/honeycomb-kernels/src/cell_insertion/vertices.rs
@@ -339,12 +339,12 @@ pub fn insert_vertices_on_edge<T: CoordsFloat>(
     let base_dart1 = edge_id as DartIdType;
     let base_dart2 = cmap.beta_transac::<2>(trans, base_dart1)?;
 
-    if darts_fh.iter().any(|d| *d == NULL_DART_ID) {
+    if darts_fh.contains(&NULL_DART_ID) {
         abort(VertexInsertionError::InvalidDarts(
             "one dart of the first half is null",
         ))?;
     }
-    if base_dart2 != NULL_DART_ID && darts_sh.iter().any(|d| *d == NULL_DART_ID) {
+    if base_dart2 != NULL_DART_ID && darts_sh.contains(&NULL_DART_ID) {
         abort(VertexInsertionError::InvalidDarts(
             "one dart of the second half is null",
         ))?;


### PR DESCRIPTION
### Description

**Scope**: benches (`hc-bench` bin)

**Type of change**: feat

**Content description**:
- add `thread-binding` feature to the `benches` crate
- update the CLI (mistake in commit msg) to add 2 new options:
  - `-b/--bind-threads`
  - `-t/--n-threads VAL`
- use `hwlocality` to bind threads of the rayon threadpool to physical core
- use `hwlocality` to bind std threads spawned in the relevant `cut-edges` backend
- update the CI:
  - separate windows from linux/macos jobs & disable hwloc usage for windows
  - add hwloc deps to the linux/macos CI

Note that if binding is enabled via the CLI, and the number of thread is superior to the number of core (whether due to the CLI or `std::thread::available_parallelism`), the pool will be configured to spawn one thread per physical core.

### Additional information

- [x] New dependency: `hwlocality`, gated behind the feature to still allow compilation on systems lacking the dependency. The feature is **enabled** by default with consideration to our HPC context.

### Necessary follow-up

...
