### PR TITLE
chore: update CI to support `hwloc` builds

### DIFF
--- a/.github/workflows/build_nix.yml
+++ b/.github/workflows/build_nix.yml
@@ -1,0 +1,76 @@
+name: Build Status (*nix)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_crates:
+    name: Build crates for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev libudev-dev
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build crates
+        run: cargo build --all --all-features
+  build_examples:
+    name: Build examples for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev libudev-dev
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build examples
+        run: cargo build --examples --all-features
+  build_benchmarks:
+    name: Build benchmarks for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install hwloc
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            brew install hwloc
+          else
+            sudo apt-get install -y libhwloc-dev libudev-dev
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build benchmarks
+        run: cargo build --benches --all-features
+

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Build Status
+name: Build Status (Windows)
 
 on:
   push:
@@ -11,11 +11,8 @@ env:
 
 jobs:
   build_crates:
-    name: Build crates for ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    name: Build crates
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,13 +20,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build crates
-        run: cargo build --all # --all-features
+        run: cargo build --all --no-default-features --features=kernels,render
   build_examples:
-    name: Build examples for ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    name: Build examples
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,13 +31,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build examples
-        run: cargo build --examples --all-features
+        run: cargo build --examples --no-default-features --features=kernels,render
   build_benchmarks:
-    name: Build benchmarks for ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    name: Build benchmarks
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,4 +42,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Build benchmarks
-        run: cargo build --benches # --all-features
+        run: cargo build --benches --no-default-features --features=kernels,render


### PR DESCRIPTION
### Description

**Scope**: repository

**Type of change**: refactor

**Content description**:
- split windows and *nix CIs
- install `hwloc`, enable all features in the *nix CIs
- disable `bind-threads` feature in the Windows CI

