### PR TITLE
Add profiling hooks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [features]
 _single_precision = []
+profiling = []
 
 # deps
 

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -8,6 +8,7 @@ use honeycomb_benches::{
     cut_edges::bench_cut_edges,
     grid_gen::bench_generate_2d_grid,
     grisubal::bench_grisubal,
+    prof_init, prof_start, prof_stop,
     remesh::bench_remesh,
     shift::bench_shift,
 };
@@ -23,6 +24,9 @@ fn main() {
 }
 
 fn run_benchmarks<T: CoordsFloat>(cli: Cli) {
+    prof_init!();
+
+    prof_start!("HCBENCH");
     let map: CMap2<T> = match cli.benches {
         Benches::Generate2dGrid(args) => bench_generate_2d_grid(args),
         Benches::CutEdges(args) => bench_cut_edges(args),
@@ -30,6 +34,8 @@ fn run_benchmarks<T: CoordsFloat>(cli: Cli) {
         Benches::Remesh(args) => bench_remesh(args),
         Benches::Shift(args) => bench_shift(args),
     };
+    prof_stop!("HCBENCH");
+
     // all bench currently generate a map,
     // we may have to move this to match arms if this changes
     if let Some(f) = cli.save_as {

--- a/benches/src/shift.rs
+++ b/benches/src/shift.rs
@@ -25,6 +25,7 @@ use honeycomb::prelude::{
 
 use crate::cli::ShiftArgs;
 use crate::utils::hash_file;
+use crate::{prof_start, prof_stop};
 
 pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
     let mut instant = std::time::Instant::now();
@@ -45,6 +46,7 @@ pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
     };
     let build_time = instant.elapsed();
 
+    prof_start!("HCBENCH_SHIFT");
     if args.no_conflict {
         todo!("TODO: require a partitioning algorithm")
     } else {
@@ -117,6 +119,7 @@ pub fn bench_shift<T: CoordsFloat>(args: ShiftArgs) -> CMap2<T> {
             }
         }
     }
+    prof_stop!("HCBENCH_SHIFT");
 
     map
 }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -34,7 +34,7 @@ pub fn hash_file(path: &str) -> Result<u64, std::io::Error> {
 }
 
 #[cfg(feature = "profiling")]
-static mut PERF_FIFO: Option<File> = None;
+pub static mut PERF_FIFO: Option<File> = None;
 
 /// Attempt to open a fifo at the path `/tmp/hc_perf_control`.
 ///
@@ -45,7 +45,7 @@ macro_rules! prof_init {
         #[cfg(feature = "profiling")]
         {
             unsafe {
-                crate::utils::PERF_FIFO = Some(
+                $crate::utils::PERF_FIFO = Some(
                     std::fs::OpenOptions::new()
                         .write(true)
                         .open("/tmp/hc_perf_control")
@@ -68,7 +68,7 @@ macro_rules! prof_start {
             if std::env::var_os($var).is_some() {
                 use std::io::Write;
                 unsafe {
-                    if let Some(ref mut f) = crate::utils::PERF_FIFO {
+                    if let Some(ref mut f) = $crate::utils::PERF_FIFO {
                         f.write_all(b"enable\n")
                             .expect("E: failed to write to FIFO");
                         f.flush().expect("E: failed to flush FIFO");
@@ -91,10 +91,10 @@ macro_rules! prof_stop {
             if std::env::var_os($var).is_some() {
                 use std::io::Write;
                 unsafe {
-                    if let Some(ref mut f) = crate::utils::PERF_FIFO {
-                        fifo.write_all(b"disable\n")
+                    if let Some(ref mut f) = $crate::utils::PERF_FIFO {
+                        f.write_all(b"disable\n")
                             .expect("E: failed to write to FIFO");
-                        fifo.flush().expect("E: failed to flush FIFO");
+                        f.flush().expect("E: failed to flush FIFO");
                     }
                 }
             }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -32,3 +32,72 @@ pub fn hash_file(path: &str) -> Result<u64, std::io::Error> {
 
     Ok(hasher.finish())
 }
+
+#[cfg(feature = "profiling")]
+static mut PERF_FIFO: Option<File> = None;
+
+/// Attempt to open a fifo at the path `/tmp/hc_perf_control`.
+///
+/// This macro doesn't generate any code if the `profiling` feature is disabled.
+#[macro_export]
+macro_rules! prof_init {
+    () => {
+        #[cfg(feature = "profiling")]
+        {
+            unsafe {
+                crate::utils::PERF_FIFO = Some(
+                    std::fs::OpenOptions::new()
+                        .write(true)
+                        .open("/tmp/hc_perf_control")
+                        .expect("Failed to open FIFO"),
+                );
+            }
+        }
+    };
+}
+
+/// Write to the `/tmp/hc_perf_control` to enable perf sampling if `${$var}` is defined.
+///
+/// This macro doesn't generate any code if the `profiling` feature is disabled.
+#[macro_export]
+macro_rules! prof_start {
+    ($var: literal) => {
+        #[cfg(feature = "profiling")]
+        {
+            // use an env variable to select profiled section
+            if std::env::var_os($var).is_some() {
+                use std::io::Write;
+                unsafe {
+                    if let Some(ref mut f) = crate::utils::PERF_FIFO {
+                        f.write_all(b"enable\n")
+                            .expect("E: failed to write to FIFO");
+                        f.flush().expect("E: failed to flush FIFO");
+                    }
+                }
+            }
+        }
+    };
+}
+
+/// Write to the `/tmp/hc_perf_control` to disable perf sampling if `${$var}` is defined.
+///
+/// This macro doesn't generate any code if the `profiling` feature is disabled.
+#[macro_export]
+macro_rules! prof_stop {
+    ($var: literal) => {
+        #[cfg(feature = "profiling")]
+        {
+            // use an env variable to select profiled section
+            if std::env::var_os($var).is_some() {
+                use std::io::Write;
+                unsafe {
+                    if let Some(ref mut f) = crate::utils::PERF_FIFO {
+                        fifo.write_all(b"disable\n")
+                            .expect("E: failed to write to FIFO");
+                        fifo.flush().expect("E: failed to flush FIFO");
+                    }
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
### Description

**Scope**: benches

**Type of change**: feat

**Content description**:
- add a `profiling` feature
- add profiling macros that generate code if the `profiling` feature is enabled
  - macros write to a fifo at `/tmp/hc_perf_control` to enable & disable `perf` sampling
  - the section profiled is controlled using environment variables (e.g. `HCBENCH_REMESH_SWAP` for the swap step of the remesh kernel)
  - `prof_init`, `prof_start`, `prof_stop`; init is required due to conditions on static mutable refs

