### PR TITLE
feat(core): return unlinked image dart ID in `unlink` an `unsew` methods

### DIFF
--- a/honeycomb-core/src/cmap/components/betas.rs
+++ b/honeycomb-core/src/cmap/components/betas.rs
@@ -227,7 +227,7 @@ impl<const N: usize> BetaFunctions<N> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         // set beta_3(lhs_dart) to NullDart
         let rd = self[(3, ld)].exchange(t, NULL_DART_ID)?;
         if rd == NULL_DART_ID {
@@ -235,6 +235,6 @@ impl<const N: usize> BetaFunctions<N> {
         }
         // set beta_3(rhs_dart) to NullDart
         self[(3, rd)].write(t, NULL_DART_ID)?;
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/components/betas.rs
+++ b/honeycomb-core/src/cmap/components/betas.rs
@@ -184,7 +184,7 @@ impl<const N: usize> BetaFunctions<N> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         // set beta_1(lhs_dart) to NullDart
         let rd = self[(1, ld)].replace(t, NULL_DART_ID)?;
         if rd == NULL_DART_ID {
@@ -192,7 +192,7 @@ impl<const N: usize> BetaFunctions<N> {
         }
         // set beta_0(rhs_dart) to NullDart
         self[(0, rd)].write(t, NULL_DART_ID)?;
-        Ok(())
+        Ok(rd)
     }
 
     /// 2-unlink operation.
@@ -212,7 +212,7 @@ impl<const N: usize> BetaFunctions<N> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         // set beta_2(dart) to NullDart
         let rd = self[(2, ld)].replace(t, NULL_DART_ID)?;
         if rd == NULL_DART_ID {
@@ -220,7 +220,7 @@ impl<const N: usize> BetaFunctions<N> {
         }
         // set beta_2(beta_2(dart)) to NullDart
         self[(2, rd)].write(t, NULL_DART_ID)?;
-        Ok(())
+        Ok(rd)
     }
 
     pub fn three_unlink_core(

--- a/honeycomb-core/src/cmap/dim2/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/links/mod.rs
@@ -72,7 +72,9 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// The second dart ID is fetched using `I` and `ld`.
     ///
-    /// # Errors
+    /// # Return / Errors
+    ///
+    /// This method returns the old value of *β<sub>I</sub>(ld)*.
     ///
     /// This method should be called in a transactional context. The `Result` is then used to
     /// validate the transaction; Errors should not be processed manually, only processed via the
@@ -88,7 +90,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -120,7 +122,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`unlink`][Self::unlink], but internally uses a transaction
     /// that will be retried until validated.
-    pub fn unlink<const I: u8>(&self, ld: DartIdType) -> Result<(), LinkError> {
+    pub fn unlink<const I: u8>(&self, ld: DartIdType) -> Result<DartIdType, LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/links/mod.rs
@@ -33,6 +33,9 @@ impl<T: CoordsFloat> CMap2<T> {
     /// `?` operator. The policy in case of failure can be defined when creating the transaction,
     /// using `Transaction::with_control`.
     ///
+    /// It may return an error if the transaction fails or if the link fails; See [`LinkError`] for
+    /// more detail about the latter.
+    ///
     /// # Panics
     ///
     /// The method may panic if:
@@ -54,6 +57,7 @@ impl<T: CoordsFloat> CMap2<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// `I`-unlink operator.
     ///
     /// # Description
@@ -80,6 +84,9 @@ impl<T: CoordsFloat> CMap2<T> {
     /// validate the transaction; Errors should not be processed manually, only processed via the
     /// `?` operator. The policy in case of failure can be defined when creating the transaction,
     /// using `Transaction::with_control`.
+    ///
+    /// It may return an error if the transaction fails or if the link fails; See [`LinkError`] for
+    /// more detail about the latter.
     ///
     /// # Panics
     ///

--- a/honeycomb-core/src/cmap/dim2/links/one.rs
+++ b/honeycomb-core/src/cmap/dim2/links/one.rs
@@ -24,7 +24,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         self.betas.one_unlink_core(t, lhs_dart_id)
     }
 }

--- a/honeycomb-core/src/cmap/dim2/links/two.rs
+++ b/honeycomb-core/src/cmap/dim2/links/two.rs
@@ -24,7 +24,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         self.betas.two_unlink_core(t, lhs_dart_id)
     }
 }

--- a/honeycomb-core/src/cmap/dim2/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/mod.rs
@@ -99,7 +99,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);
@@ -131,7 +131,7 @@ impl<T: CoordsFloat> CMap2<T> {
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn unsew<const I: u8>(&self, ld: DartIdType) -> Result<(), SewError> {
+    pub fn unsew<const I: u8>(&self, ld: DartIdType) -> Result<DartIdType, SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 3);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -43,7 +43,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         let rd = self.beta_tx::<1>(t, ld)?;
         let b2ld = self.beta_tx::<2>(t, ld)?;
 
@@ -71,6 +71,6 @@ impl<T: CoordsFloat> CMap2<T> {
                 );
             }
         }
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim2/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/one.rs
@@ -44,10 +44,9 @@ impl<T: CoordsFloat> CMap2<T> {
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, SewError> {
-        let rd = self.beta_tx::<1>(t, ld)?;
         let b2ld = self.beta_tx::<2>(t, ld)?;
 
-        try_or_coerce!(self.unlink_tx::<1>(t, ld), SewError);
+        let rd = try_or_coerce!(self.unlink_tx::<1>(t, ld), SewError);
 
         if b2ld != NULL_DART_ID {
             // split vertex attributes

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -109,11 +109,9 @@ impl<T: CoordsFloat> CMap2<T> {
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, SewError> {
-        let rd = self.beta_tx::<2>(t, ld)?;
+        let rd = try_or_coerce!(self.unlink_tx::<2>(t, ld), SewError);
         let b1ld = self.beta_tx::<1>(t, ld)?;
         let b1rd = self.beta_tx::<1>(t, rd)?;
-
-        try_or_coerce!(self.unlink_tx::<2>(t, ld), SewError);
 
         let (new_lv_ld, new_lv_rd) = (self.vertex_id_tx(t, ld)?, self.vertex_id_tx(t, b1rd)?);
         let (new_rv_ld, new_rv_rd) = (self.vertex_id_tx(t, b1ld)?, self.vertex_id_tx(t, rd)?);

--- a/honeycomb-core/src/cmap/dim2/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim2/sews/two.rs
@@ -108,7 +108,7 @@ impl<T: CoordsFloat> CMap2<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         let rd = self.beta_tx::<2>(t, ld)?;
         let b1ld = self.beta_tx::<1>(t, ld)?;
         let b1rd = self.beta_tx::<1>(t, rd)?;
@@ -165,6 +165,6 @@ impl<T: CoordsFloat> CMap2<T> {
             );
         }
 
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/links/mod.rs
@@ -93,7 +93,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -151,7 +151,7 @@ impl<T: CoordsFloat> CMap3<T> {
     /// The method may panic if:
     /// - `I >= 4` or `I == 0`,
     /// - `lhs_dart_id` is already `I`-free.
-    pub fn unlink<const I: u8>(&self, lhs_dart_id: DartIdType) -> Result<(), LinkError> {
+    pub fn unlink<const I: u8>(&self, lhs_dart_id: DartIdType) -> Result<DartIdType, LinkError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim3/links/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/links/mod.rs
@@ -59,6 +59,7 @@ impl<T: CoordsFloat> CMap3<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// `I`-unlink operator.
     ///
     /// # Description
@@ -77,12 +78,17 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// The second dart ID is fetched using `I` and `lhs_dart_id`.
     ///
-    /// # Errors
+    /// # Return / Errors
+    ///
+    /// This method returns the old value of *β<sub>I</sub>(ld)*.
     ///
     /// This method should be called in a transactional context. The `Result` is then used to
     /// validate the transaction; Errors should not be processed manually, only processed via the
     /// `?` operator. The policy in case of failure can be defined when creating the transaction,
     /// using `Transaction::with_control`.
+    ///
+    /// It may return an error if the transaction fails or if the link fails; See [`LinkError`] for
+    /// more detail about the latter.
     ///
     /// # Panics
     ///
@@ -136,12 +142,15 @@ impl<T: CoordsFloat> CMap3<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)]
     /// `I`-unlink operator.
     ///
     /// This variant is equivalent to [`unlink`][Self::unlink], but internally uses a transaction
     /// that will be retried until validated.
     ///
-    /// # Errors
+    /// # Return / Errors
+    ///
+    /// This method returns the old value of *β<sub>I</sub>(ld)*.
     ///
     /// It may return an error if the transaction fails or if the link fails; See [`LinkError`] for
     /// more detail about the latter.

--- a/honeycomb-core/src/cmap/dim3/links/one.rs
+++ b/honeycomb-core/src/cmap/dim3/links/one.rs
@@ -29,7 +29,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         let rd = self.beta_tx::<1>(t, ld)?;
         self.betas.one_unlink_core(t, ld)?;
         let (b3_ld, b3_rd) = (self.beta_tx::<3>(t, ld)?, self.beta_tx::<3>(t, rd)?);
@@ -40,6 +40,6 @@ impl<T: CoordsFloat> CMap3<T> {
             }
             self.betas.one_unlink_core(t, b3_rd)?;
         }
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/links/three.rs
+++ b/honeycomb-core/src/cmap/dim3/links/three.rs
@@ -59,9 +59,8 @@ impl<T: CoordsFloat> CMap3<T> {
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, LinkError> {
-        let rd = self.beta_tx::<3>(t, ld)?;
+        let rd = self.betas.three_unlink_core(t, ld)?;
 
-        self.betas.three_unlink_core(t, ld)?;
         let (mut lside, mut rside) = (self.beta_tx::<1>(t, ld)?, self.beta_tx::<0>(t, rd)?);
         // while we haven't completed the loop, or reached an end
         while lside != ld && lside != NULL_DART_ID {

--- a/honeycomb-core/src/cmap/dim3/links/three.rs
+++ b/honeycomb-core/src/cmap/dim3/links/three.rs
@@ -58,7 +58,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         let rd = self.beta_tx::<3>(t, ld)?;
 
         self.betas.three_unlink_core(t, ld)?;
@@ -94,6 +94,6 @@ impl<T: CoordsFloat> CMap3<T> {
         // (*) : this can be changed, but the idea here is to ensure we're unlinking the expected
         //       construct
         // (**): if we land on NULL on one side, the other side should be NULL as well
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/links/two.rs
+++ b/honeycomb-core/src/cmap/dim3/links/two.rs
@@ -24,7 +24,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         lhs_dart_id: DartIdType,
-    ) -> TransactionClosureResult<(), LinkError> {
+    ) -> TransactionClosureResult<DartIdType, LinkError> {
         self.betas.two_unlink_core(t, lhs_dart_id)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/mod.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/mod.rs
@@ -101,7 +101,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);
@@ -135,7 +135,7 @@ impl<T: CoordsFloat> CMap3<T> {
     ///
     /// This variant is equivalent to [`unsew`][Self::unsew], but internally uses a transaction that
     /// will be retried until validated.
-    pub fn unsew<const I: u8>(&self, ld: DartIdType) -> Result<(), SewError> {
+    pub fn unsew<const I: u8>(&self, ld: DartIdType) -> Result<DartIdType, SewError> {
         // these assertions + match on a const are optimized away
         assert!(I < 4);
         assert_ne!(I, 0);

--- a/honeycomb-core/src/cmap/dim3/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/one.rs
@@ -60,12 +60,11 @@ impl<T: CoordsFloat> CMap3<T> {
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, SewError> {
-        let rd = self.beta_tx::<1>(t, ld)?;
+        let rd = try_or_coerce!(self.betas.one_unlink_core(t, ld), SewError);
         let b3ld = self.beta_tx::<3>(t, ld)?;
         let b3rd = self.beta_tx::<3>(t, rd)?;
         let b2ld = self.beta_tx::<2>(t, ld)?;
 
-        try_or_coerce!(self.betas.one_unlink_core(t, ld), SewError);
         if b3ld != NULL_DART_ID && b3rd != NULL_DART_ID {
             if self.beta_tx::<1>(t, b3rd)? != b3ld {
                 // FIXME: add dedicated variant ~LinkError::DivergentStructures ?

--- a/honeycomb-core/src/cmap/dim3/sews/one.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/one.rs
@@ -51,7 +51,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         let rd = self.beta_tx::<1>(t, ld)?;
         let b3ld = self.beta_tx::<3>(t, ld)?.max(self.beta_tx::<2>(t, ld)?);
 
@@ -79,6 +79,6 @@ impl<T: CoordsFloat> CMap3<T> {
                 );
             }
         }
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -190,19 +190,19 @@ impl<T: CoordsFloat> CMap3<T> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     /// 3-unsew operation.
     pub(crate) fn three_unsew_tx(
         &self,
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, SewError> {
-        let rd = self.beta_tx::<3>(t, ld)?;
+        let rd = try_or_coerce!(self.betas.three_unlink_core(t, ld), SewError);
         let mut l_side = Vec::with_capacity(10);
         let mut r_side = Vec::with_capacity(10);
         l_side.push(ld);
         r_side.push(rd);
 
-        try_or_coerce!(self.betas.three_unlink_core(t, ld), SewError);
         let (mut l, mut r) = (self.beta_tx::<1>(t, ld)?, self.beta_tx::<0>(t, rd)?);
         // while we haven't completed the loop, or reached an end
         while l != ld && l != NULL_DART_ID {

--- a/honeycomb-core/src/cmap/dim3/sews/three.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/three.rs
@@ -150,7 +150,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         let rd = self.beta_tx::<3>(t, ld)?;
 
         try_or_coerce!(self.three_unlink_tx(t, ld), SewError);
@@ -240,6 +240,6 @@ impl<T: CoordsFloat> CMap3<T> {
                 }
             }
         }
-        Ok(())
+        Ok(rd)
     }
 }

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -118,11 +118,9 @@ impl<T: CoordsFloat> CMap3<T> {
         t: &mut Transaction,
         ld: DartIdType,
     ) -> TransactionClosureResult<DartIdType, SewError> {
-        let rd = self.beta_tx::<2>(t, ld)?;
+        let rd = try_or_coerce!(self.two_unlink_tx(t, ld), SewError);
         let b1ld = self.beta_tx::<1>(t, ld)?.max(self.beta_tx::<3>(t, ld)?);
         let b1rd = self.beta_tx::<1>(t, rd)?.max(self.beta_tx::<3>(t, rd)?);
-
-        try_or_coerce!(self.two_unlink_tx(t, ld), SewError);
 
         let (eid_newl, eid_newr) = (self.edge_id_tx(t, ld)?, self.edge_id_tx(t, rd)?);
 

--- a/honeycomb-core/src/cmap/dim3/sews/two.rs
+++ b/honeycomb-core/src/cmap/dim3/sews/two.rs
@@ -117,7 +117,7 @@ impl<T: CoordsFloat> CMap3<T> {
         &self,
         t: &mut Transaction,
         ld: DartIdType,
-    ) -> TransactionClosureResult<(), SewError> {
+    ) -> TransactionClosureResult<DartIdType, SewError> {
         let rd = self.beta_tx::<2>(t, ld)?;
         let b1ld = self.beta_tx::<1>(t, ld)?.max(self.beta_tx::<3>(t, ld)?);
         let b1rd = self.beta_tx::<1>(t, rd)?.max(self.beta_tx::<3>(t, rd)?);
@@ -181,6 +181,6 @@ impl<T: CoordsFloat> CMap3<T> {
                 );
             }
         }
-        Ok(())
+        Ok(rd)
     }
 }


### PR DESCRIPTION
### Description

**Scope**: core

**Type of change**: feat

**Content description**: `unlink` and `unsew` now return the dart ID of the (old) image of `ld`, e.g., for a 2-unsew of dart *d*, the method will return *β<sub>2</sub>(d)* (before the topology update).

This helps avoid redundant reads, and reduce the chance of observing an invalid state by reading manually the value and then unsewing;

It's one of the limit of the STM. STM would detect at commit time that the beta image value changed between the two operations, but the transaction body code would need to account for that inconsistency.

### Necessary follow-up

use it in algorithm (identified use case for `cut-edges`) 
